### PR TITLE
Re-add SSLv3_method() for OpenSSL >= 1.0.2

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension Net::SSLeay.
 
+???
+	- Re-add SSLv3_method() for OpenSSL 1.0.2 and above.
+
 1.86_03 2018-07-19
 	- Convert packaging to ExtUtils::MakeMaker
 	- Module::Install is no longer a prerequisite when building

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -4311,12 +4311,10 @@ SSLv2_method()
 #endif
 
 #ifndef OPENSSL_NO_SSL3
-#if OPENSSL_VERSION_NUMBER < 0x10002000L
 
 const SSL_METHOD *
 SSLv3_method()
 
-#endif
 #endif
 
 const SSL_METHOD *


### PR DESCRIPTION
Commit b4e2b06 removes `SSLv3_method()` (and `CTX_v3_new()`, which uses `SSLv3_method()`) with OpenSSL 1.0.2 and above, but `SSLv3_method()` was only deprecated in OpenSSL 1.1.0-pre4, not removed entirely. This was partially reverted by commit b2e2db3, which re-adds `CTX_v3_new()`; also re-add `SSLv3_method()` for now, until it is removed from OpenSSL.

This closes [RT#101484](https://rt.cpan.org/Ticket/Display.html?id=101484).