### PR TITLE
Always show libssl information in test suite output

### DIFF
--- a/t/local/03_use.t
+++ b/t/local/03_use.t
@@ -7,3 +7,20 @@ use Test::More tests => 1;
 BEGIN {
     use_ok('Net::SSLeay');
 }
+
+diag("");
+diag("Testing Net::SSLeay $Net::SSLeay::VERSION");
+diag("");
+diag("Perl information:");
+diag("  Version:         '" . $]  . "'");
+diag("  Executable path: '" . $^X . "'");
+diag("");
+diag("libssl information:");
+diag("  SSLEAY_VERSION:      '" . Net::SSLeay::SSLeay_version(Net::SSLeay::SSLEAY_VERSION())  . "'");
+diag("  SSLEAY_CFLAGS:       '" . Net::SSLeay::SSLeay_version(Net::SSLeay::SSLEAY_CFLAGS())   . "'");
+diag("  SSLEAY_BUILT_ON:     '" . Net::SSLeay::SSLeay_version(Net::SSLeay::SSLEAY_BUILT_ON()) . "'");
+diag("  SSLEAY_PLATFORM:     '" . Net::SSLeay::SSLeay_version(Net::SSLeay::SSLEAY_PLATFORM()) . "'");
+diag("  SSLEAY_DIR:          '" . Net::SSLeay::SSLeay_version(Net::SSLeay::SSLEAY_DIR())      . "'");
+if (eval "&Net::SSLeay::OPENSSL_ENGINES_DIR") {
+	diag("  OPENSSL_ENGINES_DIR: '" . Net::SSLeay::OpenSSL_version(Net::SSLeay::OPENSSL_ENGINES_DIR()) . "'");
+}

--- a/t/local/04_basic.t
+++ b/t/local/04_basic.t
@@ -16,14 +16,6 @@ SKIP: {
     ok( Net::SSLeay::SSLeay() >= 0x00903100, 'SSLeay (version min 0.9.3)' );
     isnt( Net::SSLeay::SSLeay_version(), '', 'SSLeay (version string)' );
     is( Net::SSLeay::SSLeay_version(),  Net::SSLeay::SSLeay_version(Net::SSLeay::SSLEAY_VERSION()), 'SSLeay_version optional argument' );
-
-    diag( "Version info:" );
-    diag( "Testing Net::SSLeay $Net::SSLeay::VERSION, Perl $], $^X" );
-    diag( "OpenSSL version:  '".Net::SSLeay::SSLeay_version(Net::SSLeay::SSLEAY_VERSION())."'" );
-    diag( "OpenSSL cflags:   '".Net::SSLeay::SSLeay_version(Net::SSLeay::SSLEAY_CFLAGS())."'" );
-    diag( "OpenSSL built on: '".Net::SSLeay::SSLeay_version(Net::SSLeay::SSLEAY_BUILT_ON())."'" );
-    diag( "OpenSSL platform: '".Net::SSLeay::SSLeay_version(Net::SSLeay::SSLEAY_PLATFORM())."'" );
-    diag( "OpenSSL dir:      '".Net::SSLeay::SSLeay_version(Net::SSLeay::SSLEAY_DIR())."'" );
 }
 
 is(Net::SSLeay::hello(), 1, 'hello world');
@@ -39,8 +31,6 @@ if (exists &Net::SSLeay::OpenSSL_version)
     is(Net::SSLeay::SSLeay_version(Net::SSLeay::SSLEAY_BUILT_ON()), Net::SSLeay::OpenSSL_version(Net::SSLeay::OPENSSL_BUILT_ON()), 'OpenSSL_version(OPENSSL_BUILT_ON)');
     is(Net::SSLeay::SSLeay_version(Net::SSLeay::SSLEAY_PLATFORM()), Net::SSLeay::OpenSSL_version(Net::SSLeay::OPENSSL_PLATFORM()), 'OpenSSL_version(OPENSSL_PLATFORM)');
     is(Net::SSLeay::SSLeay_version(Net::SSLeay::SSLEAY_DIR()),      Net::SSLeay::OpenSSL_version(Net::SSLeay::OPENSSL_DIR()),      'OpenSSL_version(OPENSSL_DIR)');
-
-    diag( "OpenSSL engines dir: '".Net::SSLeay::OpenSSL_version(Net::SSLeay::OPENSSL_ENGINES_DIR())."'" );
 }
 else
 {


### PR DESCRIPTION
The Perl and libssl version information printed near the start of the test suite is useful (especially for identifying smoke test failures) - print it as early as possible in the test suite, and don't suppress it when Test::Exception isn't installed.

Also, output the value of `OPENSSL_ENGINES_DIR` as part of the libssl information, if available.

Closes GitHub issue #109.