### PR TITLE
CI: Travis: test against Perl 5.28

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 language: perl
 
 perl:
+  - "5.28"
   - "5.26"
   - "5.24"
   - "5.22"


### PR DESCRIPTION
Now that Perl 5.28 appears to be available in Travis, configure Travis to build and test Net-SSLeay against that version too.

Closes #49.