### PR TITLE
GH-89 Add support for TLSv1.3 via $Net::SSLeay::ssl_version.

### DIFF
--- a/Changes
+++ b/Changes
@@ -66,6 +66,7 @@ Revision history for Perl extension Net::SSLeay.
 	  Debian Perl Group. This function now returns errors from
 	  library's error stack only when an underlying routine
 	  fails. Unrelated errors are now skipped. Fixes RT#126988.
+	- Add support for TLSv1.3 via $Net::SSLeay::ssl_version.
 	- Enhance t/local/43_misc_functions.t get_keyblock_size test
 	  to work better with AEAD ciphers.
 	- Add constants SSL_OP_ENABLE_MIDDLEBOX_COMPAT and

--- a/lib/Net/SSLeay.pm
+++ b/lib/Net/SSLeay.pm
@@ -34,6 +34,7 @@ $Net::SSLeay::trace = 0;  # Do not change here, use
 # 10 = insist on TLSv1
 # 11 = insist on TLSv1.1
 # 12 = insist on TLSv1.2
+# 13 = insist on TLSv1.3
 # 0 or undef = guess (v23)
 #
 $Net::SSLeay::ssl_version = 0;  # don't change here, use
@@ -1007,6 +1008,21 @@ sub new_x_ctx {
 	    return undef;
 	}
         $ctx = CTX_tlsv1_2_new;
+    }
+    elsif ($ssl_version == 13) {
+	unless (eval { Net::SSLeay::TLS1_3_VERSION(); } ) {
+	    warn "ssl_version has been set to 13, but this version of OpenSSL has been compiled without TLSv1.3 support";
+	    return undef;
+	}
+        $ctx = CTX_new();
+        unless(Net::SSLeay::CTX_set_min_proto_version($ctx, Net::SSLeay::TLS1_3_VERSION())) {
+            warn "CTX_set_min_proto failed for TLSv1.3";
+            return undef;
+        }
+        unless(Net::SSLeay::CTX_set_max_proto_version($ctx, Net::SSLeay::TLS1_3_VERSION())) {
+            warn "CTX_set_max_proto failed for TLSv1.3";
+            return undef;
+        }
     }
     else                       { $ctx = CTX_new(); }
     return $ctx;

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -9321,7 +9321,7 @@ have rather complex interfaces with function pointers and all. In these
 cases you should proceed wit great caution.
 
 This module defaults to using OpenSSL automatic protocol negotiation
-code for automatically detecting the version of the SSL protocol
+code for automatically detecting the version of the SSL/TLS protocol
 that the other end talks. With most web servers this works just
 fine, but once in a while I get complaints from people that the module
 does not work with some web servers. Usually this can be solved
@@ -9330,6 +9330,9 @@ by explicitly setting the protocol version, e.g.
    $Net::SSLeay::ssl_version = 2;  # Insist on SSLv2
    $Net::SSLeay::ssl_version = 3;  # Insist on SSLv3
    $Net::SSLeay::ssl_version = 10; # Insist on TLSv1
+   $Net::SSLeay::ssl_version = 11; # Insist on TLSv1.1
+   $Net::SSLeay::ssl_version = 12; # Insist on TLSv1.2
+   $Net::SSLeay::ssl_version = 13; # Insist on TLSv1.3
 
 Although the autonegotiation is nice to have, the SSL standards
 do not formally specify any such mechanism. Most of the world has


### PR DESCRIPTION
Add support for TLSv1.3 via $Net::SSLeay::ssl_version and update documentation for TLSv1.1 and TLSv1.2 support that was added in release 1.59.

Closes #89.