### PR TITLE
Developer release 1.86_07

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Revision history for Perl extension Net::SSLeay.
 
-??????? 2018-??-??
+1.86_07 2018-12-13
         - Net::SSLeay::RSA_generate_key() now prefers using
           RSA_generate_key_ex. This avois deprecated RSA_generate_key
           and allows removing the only Android specific code in

--- a/lib/Net/SSLeay.pm
+++ b/lib/Net/SSLeay.pm
@@ -66,7 +66,7 @@ $Net::SSLeay::slowly = 0;
 $Net::SSLeay::random_device = '/dev/urandom';
 $Net::SSLeay::how_random = 512;
 
-$VERSION = '1.86_06'; # Also update $Net::SSLeay::Handle::VERSION
+$VERSION = '1.86_07'; # Also update $Net::SSLeay::Handle::VERSION
 @ISA = qw(Exporter);
 
 #BEWARE:

--- a/lib/Net/SSLeay/Handle.pm
+++ b/lib/Net/SSLeay/Handle.pm
@@ -57,7 +57,7 @@ you need to add to your program is the tie function as in:
 use vars qw(@ISA @EXPORT_OK $VERSION);
 @ISA = qw(Exporter);
 @EXPORT_OK = qw(shutdown);
-$VERSION = '1.86_06';
+$VERSION = '1.86_07';
 
 my $Initialized;       #-- only _initialize() once
 my $Debug = 0;         #-- pretty hokey


### PR DESCRIPTION
Bump version number in SSLeay.pm and Handle.pm from 1.86_06 to 1.86_07,
and associate all reported changes since then with version 1.86_07.