### PR TITLE
Enable X509_check for LibreSSL.

### DIFF
--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -3102,7 +3102,7 @@ RAND_write_file(file_name)
 
 #define REM40 "Minimal X509 stuff..., this is a bit ugly and should be put in its own modules Net::SSLeay::X509.pm"
 
-#if OPENSSL_VERSION_NUMBER >= 0x1000200fL && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
 
 int
 X509_check_host(X509 *cert, const char *name, unsigned int flags = 0, SV *peername = &PL_sv_undef)


### PR DESCRIPTION
The functions X509_check_host(), X509_check_email(), X509_check_ip(),
and X509_check_ip_asc() are available since LibreSSL 2.5.0.