### PR TITLE
Re-enable d2i_X509_bio() test for LibreSSL

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,8 @@ Revision history for Perl extension Net::SSLeay.
 	- Increment Net::SSLeay::Handle's version number to keep it in sync
 	  with Net::SSLeay's, thus satisfying Kwalitee's consistent_version
 	  metric.
+	- Re-enable the d2i_X509_bio() test in t/local/33_x509_create_cert.t
+	  for LibreSSL. Thanks to Alexander Bluhm.
 
 1.86_04 2018-07-30
 	- Re-add SSLv3_method() for OpenSSL 1.0.2 and above. Fixes

--- a/t/local/33_x509_create_cert.t
+++ b/t/local/33_x509_create_cert.t
@@ -299,7 +299,7 @@ SKIP: { ### X509 certificate - unicode
 
  SKIP: 
   {
-      skip 'd2i_X509_bio fails for openssl-1.1.0e and later', 1 unless Net::SSLeay::SSLeay < 0x1010005f; 
+      skip 'd2i_X509_bio fails for openssl-1.1.0e and later', 1 unless Net::SSLeay::SSLeay < 0x1010005f or Net::SSLeay::constant("LIBRESSL_VERSION_NUMBER");
       ok(my $x509 = Net::SSLeay::d2i_X509_bio($bio2), "d2i_X509_bio");
   }
 }


### PR DESCRIPTION
The `d2i_X509_bio()` test in `t/local/33_x509_create_cert.t` is skipped for OpenSSL 1.1.0e onwards, but the way the test skip condition is defined erroneously causes it to be skipped for all LibreSSL versions too. Re-enable the test for all LibreSSL versions.

This closes [RT#124818](https://rt.cpan.org/Ticket/Display.html?id=124818). Thanks to Alexander Bluhm for the report and patch.