### PR TITLE
VMS update for newer SSL versions and removal of Module::Install

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,9 @@ Revision history for Perl extension Net::SSLeay.
 	- Don't expose ENGINE-related functions when building against
 	  OpenSSL builds without ENGINE support. Fixes RT#121538. Thanks to
 	  Paul Green.
+	- Automatically detect OpenSSL 1.0.x on VMS, and update VMS
+	  installation instructions to reflect removal of Module::Install
+	  from the build system. Fixes RT#124388. Thanks to Craig A. Berry.
 
 1.86_03 2018-07-19
 	- Convert packaging to ExtUtils::MakeMaker

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -173,6 +173,10 @@ EOM
           @{ $opts->{lib_paths} } = 'SSLLIB';
           @{ $opts->{lib_links} } = qw( ssl_libssl32.olb ssl_libcrypto32.olb );
         }
+        elsif (-r 'ssl1$root:[000000]openssl.cnf') {  # VSI or HPE SSL1 install
+            @{ $opts->{lib_paths} } = 'SYS$SHARE';
+            @{ $opts->{lib_links} } = qw( SSL1$LIBSSL_SHR32 SSL1$LIBCRYPTO_SHR32 );
+        }
         elsif (-r 'ssl$root:[000000]openssl.cnf') {  # HP install
             @{ $opts->{lib_paths} } = 'SYS$SHARE';
             @{ $opts->{lib_links} } = qw( SSL$LIBSSL_SHR32 SSL$LIBCRYPTO_SHR32 );
@@ -246,6 +250,7 @@ sub find_openssl_prefix {
 	$Config{prefix} . '\bin\openssl.exe'      => $Config{prefix},           # strawberry perl
 	$Config{prefix} . '\..\c\bin\openssl.exe' => $Config{prefix} . '\..\c', # strawberry perl
 	'/sslexe/openssl.exe'            => '/sslroot',  # VMS, openssl.org
+	'/ssl1$exe/openssl.exe'          => '/ssl1$root',# VMS, VSI or HPE install
 	'/ssl$exe/openssl.exe'           => '/ssl$root', # VMS, HP install
     );
 

--- a/README.VMS
+++ b/README.VMS
@@ -1,92 +1,27 @@
-Building on HP OpenVMS
+Building on OpenVMS
 ======================
-You'll need to either build and install OpenSSL from source using the authoritative
-sources from openssl.org or install the HP-supplied PCSI kit.  The former is more likely
-to be up-to-date and gets you SSL object libraries that that will be linked into the
-Net::SSLeay shareable image.  That means no updates to SSL without updating Net::SSLeay,
-but that could be a good thing if OpenSSL changes the API and breaks binary compability
-again.  The latter (HP install) gives you the possibility of SSL updates without
-rebuilding Net::SSLeay assuming the upgrade is binary compatible, and also gets you the
-possibility of support from HP if you encounter a problem that is within the SSL
-libraries.  If you don't know what any of this means, just use whatever is already on
-your system (if anything) or install whatever is easiest.
+You'll need to either build and install OpenSSL from source using the
+authoritative sources from openssl.org or install a PCSI kit from HPE or
+VSI.  Building against your own from-source installation currently uses
+SSL object libraries that will be statically linked into the
+Net::SSLeay shareable image.  That means no updates to SSL without
+updating Net::SSLeay.
 
-Once you've got a working installation of the SSL libraries, the steps to build
-Net::SSLeay on VMS are really the same as building any other package,and should look
-something like:
+Building against a vendor installation gives you the possibility of SSL
+updates without rebuilding Net::SSLeay, assuming the upgrade is binary
+compatible, and also gets you the possibility of vendor support if you
+encounter a problem that is within the SSL libraries.  If you don't know
+what any of this means, just use whatever is already on your system (if
+anything) or install whatever is easiest.
+
+Once you've got a working installation of the SSL libraries, the steps
+to build Net::SSLeay on VMS are really the same as building any other
+package,and should look something like:
 
  $ gzip -d Net-SSLeay-xx.xx.tar.gz
  $ vmstar -xvf Net-SSLeay-xx.xx.tar
- $ rename Net-SSLeay-xx.xx.DIR Net-SSLeay-xx_xx.DIR ! avoid dots in dirname
  $ set default [.Net-SSLeay-xx_xx]
  $ perl Makefile.PL
  $ mmk
  $ mmk test
  $ mmk install
-
-Note that Net::SSLeay uses Module::Install, which as of 1.06 does not work on VMS. A patch
-has been sent upstream but in case it hasn't made its way back downstream yet and you
-bomb out trying to run the Makefile.PL for Net::SSLeay, try the following patch, which
-patches the local [.inc] version of Module::Install embedded in Net::SSLeay.  (It may also
-be applicable other modules that use Module::Install.)
-
---- inc/Module/Install.pm.orig	2012-09-03 11:40:44 -0500
-+++ inc/Module/Install.pm	2012-09-21 16:19:55 -0500
-@@ -244,6 +244,8 @@ sub new {
- 	}
- 	return $args{_self} if $args{_self};
- 
-+	$base_path = VMS::Filespec::unixify($base_path) if $^O eq 'VMS';
-+
- 	$args{dispatch} ||= 'Admin';
- 	$args{prefix}   ||= 'inc';
- 	$args{author}   ||= ($^O eq 'VMS' ? '_author' : '.author');
-@@ -322,7 +325,7 @@ sub find_extensions {
- 	my ($self, $path) = @_;
- 
- 	my @found;
--	File::Find::find( sub {
-+	File::Find::find( {no_chdir => 1, wanted => sub {
- 		my $file = $File::Find::name;
- 		return unless $file =~ m!^\Q$path\E/(.+)\.pm\Z!is;
- 		my $subpath = $1;
-@@ -336,9 +339,9 @@ sub find_extensions {
- 		# correctly.  Otherwise, root through the file to locate the case-preserved
- 		# version of the package name.
- 		if ( $subpath eq lc($subpath) || $subpath eq uc($subpath) ) {
--			my $content = Module::Install::_read($subpath . '.pm');
-+			my $content = Module::Install::_read($File::Find::name);
- 			my $in_pod  = 0;
--			foreach ( split //, $content ) {
-+			foreach ( split /\n/, $content ) {
- 				$in_pod = 1 if /^=\w/;
- 				$in_pod = 0 if /^=cut/;
- 				next if ($in_pod || /^=cut/);  # skip pod text
-@@ -351,7 +354,7 @@ sub find_extensions {
- 		}
- 
- 		push @found, [ $file, $pkg ];
--	}, $path ) if -d $path;
-+	}}, $path ) if -d $path;
- 
- 	@found;
- }
---- inc/Module/Install/Can.pm;-0	2012-09-03 11:38:43 -0500
-+++ inc/Module/Install/Can.pm	2012-09-21 17:07:15 -0500
-@@ -121,6 +121,15 @@ END_C
- # Can we locate a (the) C compiler
- sub can_cc {
- 	my $self   = shift;
-+
-+        if ($^O eq 'VMS') {
-+            require ExtUtils::CBuilder;
-+            my $builder = ExtUtils::CBuilder->new(
-+		quiet => 1,
-+            );
-+            return $builder->have_compiler;
-+        }
-+
- 	my @chunks = split(/ /, $Config::Config{cc}) or return;
- 
- 	# $Config{cc} may contain args; try to find out the program part
-[end of patch to Module::Install]


### PR DESCRIPTION
A VMS support update from Craig A. Berry that auto-detects OpenSSL 1.0.x at compile-time and deals with the aftermath of the removal of Module::Install from the build system.

This closes [RT#124388](https://rt.cpan.org/Ticket/Display.html?id=124388).