### PR TITLE
Enable LibreSSL MAC secret size feature.

### DIFF
--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -5962,7 +5962,7 @@ SSL_get_client_random(s)
 
 #endif
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x2070000fL)
 
 void
 SSL_get_server_random(s)
@@ -5993,7 +5993,7 @@ int
 SSL_get_keyblock_size(s)
      SSL *   s
      CODE:
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x2070000fL)
         const SSL_CIPHER *ssl_cipher;
 	int cipher = NID_undef, digest = NID_undef, mac_secret_size = 0;
 	const EVP_CIPHER *c = NULL;


### PR DESCRIPTION
Get the MAC secret size from the cipher, rather than reaching into
libssl internals.  This effectively takes the OpenSSL 1.1 code path
for LibreSSL 2.7.0 instead of the OpenSSL 1.0 code path.