### PR TITLE
Added SSL_in_init() and the related functions

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -74,6 +74,7 @@ matrix:
 # Skip build for every push on most branches
 branches:
   only:
+    - master
     - /appveyor/
 
 # Tags need not to trigger builds

--- a/Changes
+++ b/Changes
@@ -1,6 +1,12 @@
 Revision history for Perl extension Net::SSLeay.
 
 ???
+	- Added SSL_in_init() and the related functions for all
+	  libraries and their versions. All return 0 or 1 as
+	  documented by OpenSSL 1.1.1. Use of these functions is
+	  recommended over using constants returned by get_state() and
+	  state(). New constants TLS_ST_*, used by OpenSSL 1.1.0 and
+	  later, will not be made available by Net::SSLeay.
 	- Net-SSLeay now requires at least Perl 5.8.1. This is a
 	  formalisation of what has been the de facto case for some time,
 	  as the distribution hasn't compiled and passed its tests on Perl

--- a/Changes
+++ b/Changes
@@ -1,12 +1,6 @@
 Revision history for Perl extension Net::SSLeay.
 
 ???
-	- Added SSL_in_init() and the related functions for all
-	  libraries and their versions. All return 0 or 1 as
-	  documented by OpenSSL 1.1.1. Use of these functions is
-	  recommended over using constants returned by get_state() and
-	  state(). New constants TLS_ST_*, used by OpenSSL 1.1.0 and
-	  later, will not be made available by Net::SSLeay.
 	- Net-SSLeay now requires at least Perl 5.8.1. This is a
 	  formalisation of what has been the de facto case for some time,
 	  as the distribution hasn't compiled and passed its tests on Perl
@@ -24,6 +18,12 @@ Revision history for Perl extension Net::SSLeay.
 	  on Windows. Fixes part of RT#121084. Thanks to Jean-Damien Durand.
 	- Add missing call to va_end() following va_start() in TRACE().
 	  Fixes RT#126028. Thanks to Jitka Plesnikova.
+	- Added SSL_in_init() and the related functions for all
+	  libraries and their versions. All return 0 or 1 as
+	  documented by OpenSSL 1.1.1. Use of these functions is
+	  recommended over using constants returned by get_state() and
+	  state(). New constants TLS_ST_*, used by OpenSSL 1.1.0 and
+	  later, will not be made available by Net::SSLeay.
 
 1.86_04 2018-07-30
 	- Re-add SSLv3_method() for OpenSSL 1.0.2 and above. Fixes

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -2475,7 +2475,7 @@ SSL_want(s)
 
  # OpenSSL 1.1.1 documents SSL_in_init and the related functions as
  # returning 0 or 1. However, older versions and e.g. LibreSSL may
- # return other values than 1.
+ # return other values than 1 which we fold to 1.
 int
 SSL_in_before(s)
      SSL *              s

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -2473,6 +2473,49 @@ int
 SSL_want(s)
      SSL *              s
 
+ # OpenSSL 1.1.1 documents SSL_in_init and the related functions as
+ # returning 0 or 1. However, older versions and e.g. LibreSSL may
+ # return other values than 1.
+int
+SSL_in_before(s)
+     SSL *              s
+     CODE:
+     RETVAL = SSL_in_before(s) == 0 ? 0 : 1;
+     OUTPUT:
+     RETVAL
+
+int
+SSL_is_init_finished(s)
+     SSL *              s
+     CODE:
+     RETVAL = SSL_is_init_finished(s) == 0 ? 0 : 1;
+     OUTPUT:
+     RETVAL
+
+int
+SSL_in_init(s)
+     SSL *              s
+     CODE:
+     RETVAL = SSL_in_init(s) == 0 ? 0 : 1;
+     OUTPUT:
+     RETVAL
+
+int
+SSL_in_connect_init(s)
+     SSL *              s
+     CODE:
+     RETVAL = SSL_in_connect_init(s) == 0 ? 0 : 1;
+     OUTPUT:
+     RETVAL
+
+int
+SSL_in_accept_init(s)
+     SSL *              s
+     CODE:
+     RETVAL = SSL_in_accept_init(s) == 0 ? 0 : 1;
+     OUTPUT:
+     RETVAL
+
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 int
 SSL_state(s)

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -3810,7 +3810,22 @@ Returns a function pointer to the TLS/SSL method set in $ssl.
 
 Check openssl doc L<http://www.openssl.org/docs/ssl/SSL_CTX_set_ssl_version.html|http://www.openssl.org/docs/ssl/SSL_CTX_set_ssl_version.html>
 
