### PR TITLE
GH-42 Add SSL_CTX_set_num_tickets and related functions.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 Revision history for Perl extension Net::SSLeay.
 
 ??????? 2018-??-??
+	- Add SSL_CTX_set_num_tickets, SSL_CTX_get_num_tickets,
+	  SSL_set_num_ticket and SSL_get_num_tickets for controlling
+	  the number of TLSv1.3 session tickets that are issued.  Add
+	  tests in 44_sess.t. Parts taken from a larger patch by Petr
+	  Pisar of RedHat.
 	- Add SSL_CTX_set_security_level, SSL_CTX_get_security_level,
 	  SSL_set_security_level and SSL_get_security_level.
 	  Add new test file 65_security_level.t.

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -1978,6 +1978,16 @@ SSL_CTX_get_security_level(SSL_CTX * ctx)
 
 #endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x10101007L && !defined(LIBRESSL_VERSION_NUMBER)
+
+int
+SSL_CTX_set_num_tickets(SSL_CTX *ctx, size_t num_tickets)
+
+size_t
+SSL_CTX_get_num_tickets(SSL_CTX *ctx)
+
+#endif
+
 void
 SSL_CTX_sess_set_new_cb(ctx, callback)
         SSL_CTX * ctx
@@ -2726,6 +2736,16 @@ SSL_set_security_level(SSL * ssl, int level)
 
 int
 SSL_get_security_level(SSL * ssl)
+
+#endif
+
+#if OPENSSL_VERSION_NUMBER >= 0x10101007L && !defined(LIBRESSL_VERSION_NUMBER)
+
+int
+SSL_set_num_tickets(SSL *ssl, size_t num_tickets)
+
+size_t
+SSL_get_num_tickets(SSL *ssl)
 
 #endif
 

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -3250,6 +3250,35 @@ Sets the security level associated with $ctx to $level.
 
 Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_security_level.html|https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_security_level.html>
 
+=item * CTX_set_num_tickets
+
+B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.1, not in LibreSSL
+
+Set number of TLSv1.3 session tickets that will be sent to a client.
+
+ my $rv = Net::SSLeay::CTX_set_num_tickets($ctx, $number_of_tickets);
+ # $ctx  - value corresponding to openssl's SSL_CTX structure
+ # $number_of_tickets - number of tickets to send
+ #
+ # returns: 1 on success, 0 on failure
+
+Set to zero if you do not no want to support a session resumption.
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_num_tickets.html|https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_num_tickets.html>
+
+=item * CTX_get_num_tickets
+
+B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.1, not in LibreSSL
+
+Get number of TLSv1.3 session tickets that will be sent to a client.
+
+ my $number_of_tickets = Net::SSLeay::CTX_get_num_tickets($ctx);
+ # $ctx  - value corresponding to openssl's SSL_CTX structure
+ #
+ # returns: (integer) number of tickets to send
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_CTX_get_num_tickets.html|https://www.openssl.org/docs/manmaster/man3/SSL_CTX_get_num_tickets.html>
+
 =back
 
 =head3 Low level API: SSL_* related functions
@@ -3795,6 +3824,35 @@ Sets the security level associated with $ssl to $level.
  # returns: no return value
 
 Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_set_security_level.html|https://www.openssl.org/docs/manmaster/man3/SSL_set_security_level.html>
+
+=item * set_num_tickets
+
+B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.1, not in LibreSSL
+
+Set number of TLSv1.3 session tickets that will be sent to a client.
+
+ my $rv = Net::SSLeay::set_num_tickets($ssl, $number_of_tickets);
+ # $ssl  - value corresponding to openssl's SSL structure
+ # $number_of_tickets - number of tickets to send
+ #
+ # returns: 1 on success, 0 on failure
+
+Set to zero if you do not no want to support a session resumption.
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_set_num_tickets.html|https://www.openssl.org/docs/manmaster/man3/SSL_set_num_tickets.html>
+
+=item * get_num_tickets
+
+B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.1, not in LibreSSL
+
+Get number of TLSv1.3 session tickets that will be sent to a client.
+
+ my $number_of_tickets = Net::SSLeay::get_num_tickets($ctx);
+ # $ctx  - value corresponding to openssl's SSL structure
+ #
+ # returns: number of tickets to send
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_get_num_tickets.html|https://www.openssl.org/docs/manmaster/man3/SSL_get_num_tickets.html>
 
 =item * get_server_random
 


### PR DESCRIPTION
Add SSL_CTX_set_num_tickets, SSL_CTX_get_num_tickets,
SSL_set_num_ticket and SSL_get_num_tickets for controlling
the number of TLSv1.3 session tickets that are issued.

Add tests in 44_sess.t.

Parts taken from a larger patch by Petr Pisar of RedHat.

This closes #42 and is a part of a larger patch in
https://rt.cpan.org/Ticket/Display.html?id=126899