### PR TITLE
GH-63 Add SSL_peek_ex, SSL_read_ex, SSL_write_ex and SSL_has_pending

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,8 +1,8 @@
 Revision history for Perl extension Net::SSLeay.
 
 ??????? 2018-??-??
-	- Net::SSLeay::read() now checks SSL_get_error() for
-	  SSL_ERROR_ZERO_RETURN for return values <= 0 to make
+	- Net::SSLeay::read() and SSL_peek() now check SSL_get_error()
+	  for SSL_ERROR_ZERO_RETURN for return values <= 0 to make
 	  Net::SSLeay::read() behave more like underlying OpenSSL
 	  function SSL_read().
 	  Convenience function ssl_read_all() now does an automatic
@@ -47,6 +47,8 @@ Revision history for Perl extension Net::SSLeay.
 	  Add new test file 44_sess.t for these and future session
 	  related tests for which no specific test file is needed.
 	- Add SSL_get_version, SSL_client_version and SSL_is_dtls.
+	- Add SSL_peek_ex, SSL_read_ex, SSL_write_ex and SSL_has_pending.
+	  Added tests in t/local/11_read.t
 	- Enhance t/local/43_misc_functions.t get_keyblock_size test
 	  to work better with AEAD ciphers.
 	- Add constants SSL_OP_ENABLE_MIDDLEBOX_COMPAT and

--- a/Changes
+++ b/Changes
@@ -48,7 +48,7 @@ Revision history for Perl extension Net::SSLeay.
 	  related tests for which no specific test file is needed.
 	- Add SSL_get_version, SSL_client_version and SSL_is_dtls.
 	- Add SSL_peek_ex, SSL_read_ex, SSL_write_ex and SSL_has_pending.
-	  Added tests in t/local/11_read.t
+	  Add tests in t/local/11_read.t
 	- Enhance t/local/43_misc_functions.t get_keyblock_size test
 	  to work better with AEAD ciphers.
 	- Add constants SSL_OP_ENABLE_MIDDLEBOX_COMPAT and

--- a/MANIFEST
+++ b/MANIFEST
@@ -89,6 +89,7 @@ t/local/07_sslecho.t
 t/local/08_pipe.t
 t/local/09_ctx_new.t
 t/local/10_rand.t
+t/local/11_read.t
 t/local/15_bio.t
 t/local/20_autoload.t
 t/local/21_constants.t

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -4201,7 +4201,24 @@ buffer is unmodified after the SSL_peek() operation.
  #
  # in scalar context: data read from the TLS/SSL connection, undef on error
  # in list context:   two-item array consisting of data read (undef on error),
- #                      and return code from SSL_read().
+ #                      and return code from SSL_peek().
+
+=item * peek_ex
+
+B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.1, not in LibreSSL
+
+Copies $max bytes from the specified $ssl into the returned value.
+In contrast to the C<Net::SSLeay::read_ex()> function, the data in the SSL
+buffer is unmodified after the SSL_peek_ex() operation.
+
+ my($got, $rv) = Net::SSLeay::peek_ex($ssl, $max);
+ # $ssl - value corresponding to openssl's SSL structure
+ # $max - [optional] max bytes to peek (integer) - default is 32768
+ #
+ # returns a list: two-item list consisting of data read (undef on error),
+ #                 and return code from SSL_peek_ex().
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_peek_ex.html|https://www.openssl.org/docs/manmaster/man3/SSL_peek_ex.html>
 
 =item * pending
 
@@ -4213,6 +4230,19 @@ Obtain number of readable bytes buffered in $ssl object.
  # returns: the number of bytes pending
 
 Check openssl doc L<http://www.openssl.org/docs/ssl/SSL_pending.html|http://www.openssl.org/docs/ssl/SSL_pending.html>
+
+=item * has_pending
+
+B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.0, not in LibreSSL
+
+Returns 1 if $ssl has buffered data (whether processed or unprocessed) and 0 otherwise.
+
+ my $rv = Net::SSLeay::has_pending($ssl);
+ # $ssl - value corresponding to openssl's SSL structure
+ #
+ # returns: (integer) 1 or 0
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_has_pending.html|https://www.openssl.org/docs/manmaster/man3/SSL_has_pending.html>
 
 =item * read
 
