### PR TITLE
GH-67 Fix export_keying_material.

### DIFF
--- a/Changes
+++ b/Changes
@@ -31,6 +31,12 @@ Revision history for Perl extension Net::SSLeay.
 	  SSL_set_security_level and SSL_get_security_level.
 	  Add new test file 65_security_level.t.
 	  All courtesy of Damyan Ivanov of Debian project.
+	- Fix export_keying_material return value check and context
+	  handling. SSL_export_keying_material use_context is now
+	  correctly set to non-zero value when context is an empty
+	  string. This affects values exported with TLSv1.2 and earlier.
+	  Update documentation in NetSSLeay.pod and add tests
+	  in t/local/45_export.t.
 	- Add RAND_priv_bytes. Add new test file t/local/10_rand.t for
 	  RAND_bytes, RAND_pseudo_bytes, RAND_priv_bytes, RAND_status,
 	  RAND_poll, RAND_file_name and RAND_load_file.

--- a/MANIFEST
+++ b/MANIFEST
@@ -108,6 +108,7 @@ t/local/41_alpn_support.t
 t/local/42_info_callback.t
 t/local/43_misc_functions.t
 t/local/44_sess.t
+t/local/45_exporter.t
 t/local/50_digest.t
 t/local/61_threads-cb-crash.t
 t/local/62_threads-ctx_new-deadlock.t

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -3903,15 +3903,20 @@ Returns internal SSLv3 client_random value.
 
 =item * export_keying_material
 
-Returns a buffer of $req_len bytes of keying material based on the constant string $label using the
-masterkey and client and server random strings as described in 
-draft-ietf-pppext-eap-ttls-01.txt and See rfc2716
-If p is present, it will be concatenated before generating the keying material
-Returns undef on error
+Returns keying material based on the string $label and optional
+$context. Note that with TLSv1.2 and lower, empty context (empty
+string) and undefined context (no value or 'undef') will return
+different values.
 
-    my $out = Net::SSLeay::export_keying_material($ssl, $req_len, $label, $p);
+  my $out = Net::SSLeay::export_keying_material($ssl, $olen, $label, $context);
+  # $ssl - value corresponding to openssl's SSL structure
+  # $olen - number of bytes to return
+  # $label - application specific label
+  # $context - [optional] context - default is undef for no context
+  #
+  # returns: keying material (binary data) or undef on error
 
-
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_export_keying_material.html|https://www.openssl.org/docs/manmaster/man3/SSL_export_keying_material.html>
 
 =item * get_session
 

