### PR TITLE
Expose SSL_CTX_set_post_handshake_auth

### DIFF
--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -7291,4 +7291,13 @@ SSL_export_keying_material(ssl, outlen, label, p)
 
 #endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x1010100fL && !defined(LIBRESSL_VERSION_NUMBER) /* OpenSSL 1.1.1 */
+
+void
+SSL_CTX_set_post_handshake_auth(s,val)
+    SSL_CTX * s
+    int val
+
+#endif
+
 #define REM_EOF "/* EOF - SSLeay.xs */"


### PR DESCRIPTION
TLS 1.3 removed renegotiation in favor of rekeying and post handshake
authentication (PHA). With PHA, a server can request a client certificate from
a client at some point after the handshake. The feature is commonly used by
HTTP servers for conditional and path specific TLS client auth. For example, a
server can decide to require a cert based on HTTP method and/or path. A client
must announce support for PHA during the handshake.

Apache mod_ssl uses PHA:
https://github.com/apache/httpd/blob/trunk/modules/ssl/ssl_engine_kernel.c#L1207

As of OpenSSL ticket https://github.com/openssl/openssl/issues/6933, TLS 1.3
clients no longer send the PHA TLS extension by default. For on-demand auth,
PHA extension must be enabled with SSL_CTX_set_post_handshake_auth(),
https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_post_handshake_auth.html .

This function is needed for the Apache httpd upstream test suite:
https://bugzilla.redhat.com/show_bug.cgi?id=1630391 .