### PR TITLE
GH-65 Updated Travis CI and Makefile.PL to OpenSSL 1.1.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     - AUTOMATED_TESTING=1
     - RELEASE_TESTING=0
   matrix:
-    - OPENSSL_VERSION=1.1.1-pre9
+    - OPENSSL_VERSION=1.1.1
     - OPENSSL_VERSION=1.1.0i
     - OPENSSL_VERSION=1.0.2p
     - OPENSSL_VERSION=1.0.1u
@@ -36,7 +36,7 @@ matrix:
   - perl: "5.8"
     env: OPENSSL_VERSION=1.1.0i
   - perl: "5.8"
-    env: OPENSSL_VERSION=1.1.1-pre9
+    env: OPENSSL_VERSION=1.1.1
 
 cache:
   directories:

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -332,7 +332,7 @@ EOM
         exit 0; # according http://wiki.cpantesters.org/wiki/CPANAuthorNotes this is best-practice when "missing library"
     }
 
-    if ($major == 1.1 && $minor > 0) {
+    if ($major == 1.1 && $minor > 1) {
         print <<EOM;
 *** That's newer than what this module was tested with
     You should consider checking if there is a newer release of this module


### PR DESCRIPTION
Travis CI now runs tests against OpenSSL 1.1.1 release.

Makefile.PL no longer warns that OpenSSL 1.1.1 is newer
than what Net::SSLeay has been tested with.

Closes #65 