### PR TITLE
GH-102 Use OPENSSL_cleanse instead of memset.

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,10 @@ Revision history for Perl extension Net::SSLeay.
           RSA_generate_key_ex. This avois deprecated RSA_generate_key
           and allows removing the only Android specific code in
           SSLeay.xs. Fixes RT#127593. Thanks to Rouven Weiler.
+        - OpenSSL_version() and OpenSSL_version_num() are available
+          with LibreSSL 2.7.0 and later. Thanks to Alexander Bluhm.
+        - Use OPENSSL_cleanse() instead of memset(). Fixes
+          RT#116599. Thanks to A. Sinan Unur.
 
 1.86_06 2018-09-29
 	- Net::SSLeay::read() and SSL_peek() now check SSL_get_error()

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -1526,7 +1526,7 @@ int tlsext_ticket_key_cb_invoke(
 		croak("name must be at at most 16 bytes, got %d",(int)svlen);
 	    if (svlen == 0)
 		croak("name should not be empty");
-	    memset(name, 0, 16);
+	    OPENSSL_cleanse(name, 16);
 	    memcpy(name,pname,svlen);
 	    usable_rv_count++;
 	}
@@ -1672,7 +1672,7 @@ time_t ASN1_TIME_timet(ASN1_TIME *asn1t) {
     }
 
     /* extract data and time */
-    memset(&t,0,sizeof(t));
+    OPENSSL_cleanse(&t, sizeof(t));
     if (asn1t->type == V_ASN1_UTCTIME) { /* YY - two digit year */
 	t.tm_year = (p[0]-'0')*10 + (p[1]-'0');
 	if (t.tm_year < 70) t.tm_year += 100;


### PR DESCRIPTION
Use OPENSSL_cleanse() instead of memset(). Fixes RT#116599.
Thanks to A. Sinan Unur.