### PR TITLE
GH-85 Developer release 1.86_06

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Revision history for Perl extension Net::SSLeay.
 
-??????? 2018-??-??
+1.86_06 2018-09-29
 	- Net::SSLeay::read() and SSL_peek() now check SSL_get_error()
 	  for SSL_ERROR_ZERO_RETURN for return values <= 0 to make
 	  Net::SSLeay::read() behave more like underlying OpenSSL
@@ -113,7 +113,7 @@ Revision history for Perl extension Net::SSLeay.
 	  Fixes RT#125273. Thanks to Steffen Ullrich.
 
 1.86_03 2018-07-19
-	- Convert packaging to ExtUtils::MakeMaker
+	- Convert packaging to ExtUtils::MakeMaker. Thanks to mohawk2.
 	- Module::Install is no longer a prerequisite when building
 	  from the reposistory.
 	- Re-apply patch from ETJ permitting configure and build in

--- a/lib/Net/SSLeay.pm
+++ b/lib/Net/SSLeay.pm
@@ -66,7 +66,7 @@ $Net::SSLeay::slowly = 0;
 $Net::SSLeay::random_device = '/dev/urandom';
 $Net::SSLeay::how_random = 512;
 
-$VERSION = '1.86_05'; # Also update $Net::SSLeay::Handle::VERSION
+$VERSION = '1.86_06'; # Also update $Net::SSLeay::Handle::VERSION
 @ISA = qw(Exporter);
 
 #BEWARE:

--- a/lib/Net/SSLeay/Handle.pm
+++ b/lib/Net/SSLeay/Handle.pm
@@ -57,7 +57,7 @@ you need to add to your program is the tie function as in:
 use vars qw(@ISA @EXPORT_OK $VERSION);
 @ISA = qw(Exporter);
 @EXPORT_OK = qw(shutdown);
-$VERSION = '0.86_05';
+$VERSION = '1.86_06';
 
 my $Initialized;       #-- only _initialize() once
 my $Debug = 0;         #-- pretty hokey


### PR DESCRIPTION
Bump version number in SSLeay.pm 1.86_05 to 1.86_06, and also bump
Handle.pm to 1.86_06.

Associate all reported changes since then with version 1.86_06.