### PR TITLE
Disable ENGINE_* functions in non-ENGINE OpenSSL builds

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,9 @@ Revision history for Perl extension Net::SSLeay.
 ???
 	- Re-add SSLv3_method() for OpenSSL 1.0.2 and above. Fixes
 	  RT#101484.
+	- Don't expose ENGINE-related functions when building against
+	  OpenSSL builds without ENGINE support. Fixes RT#121538. Thanks to
+	  Paul Green.
 
 1.86_03 2018-07-19
 	- Convert packaging to ExtUtils::MakeMaker

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -2653,6 +2653,7 @@ SSL_library_init()
 
 #if OPENSSL_VERSION_NUMBER >= 0x0090700fL
 #define REM5 "NOTE: requires 0.9.7+"
+#ifndef OPENSSL_NO_ENGINE
 
 void
 ENGINE_load_builtin_engines()
@@ -2669,6 +2670,7 @@ ENGINE_set_default(e, flags)
         ENGINE * e
         int flags
 
+#endif /* OPENSSL_NO_ENGINE */
 #endif
 
 void

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -1353,6 +1353,8 @@ Check openssl doc L<http://www.openssl.org/docs/ssl/SSL_CTX_new.html|http://www.
 
 =item * ENGINE_load_builtin_engines
 
+B<COMPATIBILITY:> Requires an OpenSSL build with dynamic engine loading support.
+
 Load all bundled ENGINEs into memory and make them visible.
 
  Net::SSLeay::ENGINE_load_builtin_engines();
@@ -1363,6 +1365,8 @@ Check openssl doc L<http://www.openssl.org/docs/crypto/engine.html|http://www.op
 
 =item * ENGINE_register_all_complete
 
+B<COMPATIBILITY:> Requires an OpenSSL build with dynamic engine loading support.
+
 Register all loaded ENGINEs for every algorithm they collectively implement.
 
  Net::SSLeay::ENGINE_register_all_complete();
@@ -1372,6 +1376,8 @@ Register all loaded ENGINEs for every algorithm they collectively implement.
 Check openssl doc L<http://www.openssl.org/docs/crypto/engine.html|http://www.openssl.org/docs/crypto/engine.html>
 
 =item * ENGINE_set_default
+
+B<COMPATIBILITY:> Requires an OpenSSL build with dynamic engine loading support.
 
 Set default engine to $e + set its flags to $flags.
 
@@ -1401,6 +1407,8 @@ Check openssl doc L<http://www.openssl.org/docs/crypto/engine.html|http://www.op
 =item * ENGINE_by_id
 
 Get ENGINE by its identification $id.
+
+B<COMPATIBILITY:> Requires an OpenSSL build with dynamic engine loading support.
 
  my $rv = Net::SSLeay::ENGINE_by_id($id);
  # $id - (string) engine identification e.g. "dynamic"


### PR DESCRIPTION
In `SSLeay.xs`, don't expose the following ENGINE-related functions in Net::SSLeay when building against OpenSSL builds without ENGINE support:

* ENGINE_load_builtin_engines
* ENGINE_register_all_complete
* ENGINE_by_id
* ENGINE_set_default

This closes [RT#121538](https://rt.cpan.org/Ticket/Display.html?id=121538). Thanks to Paul Green for the report and patch.