### PR TITLE
GH-86 Fix set_cert_and_key() return value handling.

### DIFF
--- a/Changes
+++ b/Changes
@@ -62,6 +62,10 @@ Revision history for Perl extension Net::SSLeay.
 	  Howarth. Add SSL_set_post_handshake_auth,
 	  SSL_verify_client_post_handshake and constant
 	  SSL_VERIFY_POST_HANDSHAKE.
+	- Applied a patch to set_cert_and_key() from Damyan Ivanov,
+	  Debian Perl Group. This function now returns errors from
+	  library's error stack only when an underlying routine
+	  fails. Unrelated errors are now skipped. Fixes RT#126988.
 	- Enhance t/local/43_misc_functions.t get_keyblock_size test
 	  to work better with AEAD ciphers.
 	- Add constants SSL_OP_ENABLE_MIDDLEBOX_COMPAT and

--- a/lib/Net/SSLeay.pm
+++ b/lib/Net/SSLeay.pm
@@ -1289,10 +1289,10 @@ sub set_cert_and_key ($$$) {
     my ($ctx, $cert_path, $key_path) = @_;
     my $errs = '';
     # Following will ask password unless private key is not encrypted
-    CTX_use_PrivateKey_file ($ctx, $key_path, &FILETYPE_PEM);
-    $errs .= print_errs("private key `$key_path' ($!)");
-    CTX_use_certificate_file ($ctx, $cert_path, &FILETYPE_PEM);
-    $errs .= print_errs("certificate `$cert_path' ($!)");
+    CTX_use_PrivateKey_file( $ctx, $key_path, &FILETYPE_PEM ) == 1
+        or $errs .= print_errs("private key `$key_path' ($!)");
+    CTX_use_certificate_file ($ctx, $cert_path, &FILETYPE_PEM) == 1
+        or $errs .= print_errs("certificate `$cert_path' ($!)");
     return wantarray ? (undef, $errs) : ($errs eq '');
 }
 


### PR DESCRIPTION
Applied a patch to set_cert_and_key() from Damyan Ivanov, Debian Perl Group.

set_cert_and_key() now returns errors from library's error stack only when a
function it calls returns with failure. Previously any old and unrelated errors
from the error stack were considered when setting up return values.

This fixes RT#126988 and closes #86.
For the full details, see https://rt.cpan.org/Ticket/Display.html?id=126988