--- a/t/local/45_exporter.t
+++ b/t/local/45_exporter.t
@@ -1,0 +1,193 @@
+#!/usr/bin/perl
+
+# Various TLS exporter related tests.
+
+use strict;
+use warnings;
+use Test::More;
+use Socket;
+use File::Spec;
+use Net::SSLeay;
+use Config;
+use IO::Socket::INET;
+use Storable;
+
+BEGIN {
+  plan skip_all => "fork() not supported on $^O" unless $Config{d_fork};
+  plan skip_all => "No export_keying_material()" unless defined &Net::SSLeay::export_keying_material;
+
+}
+
+my $tests = 36;
+plan tests => $tests;
+
+my $pid;
+alarm(30);
+END { kill 9,$pid if $pid }
+
+my @rounds = qw(TLSv1 TLSv1.1 TLSv1.2 TLSv1.3);
+my (%server_stats, %client_stats);
+
+my ($server, $server_ctx, $client_ctx, $server_ssl, $client_ssl);
+Net::SSLeay::initialize();
+
+# Helper for client and server
+sub make_ctx
+{
+    my ($round) = @_;
+
+    my $ctx;
+    if ($round =~ /^TLSv1\.3/) {
+	return undef unless eval { Net::SSLeay::TLS1_3_VERSION(); };
+
+	# Use API introduced in OpenSSL 1.1.0
+	$ctx = Net::SSLeay::CTX_new_with_method(Net::SSLeay::TLS_method());
+	Net::SSLeay::CTX_set_min_proto_version($ctx, Net::SSLeay::TLS1_3_VERSION());
+	Net::SSLeay::CTX_set_max_proto_version($ctx, Net::SSLeay::TLS1_3_VERSION());
+    }
+    elsif ($round =~ /^TLSv1\.2/) {
+	return undef unless exists &Net::SSLeay::TLSv1_2_method;
+
+	$ctx = Net::SSLeay::CTX_new_with_method(Net::SSLeay::TLSv1_2_method());
+    }
+    elsif ($round =~ /^TLSv1\.1/) {
+	return undef unless exists &Net::SSLeay::TLSv1_1_method;
+
+	$ctx = Net::SSLeay::CTX_new_with_method(Net::SSLeay::TLSv1_1_method());
+    }
+    else
+    {
+	$ctx = Net::SSLeay::CTX_new_with_method(Net::SSLeay::TLSv1_method());
+    }
+
+    return $ctx;
+}
+
+sub server
+{
+    # SSL server - just handle connections, write, wait for read and repeat
+    my $cert_pem = File::Spec->catfile('t', 'data', 'cert.pem');
+    my $key_pem = File::Spec->catfile('t', 'data', 'key.pem');
+
+    $server = IO::Socket::INET->new( LocalAddr => '127.0.0.1', Listen => 3)
+	or BAIL_OUT("failed to create server socket: $!");
+
+    defined($pid = fork()) or BAIL_OUT("failed to fork: $!");
+    if ($pid == 0) {
+	my ($ctx, $ssl, $ret, $cl);
+
+	foreach my $round (@rounds)
+	{
+	    $cl = $server->accept or BAIL_OUT("accept failed: $!");
+
+	    $ctx = make_ctx($round);
+	    next unless $ctx;
+
+	    Net::SSLeay::set_cert_and_key($ctx, $cert_pem, $key_pem);
+	    $ssl = Net::SSLeay::new($ctx);
+	    Net::SSLeay::set_fd($ssl, fileno($cl));
+	    Net::SSLeay::accept($ssl);
+
+	    Net::SSLeay::write($ssl, $round);
+	    my $msg = Net::SSLeay::read($ssl);
+
+	    Net::SSLeay::shutdown($ssl);
+	    Net::SSLeay::free($ssl);
+	}
+	exit(0);
+    }
+}
+
+sub client {
+    # SSL client - connect to server, read, test and repeat
+
+    my $saddr = $server->sockhost.':'.$server->sockport;
+    my ($ctx, $ssl, $ret, $cl);
+    my $end = "end";
+
+    foreach my $round (@rounds)
+    {
+	$cl = IO::Socket::INET->new($saddr)
+	    or BAIL_OUT("failed to connect to server: $!");
+
+	$ctx = make_ctx($round);
+	unless($ctx) {
+	  SKIP: {
+	      skip("Skipping round $round", 9);
+	    }
+	    next;
+	}
+
+	$ssl = Net::SSLeay::new($ctx);
+	Net::SSLeay::set_fd($ssl, $cl);
+	Net::SSLeay::connect($ssl);
+	my $msg = Net::SSLeay::read($ssl);
+
+	test_export($ssl);
+
+	Net::SSLeay::write($ssl, $msg);
+
+	Net::SSLeay::shutdown($ssl);
+	Net::SSLeay::free($ssl);
+    }
+
+    return;
+}
+
+sub test_export
+{
+    my ($ssl) = @_;
+
+    my ($bytes1_0, $bytes1_1, $bytes1_2, $bytes1_3, $bytes2_0, $bytes2_2_64);
+
+    my $tls_version = Net::SSLeay::get_version($ssl);
+
+    $bytes1_0 = Net::SSLeay::export_keying_material($ssl, 64, 'label 1');
+    $bytes1_1 = Net::SSLeay::export_keying_material($ssl, 64, 'label 1', undef);
+    $bytes1_2 = Net::SSLeay::export_keying_material($ssl, 64, 'label 1', '');
+    $bytes1_3 = Net::SSLeay::export_keying_material($ssl, 64, 'label 1', 'context');
+    $bytes2_0 = Net::SSLeay::export_keying_material($ssl, 128, 'label 1', '');
+    $bytes2_2_64 = substr($bytes2_0, 0, 64);
+
+    is(length($bytes1_0), 64, "$tls_version: Got enough for bytes1_0");
+    is(length($bytes1_1), 64, "$tls_version: Got enough for bytes1_1");
+    is(length($bytes1_2), 64, "$tls_version: Got enough for bytes1_2");
+    is(length($bytes1_3), 64, "$tls_version: Got enough for bytes1_3");
+    is(length($bytes2_0), 128, "$tls_version: Got enough for bytes2_0");
+
+    $bytes1_0 = unpack('H*', $bytes1_0);
+    $bytes1_1 = unpack('H*', $bytes1_1);
+    $bytes1_2 = unpack('H*', $bytes1_2);
+    $bytes1_3 = unpack('H*', $bytes1_3);
+    $bytes2_0 = unpack('H*', $bytes2_0);
+    $bytes2_2_64 = unpack('H*', $bytes2_2_64);
+
+    # Last argument should default to undef
+    is($bytes1_0, $bytes1_1, "$tls_version: context default param is undef");
+
+    # Empty and undefined context are the same for TLSv1.3.
+    # Different length export changes the whole values for TLSv1.3.
+    if ($tls_version eq 'TLSv1.3') {
+	is($bytes1_0, $bytes1_2, "$tls_version: empty and undefined context yields equal values");
+	isnt($bytes2_2_64, $bytes1_2, "$tls_version: export length does matter");
+    } else {
+	isnt($bytes1_0, $bytes1_2, "$tls_version: empty and undefined context yields different values");
+	is($bytes2_2_64, $bytes1_2, "$tls_version: export length does not matter");
+    }
+
+    isnt($bytes1_3, $bytes1_0, "$tls_version: different context");
+
+    return;
+}
+
+# For SSL_export_keying_material_early available with TLSv1.3
+sub test_export_early
+{
+
+    return;
+}
+
+server();
+client();
+waitpid $pid, 0;
+exit(0);


### PR DESCRIPTION
export_keying_material() now handles return value from
SSL_export_keying_material() correctly. Flag use_context is now correctly set
when context is empty as opposed to no context at all.

Update export_keying_material documentation in the pod file.

Add new test file t/local/45_exporter.t for export_keying_material with place
holder for export_keying_material_early.

Closes #67 