### PR TITLE
Increase minimum supported Perl version to 5.8.1

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,3 +1,5 @@
+use 5.8.1;
+
 use strict;
 use warnings;
 use ExtUtils::MakeMaker;
@@ -29,6 +31,7 @@ my %eumm_args = (
     'Test::More' => '0.60_01',
   },
   PREREQ_PM => {
+    'perl' => '5.8.1',
     'MIME::Base64' => '0',
   },
   test => { TESTS => $tests },

--- a/README
+++ b/README
@@ -17,8 +17,7 @@ for the latest and possibly unstable version from git:
 Prerequisites
 -------------
 
-perl-5.6.1     though anything starting from perl5.003 probably works. Later
-	       versions are OK.
+Perl 5.8.1 or higher.
 
 OpenSSL-0.9.6j through to at least OpenSSL-1.1 and probably later
 	       http://www.openssl.org/ - On Linux, you can either build and
@@ -218,9 +217,6 @@ I have a report (schinder@@pobox._com) of make test segfaulting on
 Linux-PPC. This still needs to be investigated. No recent information
 has been received.
 
-It seems perl5.004 (at least some versions) has bad xsub compiler which
-can make builds sometimes fail. Try upgrading to perl-5.6.1 first.
-
 "Random number generator not seeded!!!" This warning indicates that
     randomize() was not able to read /dev/random or /dev/urandom, possibly
     because your system does not have them or they are differently
@@ -232,20 +228,6 @@ is, just say `perldoc Net::SSLeay' or `more SSLeay.pm')?
 
 Are you sure you didn't confuse `Net::SSLeay' with `SSLeay' that
 comes with OpenSSL?
-
-My development environments used to be
-
-  i686,   Linux-2.4.3,  gcc-2.92.2,   glibc-2.2,   perl-5.6.0,   openssl-0.9.6a
-  i686,   Linux-2.4.3,  gcc-2.92.2,   glibc-2.2,   perl5.005_02, openssl-0.9.6a
-  i686,   Linux-2.0.35, gcc-2.7.2.3,  glibc-2.0.6, perl5.005_02, openssl-0.9.5a
-  i586,   Linux-2.4.3,  gcc-2.92.2.1, glibc-2.2.2, perl-5.6.0,   openssl-0.9.6a
-  i586,   Linux-2.4.3,  gcc-2.92.2.1, glibc-2.2.2, perl5.005_03, openssl-0.9.6
-  i586,   Linux-2.4.3,  gcc-2.92.2.1, glibc-2.2.2, perl5.005_03, openssl-0.9.6a
-  Sun-U1, SunOS-5.6,    gcc-2.92.2,   libc2        perl-5.6.1,   openssl-0.9.6c
-
-Unfortunately I do not have access to other systems so you are
-somewhat on your own. Everything compiles without a warning (except
-those mentioned above) on my systems.
 
 Check that perl is finding your OpenSSL.
 

--- a/lib/Net/SSLeay.pm
+++ b/lib/Net/SSLeay.pm
@@ -11,12 +11,13 @@
 
 package Net::SSLeay;
 
+use 5.8.1;
+
 use strict;
 use Carp;
 use vars qw($VERSION @ISA @EXPORT @EXPORT_OK $AUTOLOAD $CRLF);
 use Socket;
 use Errno;
-require 5.005_000;
 
 require Exporter;
 use AutoLoader;

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -8978,10 +8978,10 @@ is implemented.
 The high level API functions use a global file handle C<SSLCAT_S>
 internally. This really should not be a problem because there is no
 way to interleave the high level API functions, unless you use threads
-(but threads are not very well supported in perl anyway (as of version
-5.6.1). However, you may run into problems if you call undocumented
-internal functions in an interleaved fashion. The best solution is to "require Net::SSLeay"
-in one thread after all the threads have been created.
+(but threads are not very well supported in perl anyway). However, you
+may run into problems if you call undocumented internal functions in an
+interleaved fashion. The best solution is to "require Net::SSLeay" in
+one thread after all the threads have been created.
 
 =head1 DIAGNOSTICS
 

--- a/t/local/33_x509_create_cert.t
+++ b/t/local/33_x509_create_cert.t
@@ -228,8 +228,7 @@ is(Net::SSLeay::X509_NAME_cmp($ca_issuer, $ca_subject), 0, "X509_NAME_cmp");
   is(Net::SSLeay::X509_free($x509ss), undef, "X509_free");
 }
 
-SKIP: { ### X509 certificate - unicode
-  skip('skiiping unicode related stuff on perl 5.6', 5) if $] < 5.007;
+{ ### X509 certificate - unicode
   ok(my $x509  = Net::SSLeay::X509_new(), "X509_new");
   ok(my $name = Net::SSLeay::X509_get_subject_name($x509), "X509_get_subject_name");
   my $txt = "\x{17E}lut\xFD";

--- a/t/local/61_threads-cb-crash.t
+++ b/t/local/61_threads-cb-crash.t
@@ -4,7 +4,7 @@ use Config;
 use Test::More;
 
 BEGIN {
-  plan skip_all => "your perl is not compiled with ithreads or is pre-5.8" unless $Config{useithreads} && $] >= 5.008;
+  plan skip_all => "your perl is not compiled with ithreads" unless $Config{useithreads};
   require threads;
 };
 

--- a/t/local/62_threads-ctx_new-deadlock.t
+++ b/t/local/62_threads-ctx_new-deadlock.t
@@ -4,7 +4,7 @@ use Config;
 use Test::More;
 
 BEGIN {
-  plan skip_all => "your perl is not compiled with ithreads or is pre-5.8" unless $Config{useithreads} && $] >= 5.008;
+  plan skip_all => "your perl is not compiled with ithreads" unless $Config{useithreads};
   require threads;
 };
 


### PR DESCRIPTION
Advertise Perl 5.8.1 as the minimum supported version on CPAN (via `META.json` and `META.yml`), require at least Perl 5.8.1 to run `Makefile.PL` or use the modules, remove checks on Perl versions below 5.8.1 when skipping tests, and remove all documentation relating to earlier versions of Perl.

Closes #25.