### PR TITLE
Library auto-detection fixes for Windows

### DIFF
--- a/Changes
+++ b/Changes
@@ -10,6 +10,9 @@ Revision history for Perl extension Net::SSLeay.
 	  metric.
 	- Re-enable the d2i_X509_bio() test in t/local/33_x509_create_cert.t
 	  for LibreSSL. Thanks to Alexander Bluhm.
+	- Automatically detect new library names on Windows for OpenSSL
+	  1.1.0 onwards (libcrypto, libssl). Fixes part of RT#121084. Thanks
+	  to Jean-Damien Durand.
 
 1.86_04 2018-07-30
 	- Re-add SSLv3_method() for OpenSSL 1.0.2 and above. Fixes

--- a/Changes
+++ b/Changes
@@ -13,6 +13,9 @@ Revision history for Perl extension Net::SSLeay.
 	- Automatically detect new library names on Windows for OpenSSL
 	  1.1.0 onwards (libcrypto, libssl). Fixes part of RT#121084. Thanks
 	  to Jean-Damien Durand.
+	- Fix a typo preventing OpenSSL libraries built with the VC compiler
+	  (i.e. ones with a ".lib" suffix) from being automatically detected
+	  on Windows. Fixes part of RT#121084. Thanks to Jean-Damien Durand.
 
 1.86_04 2018-07-30
 	- Re-add SSLv3_method() for OpenSSL 1.0.2 and above. Fixes

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -154,7 +154,7 @@ EOM
         my @pairs = ();
         # Library names depend on the compiler
         @pairs = (['eay32','ssl32'],['crypto.dll','ssl.dll'],['crypto','ssl']) if $Config{cc} =~ /gcc/;
-        @pairs = (['libeay32','ssleay32'],['libeay32MD','ssleay32MD'],['libeay32MT','ssleay32MT']) if $Config{cc} =~ /cl/;
+        @pairs = (['libeay32','ssleay32'],['libeay32MD','ssleay32MD'],['libeay32MT','ssleay32MT'],['libcrypto','libssl']) if $Config{cc} =~ /cl/;
         for my $dir (@{$opts->{lib_paths}}) {
           for my $p (@pairs) {
             $found = 1 if ($Config{cc} =~ /gcc/ && -f "$dir/lib$p->[0].a" && -f "$dir/lib$p->[1].a");

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -158,7 +158,7 @@ EOM
         for my $dir (@{$opts->{lib_paths}}) {
           for my $p (@pairs) {
             $found = 1 if ($Config{cc} =~ /gcc/ && -f "$dir/lib$p->[0].a" && -f "$dir/lib$p->[1].a");
-            $found = 1 if ($Config{cc} =~ /cl/ && -f "$dir/$p->[0].lib" && -f "$dir/p->[1].lib");
+            $found = 1 if ($Config{cc} =~ /cl/ && -f "$dir/$p->[0].lib" && -f "$dir/$p->[1].lib");
             if ($found) {
               $opts->{lib_links} = [$p->[0], $p->[1], 'crypt32']; # Some systems need this system lib crypt32 too
               $opts->{lib_paths} = [$dir];


### PR DESCRIPTION
Two patches for OpenSSL on Windows from Jean-Damien Durand:

* The first enables auto-detection of `libcrypto` and `libssl`, which are the library names used by OpenSSL 1.1.0 onwards when compiled with the VC compiler.
* The second fixes a typo that prevented auto-detection of VC-compiled OpenSSL libraries (i.e. ones ending in `.lib`).

This closes [RT#121084](https://rt.cpan.org/Ticket/Display.html?id=121084).