@@ -4229,6 +4259,21 @@ Tries to read $max bytes from the specified $ssl.
  #                      and return code from SSL_read().
 
 Check openssl doc L<http://www.openssl.org/docs/ssl/SSL_read.html|http://www.openssl.org/docs/ssl/SSL_read.html>
+
+=item * read_ex
+
+B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.1, not in LibreSSL
+
+Tries to read $max bytes from the specified $ssl.
+
+ my($got, $rv) = Net::SSLeay::read_ex($ssl, $max);
+ # $ssl - value corresponding to openssl's SSL structure
+ # $max - [optional] max bytes to read (integer) - default is 32768
+ #
+ # returns a list: two-item list consisting of data read (undef on error),
+ #                 and return code from SSL_read_ex().
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_read_ex.html|https://www.openssl.org/docs/manmaster/man3/SSL_read_ex.html>
 
 =item * renegotiate
 
@@ -5013,6 +5058,21 @@ Writes data from the buffer $data into the specified $ssl connection.
  #          <0 - error
 
 Check openssl doc L<http://www.openssl.org/docs/ssl/SSL_write.html|http://www.openssl.org/docs/ssl/SSL_write.html>
+
+=item * write_ex
+
+B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.1, not in LibreSSL
+
+Writes data from the buffer $data into the specified $ssl connection.
+
+ my ($len, $rv) = Net::SSLeay::write_ex($ssl, $data);
+ # $ssl - value corresponding to openssl's SSL structure
+ # $data - data to be written
+ #
+ # returns a list: two-item list consisting of number of bytes written,
+ #                 and return code from SSL_write_ex()
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_write_ex.html|https://www.openssl.org/docs/manmaster/man3/SSL_write_ex.html>
 
 =item * write_partial
 

--- a/t/local/11_read.t
+++ b/t/local/11_read.t
@@ -1,7 +1,8 @@
 #!/usr/bin/perl
 
-# Various SSL read related tests. Currently:
-# - SSL_read, SSL_peek
+# Various SSL read and write related tests:
+# - SSL_read, SSL_peek, SSL_read_ex, SSL_peek_ex,
+# - SSL_write_ex, SSL_pending and SSL_has_pending.
 
 use strict;
 use warnings;
@@ -24,7 +25,7 @@ my $pid;
 alarm(30);
 END { kill 9,$pid if $pid }
 
-my ($server, $server_ctx, $client_ctx, $server_ssl, $client_ssl);
+my $server;
 Net::SSLeay::initialize();
 
 # See that lengths differ for all msgs

