### PR TITLE
Enable OpenSSL_version for LibreSSL.

### DIFF
--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -1829,7 +1829,7 @@ const char *
 SSLeay_version(type=SSLEAY_VERSION)
         int type
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x2070000fL)
 
 unsigned long
 OpenSSL_version_num()


### PR DESCRIPTION
The functions OpenSSL_version_num() and OpenSSL_version() are
available since LibreSSL 2.7.0.