### PR TITLE
GH-83 Fix a memory leak in cb_data_advanced_put.

### DIFF
--- a/Changes
+++ b/Changes
@@ -18,6 +18,9 @@ Revision history for Perl extension Net::SSLeay.
 	  Net::SSLeay::accept().
 	  Thanks to Petr Pisar and Sebastian Andrzej Siewior for the
 	  patches (in #RT125218).
+	- Fix a memory leak in cb_data_advanced_put. Fixes
+	  RT#127131. Noticed, investigated and patched by Paul
+	  Evans. Thanks!
 	- Enable OpenSSL 1.1.1-pre9 with Travis CI.
 	- Add SSL_CTX_set_num_tickets, SSL_CTX_get_num_tickets,
 	  SSL_set_num_ticket and SSL_get_num_tickets for controlling

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -522,9 +522,13 @@ int cb_data_advanced_put(void *ptr, const char* data_name, SV* data)
 
     /* first delete already stored value */
     hv_delete(L2HV, data_name, strlen(data_name), G_DISCARD);
-    if (data!=NULL)
+    if (data!=NULL) {
         if (SvOK(data))
             hv_store(L2HV, data_name, strlen(data_name), data, 0);
+        else
+            /* we're not storing data so discard it */
+            SvREFCNT_dec(data);
+    }
 
     return 1;
 }


### PR DESCRIPTION
Fixes [RT#127131](https://rt.cpan.org/Ticket/Display.html?id=127131). Noticed, investigated and patched by Paul Evans.