+=item * in_init, in_before, is_init_finished, in_connect_init, in_accept_init
+
+B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before.
+
+Retrieve information about the handshake state machine. All functions take $ssl as the only argument and return 0 or 1. These functions are recommended over get_state() and state().
+
+ my $rv = Net::SSLeay::is_init_finished($ssl);
+ # $ssl - value corresponding to openssl's SSL structure
+ #
+ # returns: All functions return 1 or 0
+
+Check openssl doc L<https://www.openssl.org/docs/ssl/SSL_in_init.html|http://www.openssl.org/docs/ssl/SSL_in_init.html>
+
 =item * get_state
+
+B<COMPATIBILITY:> OpenSSL 1.1.0 and later use different constants which are not made available. Use is_init_finished() and related functions instead.
 
 Returns the SSL connection state.
 

--- a/t/local/07_sslecho.t
+++ b/t/local/07_sslecho.t
@@ -13,7 +13,7 @@ BEGIN {
   plan skip_all => "fork() not supported on $^O" unless $Config{d_fork};
 }
 
-plan tests => 78;
+plan tests => 99;
 
 my $sock;
 my $pid;
@@ -76,8 +76,13 @@ Net::SSLeay::library_init();
             my $ssl = Net::SSLeay::new($ctx);
             ok($ssl, 'new');
 
+	    is(Net::SSLeay::in_before($ssl), 1, 'in_before is 1');
+	    is(Net::SSLeay::in_init($ssl), 1, 'in_init is 1');
+
             ok(Net::SSLeay::set_fd($ssl, fileno($ns)), 'set_fd using fileno');
             ok(Net::SSLeay::accept($ssl), 'accept');
+
+	    is(Net::SSLeay::is_init_finished($ssl), 1, 'is_init_finished is 1');
 
             ok(Net::SSLeay::get_cipher($ssl), 'get_cipher');
             like(Net::SSLeay::get_shared_ciphers($ssl), qr/(AES|RSA|SHA|CBC|DES)/, 'get_shared_ciphers');
@@ -351,7 +356,7 @@ waitpid $pid, 0;
 push @results, [ $? == 0, 'server exited with 0' ];
 
 END {
-    Test::More->builder->current_test(51);
+    Test::More->builder->current_test(72);
     for my $t (@results) {
         ok( $t->[0], $t->[1] );
     }

--- a/t/local/09_ctx_new.t
+++ b/t/local/09_ctx_new.t
@@ -1,10 +1,11 @@
 #!/usr/bin/perl
 
 # Tests for SSL_CTX_new and related functions
+# Also test handshake state machine retrieval
 
 use strict;
 use warnings;
-use Test::More tests => 40;
+use Test::More tests => 44;
 use Net::SSLeay;
 
 Net::SSLeay::randomize();
@@ -31,6 +32,12 @@ ok($ctx_23_server, 'CTX_new with SSLv23_server_method');
 
 my $ctx_tls1 = Net::SSLeay::CTX_new_with_method(Net::SSLeay::TLSv1_method());
 ok($ctx_tls1, 'CTX_new with TLSv1_method');
+
+# Retrieve information about the handshake state machine
+is(Net::SSLeay::in_connect_init(Net::SSLeay::new($ctx_23_client)), 1, 'in_connect_init() is 1 for client');
+is(Net::SSLeay::in_accept_init(Net::SSLeay::new($ctx_23_client)),  0, 'in_accept_init() is 0 for client');
+is(Net::SSLeay::in_connect_init(Net::SSLeay::new($ctx_23_server)), 0, 'in_connect_init() is 0 for server');
+is(Net::SSLeay::in_accept_init(Net::SSLeay::new($ctx_23_server)),  1, 'in_accept_init() is 1 for server');
 
 # Need recent enough OpenSSL or LibreSSL for TLS_method functions
 my ($ctx_tls, $ssl_tls, $ctx_tls_client, $ssl_tls_client, $ctx_tls_server, $ssl_tls_server);


### PR DESCRIPTION
Use of these convenience functions is now recommended when needing
access to handshake state machine state. See Changes for more information.