### PR TITLE
Sync Net::SSLeay and Net::SSLeay::Handle version numbers

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for Perl extension Net::SSLeay.
 
+???
+	- Increment Net::SSLeay::Handle's version number to keep it in sync
+	  with Net::SSLeay's, thus satisfying Kwalitee's consistent_version
+	  metric.
+
 1.86_04 2018-07-30
 	- Re-add SSLv3_method() for OpenSSL 1.0.2 and above. Fixes
 	  RT#101484.

--- a/lib/Net/SSLeay.pm
+++ b/lib/Net/SSLeay.pm
@@ -61,7 +61,7 @@ $Net::SSLeay::slowly = 0;
 $Net::SSLeay::random_device = '/dev/urandom';
 $Net::SSLeay::how_random = 512;
 
-$VERSION = '1.86_04'; # Version in META.yml is automatically updated
+$VERSION = '1.86_04'; # Also update $Net::SSLeay::Handle::VERSION
 @ISA = qw(Exporter);
 
 #BEWARE:

--- a/lib/Net/SSLeay/Handle.pm
+++ b/lib/Net/SSLeay/Handle.pm
@@ -54,7 +54,7 @@ you need to add to your program is the tie function as in:
 use vars qw(@ISA @EXPORT_OK $VERSION);
 @ISA = qw(Exporter);
 @EXPORT_OK = qw(shutdown);
-$VERSION = '0.61';
+$VERSION = '0.86_04';
 
 my $Initialized;       #-- only _initialize() once
 my $Debug = 0;         #-- pretty hokey


### PR DESCRIPTION
Increment Net::SSLeay::Handle's version number to keep it in sync with Net::SSLeay's, thus satisfying Kwalitee's `consistent_version` metric.

Closes #23.