### PR TITLE
GH-36 Add SSL_CTX_set_ciphersuites and SSL_set_ciphersuites

### DIFF
--- a/Changes
+++ b/Changes
@@ -24,6 +24,9 @@ Revision history for Perl extension Net::SSLeay.
 	  the number of TLSv1.3 session tickets that are issued.  Add
 	  tests in 44_sess.t. Parts taken from a larger patch by Petr
 	  Pisar of RedHat.
+	- Add SSL_CTX_set_ciphersuites and SSL_set_ciphersuites for
+	  configuring the available TLSv1.3 ciphersuites. Add tests in
+	  43_misc_functions.t and clarify SSL_client_version tests.
 	- Add SSL_CTX_set_security_level, SSL_CTX_get_security_level,
 	  SSL_set_security_level and SSL_get_security_level.
 	  Add new test file 65_security_level.t.

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -1995,6 +1995,13 @@ SSL_CTX_get_num_tickets(SSL_CTX *ctx)
 
 #endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x10101003L && !defined(LIBRESSL_VERSION_NUMBER)
+
+int
+SSL_CTX_set_ciphersuites(SSL_CTX *ctx, const char *str)
+
+#endif
+
 void
 SSL_CTX_sess_set_new_cb(ctx, callback)
         SSL_CTX * ctx
@@ -2765,6 +2772,13 @@ SSL_set_num_tickets(SSL *ssl, size_t num_tickets)
 
 size_t
 SSL_get_num_tickets(SSL *ssl)
+
+#endif
+
+#if OPENSSL_VERSION_NUMBER >= 0x10101003L && !defined(LIBRESSL_VERSION_NUMBER)
+
+int
+SSL_set_ciphersuites(SSL *ssl, const char *str)
 
 #endif
 

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -2908,6 +2908,20 @@ The format of $str is described in L<http://www.openssl.org/docs/apps/ciphers.ht
 
 Check openssl doc L<http://www.openssl.org/docs/ssl/SSL_CTX_set_cipher_list.html|http://www.openssl.org/docs/ssl/SSL_CTX_set_cipher_list.html>
 
+=item * CTX_set_ciphersuites
+
+B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.1, not in LibreSSL
+
+Configure the available TLSv1.3 ciphersuites.
+
+ my $rv = Net::SSLeay::CTX_set_ciphersuites($ctx, $str);
+ # $ctx  - value corresponding to openssl's SSL_CTX structure
+ # $str  - colon (":") separated list of TLSv1.3 ciphersuite names in order of preference
+ #
+ # returns: (integer) 1 if the requested ciphersuite list was configured, and 0 otherwise
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_ciphersuites.html|https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_ciphersuites.html>
+
 =item * CTX_set_client_CA_list
 
 Sets the list of CAs sent to the client when requesting a client certificate for $ctx.
@@ -4303,6 +4317,20 @@ Sets the list of ciphers only for ssl.
  # returns: 1 if any cipher could be selected and 0 on complete failure
 
 Check openssl doc L<http://www.openssl.org/docs/ssl/SSL_CTX_set_cipher_list.html|http://www.openssl.org/docs/ssl/SSL_CTX_set_cipher_list.html>
+
+=item * set_ciphersuites
+
+B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.1, not in LibreSSL
+
+Configure the available TLSv1.3 ciphersuites.
+
+ my $rv = Net::SSLeay::set_ciphersuites($ssl, $str);
+ # $ssl  - value corresponding to openssl's SSL structure
+ # $str  - colon (":") separated list of TLSv1.3 ciphersuite names in order of preference
+ #
+ # returns: (integer) 1 if the requested ciphersuite list was configured, and 0 otherwise
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_set_ciphersuites.html|https://www.openssl.org/docs/manmaster/man3/SSL_set_ciphersuites.html>
 
 =item * set_client_CA_list
 


### PR DESCRIPTION
Add SSL_CTX_set_ciphersuites and SSL_set_ciphersuites for
configuring the available TLSv1.3 ciphersuites. For TLSv1.2 and
below you need to use SSL_CTX_set_cipher_list and SSL_set_cipher_list.

For more information, see https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_ciphersuites.html

Add tests in 43_misc_functions.t and clarify SSL_client_version tests.

Closes #36 