### PR TITLE
CI: Travis: test against OpenSSL 1.1.1a, 1.1.0j, 1.0.2q

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ env:
     - AUTOMATED_TESTING=1
     - RELEASE_TESTING=0
   matrix:
-    - OPENSSL_VERSION=1.1.1
-    - OPENSSL_VERSION=1.1.0i
-    - OPENSSL_VERSION=1.0.2p
+    - OPENSSL_VERSION=1.1.1a
+    - OPENSSL_VERSION=1.1.0j
+    - OPENSSL_VERSION=1.0.2q
     - OPENSSL_VERSION=1.0.1u
     - OPENSSL_VERSION=1.0.0s
     - OPENSSL_VERSION=0.9.8zh
@@ -34,9 +34,9 @@ env:
 matrix:
   exclude:
   - perl: "5.8"
-    env: OPENSSL_VERSION=1.1.0i
+    env: OPENSSL_VERSION=1.1.0j
   - perl: "5.8"
-    env: OPENSSL_VERSION=1.1.1
+    env: OPENSSL_VERSION=1.1.1a
 
 cache:
   directories:


### PR DESCRIPTION
Now that OpenSSL 1.1.1a, 1.1.0j and 1.0.2q have been released, configure Travis to build and test Net-SSLeay against those versions.

Closes #113.