### PR TITLE
GH-13 Changes for 1.86_03 release

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,19 +39,12 @@ platform:
 # - old Strawberry Perls don't have cpanm
 # - on server 2012R2 image's MinGW was causing linking problems with
 #   Strawberry Perl's MinGW.
-# - ExtUtils::MakeMaker is updated before Module::Install on older
-#   Perls to a version that installs successfully and is recent enough
-#   for Module::Install
-# - Freeze Module::Install to the currently latest version because it
-#   seems to work. Change it later if needed; avoid moving parts now.
-# - Tests are skipped for some versions because the dependency
-#   failures did not affect Net::SSLeay build
+# - See 1.86 developer builds for config that did more with cpanm.
 environment:
   AUTOMATED_TESTING: 1
   PERL_MM_USE_DEFAULT: 1
   RELEASE_TESTING: 0
   OPENSSL_PREFIX: C:\strawberry\c
-  ssleay_module_install: 1.19
   matrix:
     - perl: 5.26.2.1
     - perl: 5.24.4.1
@@ -62,15 +55,11 @@ environment:
     - perl: 5.14.4.1
     - perl: 5.12.3.20180703
       ssleay_need_cpanm: 1
-      PERL_CPANM_OPT: --notest
     - perl: 5.10.1.5
       ssleay_need_cpanm: 1
-      ssleay_make_maker: 6.98
       ssleay_rename_mingw: 1
     - perl: 5.8.9.5
       ssleay_need_cpanm: 1
-      PERL_CPANM_OPT: --notest
-      ssleay_make_maker: 6.98
       ssleay_rename_mingw: 1
 
 # 64 bit Strawberry Perl is not built for all versions
@@ -113,8 +102,6 @@ install:
   - if /I "%ssleay_need_cpanm%" == "1" cpan App::cpanminus
   - if /I "%ssleay_rename_mingw%" == "1" if exist C:\MinGW move C:\MinGW C:\MinGW-image
   - if /I "%ssleay_rename_mingw%" == "1" if exist C:\MinGW-W64 move C:\MinGW-W64 C:\MinGW-W64-image
-  - if not "%ssleay_make_maker%" == "" cpanm --no-man-pages ExtUtils::MakeMaker@%ssleay_make_maker%
-  - if not "%ssleay_module_install%" == "" cpanm --no-man-pages Module::Install@%ssleay_module_install%
   - cpanm --quiet --no-man-pages --installdeps --with-develop --notest .
   - perl -V
 

--- a/Changes
+++ b/Changes
@@ -1,7 +1,9 @@
 Revision history for Perl extension Net::SSLeay.
 
-???
-	- Convert packaging to EUMM
+1.86_03 2018-07-19
+	- Convert packaging to ExtUtils::MakeMaker
+	- Module::Install is no longer a prerequisite when building
+	  from the reposistory.
 	- Re-apply patch from ETJ permitting configure and build in
 	  places with a space in the name.
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,6 +18,7 @@ my $tests = prompt(
 
 my %eumm_args = (
   NAME => 'Net::SSLeay',
+  ABSTRACT => 'Perl extension for using OpenSSL',
   LICENSE => 'perl',
   AUTHOR => 'Originally written by Sampo Kellomäki',
   VERSION_FROM => 'lib/Net/SSLeay.pm',

--- a/lib/Net/SSLeay.pm
+++ b/lib/Net/SSLeay.pm
@@ -61,7 +61,7 @@ $Net::SSLeay::slowly = 0;
 $Net::SSLeay::random_device = '/dev/urandom';
 $Net::SSLeay::how_random = 512;
 
-$VERSION = '1.86_02'; # Version in META.yml is automatically updated
+$VERSION = '1.86_03'; # Version in META.yml is automatically updated
 @ISA = qw(Exporter);
 
 #BEWARE:


### PR DESCRIPTION
Module::Install is no longer needed.

Abstract was missing from the generated META.yml.