### PR TITLE
Declare variable n_a whenever POPpx macro is used

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 Revision history for Perl extension Net::SSLeay.
 
+?? ????-??-??
+	- Declare n_a in ssleay_set_psk_client_callback_invoke and
+	  ssleay_ctx_set_psk_client_callback_invoke to avoid a compilation
+	  error with Perl versions below 5.8.8. Fixes RT#128030. Thanks to
+	  Graham Ollis for the report.
+
 1.86_07 2018-12-13
         - Net::SSLeay::RSA_generate_key() now prefers using
           RSA_generate_key_ex. This avois deprecated RSA_generate_key

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -980,6 +980,8 @@ unsigned int ssleay_set_psk_client_callback_invoke(SSL *ssl, const char *hint,
     BIGNUM *psk_bn = NULL;
     SV * cb_func;
     SV * hintsv;
+    /* this n_a is required for building with old perls: */
+    STRLEN n_a;
 
     PR1("STARTED: ssleay_set_psk_client_callback_invoke\n");
     cb_func = cb_data_advanced_get(ssl, "ssleay_set_psk_client_callback!!func");
@@ -1036,6 +1038,8 @@ unsigned int ssleay_ctx_set_psk_client_callback_invoke(SSL *ssl, const char *hin
     BIGNUM *psk_bn = NULL;
     SV * cb_func;
     SV * hintsv;
+    /* this n_a is required for building with old perls: */
+    STRLEN n_a;
 
     ctx = SSL_get_SSL_CTX(ssl);
 


### PR DESCRIPTION
`ssleay_set_psk_client_callback_invoke` and `ssleay_ctx_set_psk_client_callback_invoke` use the `POPpx` macro, [an API-breaking change to which was made in Perl 5.8.8](https://www.nntp.perl.org/group/perl.perl5.porters/2006/03/msg110764.html). Other functions in SSLeay.xs define a variable `n_a` (of type `STRLEN`) to work around the API incompatibility on older Perls, but no such variable is in scope in these functions. This PR defines `n_a` in these functions to fix compatibility with Perl 5.8.7 and below.

This fixes [RT#128030](https://rt.cpan.org/Public/Bug/Display.html?id=128030). Thanks to Graham Ollis for the report.