--- a/t/local/11_read.t
+++ b/t/local/11_read.t
@@ -1,0 +1,320 @@
+#!/usr/bin/perl
+
+# Various SSL read related tests. Currently:
+# - SSL_read, SSL_peek
+
+use strict;
+use warnings;
+use Test::More;
+use Socket;
+use File::Spec;
+use Net::SSLeay;
+use Config;
+use IO::Socket::INET;
+use Storable;
+
+BEGIN {
+  plan skip_all => "fork() not supported on $^O" unless $Config{d_fork};
+}
+
+my $tests = 53;
+plan tests => $tests;
+
+my $pid;
+alarm(30);
+END { kill 9,$pid if $pid }
+
+my ($server, $server_ctx, $client_ctx, $server_ssl, $client_ssl);
+Net::SSLeay::initialize();
+
+# See that lengths differ for all msgs
+my $msg1 = "1 first message from server";
+my $msg2 = "2 second message from server";
+my $msg3 = "3 third message from server: pad";
+
+my @rounds = qw(openssl openssl-1.1.0 openssl-1.1.1);
+
+sub server
+{
+    # SSL server - just handle connections, send to client and exit
+    my $cert_pem = File::Spec->catfile('t', 'data', 'cert.pem');
+    my $key_pem = File::Spec->catfile('t', 'data', 'key.pem');
+
+    $server = IO::Socket::INET->new( LocalAddr => '127.0.0.1', Listen => 3)
+	or BAIL_OUT("failed to create server socket: $!");
+
+    defined($pid = fork()) or BAIL_OUT("failed to fork: $!");
+    if ($pid == 0) {
+	foreach my $round (@rounds)
+	{
+	    my ($ctx, $ssl, $cl);
+
+	    next if skip_round($round);
+
+	    $cl = $server->accept or BAIL_OUT("accept failed: $!");
+
+	    $ctx = Net::SSLeay::CTX_new();
+	    Net::SSLeay::set_cert_and_key($ctx, $cert_pem, $key_pem);
+
+	    $ssl = Net::SSLeay::new($ctx);
+	    Net::SSLeay::set_fd($ssl, fileno($cl));
+	    Net::SSLeay::accept($ssl);
+
+	    Net::SSLeay::write($ssl, $msg1);
+	    Net::SSLeay::write($ssl, $msg2);
+
+	    my $msg = Net::SSLeay::read($ssl);
+	    Net::SSLeay::write($ssl, $msg);
+	}
+	exit(0);
+    }
+}
+
+sub client
+{
+    my $saddr = $server->sockhost.':'.$server->sockport;
+    foreach my $round (@rounds)
+    {
+	my ($ctx, $ssl, $cl);
+
+	$cl = IO::Socket::INET->new($saddr)
+	    or BAIL_OUT("failed to connect to server: $!");
+
+	$ctx = Net::SSLeay::CTX_new();
+	$ssl = Net::SSLeay::new($ctx);
+
+	my ($reason, $num_tests) = skip_round($round);
+	if ($reason) {
+	  SKIP: {
+	      skip($reason, $num_tests);
+	    }
+	    next;
+	}
+
+	round_openssl($ctx, $ssl, $cl) if $round eq 'openssl';
+	round_openssl_1_1_0($ctx, $ssl, $cl) if $round eq 'openssl-1.1.0';
+	round_openssl_1_1_1($ctx, $ssl, $cl) if $round eq 'openssl-1.1.1';
+
+	Net::SSLeay::shutdown($ssl);
+	Net::SSLeay::free($ssl);
+    }
+    return;
+}
+
+# Returns list for skip() if we should skip this round, false if we
+# shouldn't
+sub skip_round
+{
+    my ($round) = @_;
+
+    return if $round eq 'openssl';
+
+    if ($round eq 'openssl-1.1.0') {
+	if (Net::SSLeay::constant("OPENSSL_VERSION_NUMBER") < 0x1010000f ||
+	    Net::SSLeay::constant("LIBRESSL_VERSION_NUMBER"))
+	{
+	    return ("Need OpenSSL 1.1.0 or later", 6);
+	} else {
+	    return;
+	}
+    }
+
+    if ($round eq 'openssl-1.1.1') {
+	if (Net::SSLeay::constant("OPENSSL_VERSION_NUMBER") < 0x1010100f ||
+	    Net::SSLeay::constant("LIBRESSL_VERSION_NUMBER"))
+	{
+	    return ("Need OpenSSL 1.1.1 or later", 26);
+	} else {
+	    return;
+	}
+    }
+
+    diag("Unknown round: $round");
+    return;
+}
+
+sub round_openssl
+{
+    my ($ctx, $ssl, $cl) = @_;
+
+    my ($peek_msg, $read_msg, $len, $err, $ret);
+
+    # ssl is not connected yet
+    $peek_msg = Net::SSLeay::peek($ssl);
+    is($peek_msg, undef, "scalar: peek returns undef for closed ssl");
+
+    ($peek_msg, $len) = Net::SSLeay::peek($ssl);
+    is($peek_msg, undef, "list: peek returns undef for closed ssl");
+    cmp_ok($len, '<=', 0, 'list: peek returns length <=0 for closed ssl');
+    $err = Net::SSLeay::get_error($ssl, $len);
+    isnt($err, Net::SSLeay::ERROR_WANT_READ(), "peek err $err is not retryable WANT_READ");
+    isnt($err, Net::SSLeay::ERROR_WANT_WRITE(), "peek err $err is not retryable WANT_WRITE");
+
+    $read_msg = Net::SSLeay::read($ssl);
+    is($read_msg, undef, "scalar: read returns undef for closed ssl");
+
+    ($read_msg, $len) = Net::SSLeay::read($ssl);
+    is($read_msg, undef, "list: read returns undef for closed ssl");
+    cmp_ok($len, '<=', 0, 'list: read returns length <=0 for closed ssl');
+    $err = Net::SSLeay::get_error($ssl, $len);
+    isnt($err, Net::SSLeay::ERROR_WANT_READ(), "read err $err is not retryable WANT_READ");
+    isnt($err, Net::SSLeay::ERROR_WANT_WRITE(), "read err $err is not retryable WANT_WRITE");
+
+    $ret = Net::SSLeay::pending($ssl);
+    is($ret, 0, "pending returns 0 for closed ssl");
+
+    Net::SSLeay::set_fd($ssl, $cl);
+    Net::SSLeay::connect($ssl);
+
+    # msg1
+    $ret = Net::SSLeay::pending($ssl);
+    is($ret, 0, "pending returns 0");
+
+    $peek_msg = Net::SSLeay::peek($ssl);
+    is($peek_msg, $msg1, "scalar: peek returns msg1");
+
+    # processing was triggered by peek
+    $ret = Net::SSLeay::pending($ssl);
+    is($ret, length($msg1), "pending returns msg1 length");
+
+    ($peek_msg, $len) = Net::SSLeay::peek($ssl);
+    is($peek_msg, $msg1, "list: peek returns msg1");
+    is($len, length($msg1), "list: peek returns msg1 length");
+
+    $read_msg = Net::SSLeay::read($ssl);
+    is($peek_msg, $read_msg, "scalar: read and peek agree about msg1");
+
+    # msg2
+    $peek_msg = Net::SSLeay::peek($ssl);
+    is($peek_msg, $msg2, "scalar: peek returns msg2");
+
+    ($read_msg, $len) = Net::SSLeay::read($ssl);
+    is($peek_msg, $read_msg, "list: read and peek agree about msg2");
+    is($len, length($msg2), "list: read returns msg2 length");
+
+    # msg3
+    Net::SSLeay::write($ssl, $msg3);
+    is(Net::SSLeay::read($ssl), $msg3, "ping with msg3");
+
+    return;
+}
+
+# Test has_pending and other functionality added in 1.1.0.
+# Revisit: Better tests for has_pending
+sub round_openssl_1_1_0
+{
+    my ($ctx, $ssl, $cl) = @_;
+
+    my ($peek_msg, $read_msg, $len, $err, $ret);
+
+    # ssl is not connected yet
+    $ret = Net::SSLeay::has_pending($ssl);
+    is($ret, 0, "1.1.0: has_pending returns 0 for closed ssl");
+
+    Net::SSLeay::set_fd($ssl, $cl);
+    Net::SSLeay::connect($ssl);
+
+    # msg1
+    $ret = Net::SSLeay::has_pending($ssl);
+    is($ret, 0, "1.1.0: has_pending returns 0");
+
+    # This triggers processing after which we have pending data
+    $peek_msg = Net::SSLeay::peek($ssl);
+    is($peek_msg, $msg1, "1.1.0: peek returns msg1");
+
+    $ret = Net::SSLeay::has_pending($ssl);
+    is($ret, 1, "1.1.0: has_pending returns 1");
+
+    Net::SSLeay::read($ssl); # Read and discard
+
+    $ret = Net::SSLeay::has_pending($ssl);
+    is($ret, 0, "1.1.0: has_pending returns 0 after read");
+
+    # msg2
+    Net::SSLeay::read($ssl); # Read and discard
+
+    # msg3
+    Net::SSLeay::write($ssl, $msg3);
+    is(Net::SSLeay::read($ssl), $msg3, "1.1.0: ping with msg3");
+
+    return;
+}
+
+sub round_openssl_1_1_1
+{
+    my ($ctx, $ssl, $cl) = @_;
+
+    my ($peek_msg, $read_msg, $len, $err, $err_ex, $ret);
+
+    # ssl is not connected yet
+    ($peek_msg, $ret) = Net::SSLeay::peek_ex($ssl);
+    is($peek_msg, undef, "1.1.1: list: peek_ex returns undef message for closed ssl");
+    is($ret, 0, '1.1.1: list: peek_ex returns 0 for closed ssl');
+    $err = Net::SSLeay::get_error($ssl, $ret);
+    isnt($err, Net::SSLeay::ERROR_WANT_READ(), "1.1.1: peek_ex err $err is not retryable WANT_READ");
+    isnt($err, Net::SSLeay::ERROR_WANT_WRITE(), "1.1.1: peek_ex err $err is not retryable WANT_WRITE");
+
+    ($read_msg, $len) = Net::SSLeay::read($ssl);
+    is($read_msg, undef, "1.1.1: list: read returns undef message for closed ssl");
+    cmp_ok($len, '<=', 0, '1.1.1: list: read returns length <=0 for closed ssl');
+    $err = Net::SSLeay::get_error($ssl, $len);
+    isnt($err, Net::SSLeay::ERROR_WANT_READ(), "1.1.1: read err $err is not retryable WANT_READ");
+    isnt($err, Net::SSLeay::ERROR_WANT_WRITE(), "1.1.1: read err $err is not retryable WANT_WRITE");
+
+    ($read_msg, $ret) = Net::SSLeay::read_ex($ssl);
+    is($read_msg, undef, "1.1.1: list: read_ex returns undef message for closed sssl");
+    is($ret, 0, "1.1.1: list: read_ex returns 0 for closed sssl");
+    $err_ex = Net::SSLeay::get_error($ssl, $ret);
+    is ($err_ex, $err, '1.1.1: read_ex and read err are equal');
+
+    Net::SSLeay::set_fd($ssl, $cl);
+    Net::SSLeay::connect($ssl);
+
+    # msg1
+    $ret = Net::SSLeay::has_pending($ssl);
+    is($ret, 0, "1.1.1: has_pending returns 0");
+
+    # This triggers processing after which we have pending data
+    ($peek_msg, $ret) = Net::SSLeay::peek_ex($ssl);
+    is($peek_msg, $msg1, "1.1.1: list: peek_ex returns msg1");
+    is($ret, 1, "1.1.1: list: peek_ex returns 1");
+
+    $len = Net::SSLeay::pending($ssl);
+    is($len, length($msg1), "1.1.1: pending returns msg1 length");
+
+    $ret = Net::SSLeay::has_pending($ssl);
+    is($ret, 1, "1.1.1: has_pending returns 1");
+
+    ($read_msg, $ret) = Net::SSLeay::read_ex($ssl);
+    is($read_msg, $msg1, "1.1.1: list: read_ex returns msg1");
+    is($ret, 1, "1.1.1: list: read_ex returns 1");
+
+    $len = Net::SSLeay::pending($ssl);
+    is($len, 0, "1.1.1: pending returns 0 after read_ex");
+
+    $ret = Net::SSLeay::has_pending($ssl);
+    is($ret, 0, "1.1.1: has_pending returns 0 after read_ex");
+
+    # msg2
+    Net::SSLeay::read($ssl); # Read and discard
+
+    # msg3
+    ($len, $ret) = Net::SSLeay::write_ex($ssl, $msg3);
+    is($len, length($msg3), "1.1.1: write_ex wrote all");
+    is($ret, 1, "1.1.1: write_ex returns 1");
+
+    my ($read_msg1, $ret1) = Net::SSLeay::read_ex($ssl, 5);
+    my ($read_msg2, $ret2) = Net::SSLeay::read_ex($ssl, (length($msg3) - 5));
+
+    is($ret1, 1, '1.1.1: ping with msg3 part1 ok');
+    is($ret2, 1, '1.1.1: ping with msg3 part2 ok');
+    is(length($read_msg1), 5, '1.1.1: ping with msg3, part1 length was 5');
+    is($read_msg1 . $read_msg2, $msg3, "1.1.1: ping with msg3 in two parts");
+
+    return;
+}
+
+server();
+client();
+waitpid $pid, 0;
+exit(0);


### PR DESCRIPTION
Added SSL_peek_ex, SSL_read_ex, SSL_write_ex and SSL_has_pending.

SSL_*_ex require OpenSSL 1.1.1 or later. SSL_has_pending requires
OpenSSL 1.1.0 or later.
    
Updated Net::SSLeay::peek to reflect the recent changes in
Net::SSLeay::read.
    
Added tests for the newly added functions in t/local/11_read.t.
