### PR TITLE
GH-39 Update author/maintainer information

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,7 +22,14 @@ my %eumm_args = (
   NAME => 'Net::SSLeay',
   ABSTRACT => 'Perl extension for using OpenSSL',
   LICENSE => 'perl',
-  AUTHOR => 'Originally written by Sampo Kellomäki',
+  AUTHOR => [
+    'Sampo Kellomäki <sampo@iki.fi>',
+    'Florian Ragwitz <rafl@debian.org>',
+    'Mike McCauley <mikem@airspayce.com>',
+    'Chris Novakovic <chris@chrisn.me.uk>',
+    'Tuure Vartiainen <vartiait@radiatorsoftware.com>',
+    'Heikki Vatiainen <hvn@radiatorsoftware.com>'
+  ],
   VERSION_FROM => 'lib/Net/SSLeay.pm',
   CONFIGURE_REQUIRES => {
     'ExtUtils::MakeMaker' => '0',

--- a/README
+++ b/README
@@ -278,10 +278,12 @@ so I can fix it. Patches and gdb session dumps are also welcome.
 License and Copying
 -------------------
 
-Copyright (c) 1996-2002 Sampo Kellomaki <sampo@symlabs.com>
-Copyright (c) 2005 Florian Ragwitz <rafl@debian.org>
-Copyright (c) 2005 Mike McCauley <mikem@airspayce.com>
-
+Copyright (c) 1996-2003 Sampo Kellomäki <sampo@iki.fi>
+Copyright (c) 2005-2010 Florian Ragwitz <rafl@debian.org>
+Copyright (c) 2005-2018 Mike McCauley <mikem@airspayce.com>
+Copyright (c) 2018- Chris Novakovic <chris@chrisn.me.uk>
+Copyright (c) 2018- Tuure Vartiainen <vartiait@radiatorsoftware.com>
+Copyright (c) 2018- Heikki Vatiainen <hvn@radiatorsoftware.com>
 
 All Rights Reserved.
 

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -1,8 +1,11 @@
 /* SSLeay.xs - Perl module for using Eric Young's implementation of SSL
  *
- * Copyright (c) 1996-2002 Sampo Kellomaki <sampo@iki.fi>
- * Copyright (C) 2005 Florian Ragwitz <rafl@debian.org>
- * Copyright (C) 2005 Mike McCauley <mikem@airspayce.com>
+ * Copyright (c) 1996-2003 Sampo Kellomäki <sampo@iki.fi>
+ * Copyright (c) 2005-2010 Florian Ragwitz <rafl@debian.org>
+ * Copyright (c) 2005-2018 Mike McCauley <mikem@airspayce.com>
+ * Copyright (c) 2018- Chris Novakovic <chris@chrisn.me.uk>
+ * Copyright (c) 2018- Tuure Vartiainen <vartiait@radiatorsoftware.com>
+ * Copyright (c) 2018- Heikki Vatiainen <hvn@radiatorsoftware.com>
  * 
  * All Rights Reserved.
  *

--- a/lib/Net/SSLeay.pm
+++ b/lib/Net/SSLeay.pm
@@ -1,8 +1,11 @@
 # Net::SSLeay.pm - Perl module for using Eric Young's implementation of SSL
 #
-# Copyright (c) 1996-2003 Sampo Kellomaki <sampo@iki.fi>, All Rights Reserved.
-# Copyright (C) 2005 Florian Ragwitz <rafl@debian.org>, All Rights Reserved.
-# Copyright (C) 2005 Mike McCauley <mikem@airspayce.com>, All Rights Reserved.
+# Copyright (c) 1996-2003 Sampo Kellomäki <sampo@iki.fi>, All Rights Reserved.
+# Copyright (c) 2005-2010 Florian Ragwitz <rafl@debian.org>, All Rights Reserved.
+# Copyright (c) 2005-2018 Mike McCauley <mikem@airspayce.com>, All Rights Reserved.
+# Copyright (c) 2018- Chris Novakovic <chris@chrisn.me.uk>, All Rights Reserved.
+# Copyright (c) 2018- Tuure Vartiainen <vartiait@radiatorsoftware.com>, All Rights Reserved.
+# Copyright (c) 2018- Heikki Vatiainen <hvn@radiatorsoftware.com>, All Rights Reserved.
 #
 # Change data removed from here. See Changes
 # The distribution and use of this module are subject to the conditions

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -9151,17 +9151,27 @@ Commercial support for Net::SSLeay may be obtained from
 
 =head1 AUTHOR
 
-Maintained by Mike McCauley and Florian Ragwitz since November 2005
+Originally written by Sampo Kellomäki.
 
-Originally written by Sampo Kellomäki <sampo@symlabs.com>
+Maintained by Florian Ragwitz between November 2005 and January 2010.
+
+Maintained by Mike McCauley between November 2005 and June 2018.
+
+Maintained by Chris Novakovic, Tuure Vartiainen and Heikki Vatiainen since June 2018.
 
 =head1 COPYRIGHT
 
-Copyright (c) 1996-2003 Sampo Kellomäki <sampo@symlabs.com>
+Copyright (c) 1996-2003 Sampo Kellomäki <sampo@iki.fi>
 
-Copyright (C) 2005-2006 Florian Ragwitz <rafl@debian.org>
+Copyright (c) 2005-2010 Florian Ragwitz <rafl@debian.org>
 
-Copyright (C) 2005 Mike McCauley <mikem@airspayce.com>
+Copyright (c) 2005-2018 Mike McCauley <mikem@airspayce.com>
+
+Copyright (c) 2018- Chris Novakovic <chris@chrisn.me.uk>
+
+Copyright (c) 2018- Tuure Vartiainen <vartiait@radiatorsoftware.com>
+
+Copyright (c) 2018- Heikki Vatiainen <hvn@radiatorsoftware.com>
 
 All Rights Reserved.
 

--- a/lib/Net/SSLeay/Handle.pm
+++ b/lib/Net/SSLeay/Handle.pm
@@ -9,6 +9,8 @@ use Net::SSLeay;
 
 require Exporter;
 
+=encoding utf-8
+
 =head1 NAME
 
 Net::SSLeay::Handle - Perl module that lets SSL (HTTPS) sockets be
@@ -348,7 +350,33 @@ Please see Net-SSLeay-Handle-0.50/Changes file.
 
 =head1 AUTHOR
 
-Jim Bowlin jbowlin@linklint.org
+Originally written by Jim Bowlin.
+
+Maintained by Sampo Kellomäki between July 2001 and August 2003.
+
+Maintained by Florian Ragwitz between November 2005 and January 2010.
+
+Maintained by Mike McCauley between November 2005 and June 2018.
+
+Maintained by Chris Novakovic, Tuure Vartiainen and Heikki Vatiainen since June 2018.
+
+=head1 COPYRIGHT
+
+Copyright (c) 2001 Jim Bowlin <jbowlin@linklint.org>
+
+Copyright (c) 2001-2003 Sampo Kellomäki <sampo@iki.fi>
+
+Copyright (c) 2005-2010 Florian Ragwitz <rafl@debian.org>
+
+Copyright (c) 2005-2018 Mike McCauley <mikem@airspayce.com>
+
+Copyright (c) 2018- Chris Novakovic <chris@chrisn.me.uk>
+
+Copyright (c) 2018- Tuure Vartiainen <vartiait@radiatorsoftware.com>
+
+Copyright (c) 2018- Heikki Vatiainen <hvn@radiatorsoftware.com>
+
+All rights reserved.
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
Update author and copyright information based on the following:

* Sampo's last Net-SSLeay release was 1.25 (2003-08-18), so change his copyright duration from 1996-2002 to 1996-2003.
* Standardise Sampo's surname and email address: "Kellomäki" and sampo@iki.fi (his current CPAN email address) respectively.
* Florian's last commit to the old Net-SSLeay SVN repository was revision 260 (2010-01-30), so change his copyright duration from 2005-2006 to 2005-2010.
* Mike McCauley handed over maintainership of Net-SSLeay in June 2018, so change his copyright duration to 2005-2018.
* Chris Novakovic, Tuure Vartiainen and Heikki Vatiainen took over maintainership of Net-SSLeay in June 2018, so give them copyright from 2018 onwards.
* Replicate this information in `lib/Net/SSLeay/Handle.pm`, which has been maintained as part of Net-SSLeay since 2001-07-18.

Closes #39.