### PR TITLE
Set security level to 1 in tests that use pre-generated RSA keys

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,12 @@ Revision history for Perl extension Net::SSLeay.
 	  SSL_set_security_level and SSL_get_security_level.
 	  Add new test file 65_security_level.t.
 	  All courtesy of Damyan Ivanov of Debian project.
+	- Set OpenSSL security level to 1 in tests that use the test suite's
+	  (1024-bit) RSA keys, which allows the test suite to pass when
+	  Net-SSLeay is built against an OpenSSL with a higher default
+	  security level. Fixes RT#126987. Thanks to Petr Pisar (in
+	  RT#126270) and Damyan Ivanov (in RT#126987) for the reports and
+	  patches, and to Damyan Ivanov for the preferred patch.
 	- Add SSL_CTX_sess_set_new_cb and SSL_CTX_sess_set_remove_cb.
 	  Add new test file 44_sess.t for these and future session
 	  related tests for which no specific test file is needed.

--- a/t/local/07_sslecho.t
+++ b/t/local/07_sslecho.t
@@ -58,6 +58,7 @@ Net::SSLeay::library_init();
 
     my $ctx = Net::SSLeay::CTX_new();
     ok($ctx, 'CTX_new');
+    Net::SSLeay::CTX_set_security_level($ctx, 1) if exists &Net::SSLeay::CTX_set_security_level;
     ok(Net::SSLeay::CTX_set_cipher_list($ctx, 'ALL'), 'CTX_set_cipher_list');
     my ($dummy, $errs) = Net::SSLeay::set_cert_and_key($ctx, $cert_pem, $key_pem);
     ok($errs eq '', "set_cert_and_key: $errs");
@@ -75,6 +76,7 @@ Net::SSLeay::library_init();
 
             my $ssl = Net::SSLeay::new($ctx);
             ok($ssl, 'new');
+            Net::SSLeay::set_security_level($ssl, 1) if exists &Net::SSLeay::set_security_level;
 
 	    is(Net::SSLeay::in_before($ssl), 1, 'in_before is 1');
 	    is(Net::SSLeay::in_init($ssl), 1, 'in_init is 1');

--- a/t/local/08_pipe.t
+++ b/t/local/08_pipe.t
@@ -44,6 +44,7 @@ die unless defined $pid;
 
 if ($pid == 0) {
     my $ctx = Net::SSLeay::CTX_new();
+    Net::SSLeay::CTX_set_security_level($ctx, 1) if exists &Net::SSLeay::CTX_set_security_level;
     Net::SSLeay::set_server_cert_and_key($ctx, $cert, $key);
 
     my $ssl = Net::SSLeay::new($ctx);
@@ -68,6 +69,7 @@ if ($pid == 0) {
 my @results;
 {
     my $ctx = Net::SSLeay::CTX_new();
+    Net::SSLeay::CTX_set_security_level($ctx, 1) if exists &Net::SSLeay::CTX_set_security_level;
     my $ssl = Net::SSLeay::new($ctx);
 
     my $rc_handle = IO::Handle->new_from_fd( fileno($rc), 'r' );

--- a/t/local/36_verify.t
+++ b/t/local/36_verify.t
@@ -233,6 +233,7 @@ sub client {
     {
 	$ctx = Net::SSLeay::CTX_new();
 	is(Net::SSLeay::CTX_load_verify_locations($ctx, $ca_pem, $ca_dir), 1, "load_verify_locations($ca_pem $ca_dir)");
+	Net::SSLeay::CTX_set_security_level($ctx, 1) if exists &Net::SSLeay::CTX_set_security_level;
 
 	$cl = IO::Socket::INET->new($server_addr) or BAIL_OUT("failed to connect to server: $!");
 

--- a/t/local/64_ticket_sharing.t
+++ b/t/local/64_ticket_sharing.t
@@ -178,6 +178,7 @@ sub _handshake {
 	my $ctx = Net::SSLeay::CTX_tlsv1_new();
 	Net::SSLeay::CTX_set_options($ctx,Net::SSLeay::OP_ALL());
 	Net::SSLeay::CTX_set_cipher_list($ctx,'AES128-SHA');
+	Net::SSLeay::CTX_set_security_level($ctx, 1) if exists &Net::SSLeay::CTX_set_security_level;
 	my $id = 'client';
 	if ($args{cert}) {
 	    my ($cert,$key) = @{ delete $args{cert} };
@@ -240,6 +241,7 @@ sub _handshake {
     sub _reset {
 	my $self = shift;
 	my $ssl = Net::SSLeay::new($self->{ctx});
+	Net::SSLeay::set_security_level($ssl, 1) if exists &Net::SSLeay::set_security_level;
 	my @bio = (
 	    Net::SSLeay::BIO_new(Net::SSLeay::BIO_s_mem()),
 	    Net::SSLeay::BIO_new(Net::SSLeay::BIO_s_mem()),


### PR DESCRIPTION
The RSA keys generated for the test suite are 1024 bits long, but some distributions (notably Debian and RHEL) are now building their OpenSSL packages with security level 2 as the default, which prohibits the use of RSA keys under 2048 bits in length and causes tests that load these keys to fail. Set the security level to 1 (which permits the use of weaker keys) in tests that use the test suite's keys.

This closes [RT#126987](https://rt.cpan.org/Ticket/Display.html?id=126987), and addresses the same problem reported in [RT#126270](https://rt.cpan.org/Ticket/Display.html?id=126270) but fixes it in a more preferred way.