### PR TITLE
Add missing call to va_end() in TRACE()

### DIFF
--- a/Changes
+++ b/Changes
@@ -16,6 +16,8 @@ Revision history for Perl extension Net::SSLeay.
 	- Fix a typo preventing OpenSSL libraries built with the VC compiler
 	  (i.e. ones with a ".lib" suffix) from being automatically detected
 	  on Windows. Fixes part of RT#121084. Thanks to Jean-Damien Durand.
+	- Add missing call to va_end() following va_start() in TRACE().
+	  Fixes RT#126028. Thanks to Jitka Plesnikova.
 
 1.86_04 2018-07-30
 	- Re-add SSLv3_method() for OpenSSL 1.0.2 and above. Fixes

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -222,6 +222,7 @@ static void TRACE(int level,char *msg,...) {
 	va_start(args,msg);
 	vsnprintf(buf,4095,msg,args);
 	warn("%s",buf);
+	va_end(args);
     }
 }
 


### PR DESCRIPTION
In `SSLeay.xs`, `TRACE()` makes a call to `va_start()` without a corresponding call to `va_end()` before the function returns. Add the missing call to `va_end()`.

This closes [RT#126028](https://rt.cpan.org/Ticket/Display.html?id=126028). Thanks to Jitka Plesnikova for the report and patch.