### PR TITLE
Support for curve selection using (CTX_)set1_groups_list,  (CTX_)set1_curves_list and (CTX_)set_ecdh_auto

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -115,5 +115,6 @@ t/local/62_threads-ctx_new-deadlock.t
 t/local/63_ec_key_generate_key.t
 t/local/64_ticket_sharing.t
 t/local/65_ticket_sharing_2.t
+t/local/66_curves.t
 t/local/kwalitee.t
 typemap

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -5655,7 +5655,7 @@ EC_KEY_generate_key(curve)
 	RETVAL
 
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#ifdef SSL_CTRL_SET_ECDH_AUTO
 
 long
 SSL_CTX_set_ecdh_auto(ctx,onoff)
@@ -5669,7 +5669,7 @@ SSL_set_ecdh_auto(ssl,onoff)
 
 #endif
 
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+#ifdef SSL_CTRL_SET_CURVES_LIST
 
 long
 SSL_CTX_set1_curves_list(ctx,list)
@@ -5683,7 +5683,7 @@ SSL_set1_curves_list(ssl,list)
 
 #endif
 
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+#if SSL_CTRL_SET_GROUPS_LIST
 
 long
 SSL_CTX_set1_groups_list(ctx,list)

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -5655,6 +5655,50 @@ EC_KEY_generate_key(curve)
 	RETVAL
 
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+
+long
+SSL_CTX_set_ecdh_auto(ctx,onoff)
+     SSL_CTX * ctx
+     int onoff
+
+long
+SSL_set_ecdh_auto(ssl,onoff)
+     SSL * ssl
+     int onoff
+
+#endif
+
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+
+long
+SSL_CTX_set1_curves_list(ctx,list)
+     SSL_CTX * ctx
+     char * list
+
+long
+SSL_set1_curves_list(ssl,list)
+     SSL * ssl
+     char * list
+
+#endif
+
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+
+long
+SSL_CTX_set1_groups_list(ctx,list)
+     SSL_CTX * ctx
+     char * list
+
+long
+SSL_set1_groups_list(ssl,list)
+     SSL * ssl
+     char * list
+
+#endif
+
+
+
 #endif
 
 void *

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -8914,7 +8914,7 @@ These functions are only available since OpenSSL 1.1.0.
 These functions set the supported groups in the order of preferences by calling
 SSL_CTX_set1_groups_list or SSL_set1_groups_list respectively.
 This is practically the same as CTX_set1_curves_list and set1_curves_list except
-that als DH groups can be given as supported by TLS 1.3.
+that all DH groups can be given as supported by TLS 1.3.
 These functions are only available since OpenSSL 1.1.1.
 
   Net::SSLeay::CTX_set1_groups_list($ctx,"P-521:P-384:P-256");

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -8912,7 +8912,7 @@ These functions are only available since OpenSSL 1.1.0.
 =item * CTX_set1_groups_list, set1_groups_list
 
 These functions set the supported groups in the order of preferences by calling
-SSL_CTX_set1_groups_list resp. SSL_set1_groups_list.
+SSL_CTX_set1_groups_list or SSL_set1_groups_list respectively.
 This is practically the same as CTX_set1_curves_list and set1_curves_list except
 that als DH groups can be given as supported by TLS 1.3.
 These functions are only available since OpenSSL 1.1.1.

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -8886,6 +8886,40 @@ like X509_set_pubkey.
 This function has no equivalent in OpenSSL but combines multiple OpenSSL
 functions for an easier interface.
 
+=item * CTX_set_ecdh_auto, set_ecdh_auto
+
+These functions enable or disable the automatic curve selection on the server
+side by calling SSL_CTX_set_ecdh_auto resp. SSL_set_ecdh_auto.
+If enabled the highest preference curve is automatically used for ECDH temporary
+keys used during key exchange.
+This function is no longer available for OpenSSL 1.1.0 or higher.
+
+  Net::SSLeay::CTX_set_ecdh_auto($ctx,1);
+  Net::SSLeay::set_ecdh_auto($ssl,1);
+
+=item * CTX_set1_curves_list, set1_curves_list
+
+These functions set the supported curves in the order of preferences by calling
+SSL_CTX_set1_curves_list resp. SSL_set1_curves_list.
+For a TLS client these curves are offered to the server in the supported curves
+extension while on the server side these are used to determine the shared
+curve.
+These functions are only available since OpenSSL 1.1.0.
+
+  Net::SSLeay::CTX_set1_curves_list($ctx,"P-521:P-384:P-256");
+  Net::SSLeay::set1_curves_list($ssl,"P-521:P-384:P-256");
+
+=item * CTX_set1_groups_list, set1_groups_list
+
+These functions set the supported groups in the order of preferences by calling
+SSL_CTX_set1_groups_list resp. SSL_set1_groups_list.
+This is practically the same as CTX_set1_curves_list and set1_curves_list except
+that als DH groups can be given as supported by TLS 1.3.
+These functions are only available since OpenSSL 1.1.1.
+
+  Net::SSLeay::CTX_set1_groups_list($ctx,"P-521:P-384:P-256");
+  Net::SSLeay::set1_groups_list($ssl,"P-521:P-384:P-256");
+
 =back
 
 

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -8889,7 +8889,7 @@ functions for an easier interface.
 =item * CTX_set_ecdh_auto, set_ecdh_auto
 
 These functions enable or disable the automatic curve selection on the server
-side by calling SSL_CTX_set_ecdh_auto resp. SSL_set_ecdh_auto.
+side by calling SSL_CTX_set_ecdh_auto or SSL_set_ecdh_auto respectively.
 If enabled the highest preference curve is automatically used for ECDH temporary
 keys used during key exchange.
 This function is no longer available for OpenSSL 1.1.0 or higher.

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -8899,7 +8899,7 @@ This function is no longer available for OpenSSL 1.1.0 or higher.
 
 =item * CTX_set1_curves_list, set1_curves_list
 
-These functions set the supported curves in the order of preferences by calling
+These functions set the supported curves in the order of preference by calling
 SSL_CTX_set1_curves_list resp. SSL_set1_curves_list.
 For a TLS client these curves are offered to the server in the supported curves
 extension while on the server side these are used to determine the shared
@@ -8911,8 +8911,8 @@ These functions are only available since OpenSSL 1.1.0.
 
 =item * CTX_set1_groups_list, set1_groups_list
 
-These functions set the supported groups in the order of preferences by calling
-SSL_CTX_set1_groups_list or SSL_set1_groups_list respectively.
+These functions set the supported groups in the order of preference by calling
+SSL_CTX_set1_groups_list resp. SSL_set1_groups_list.
 This is practically the same as CTX_set1_curves_list and set1_curves_list except
 that all DH groups can be given as supported by TLS 1.3.
 These functions are only available since OpenSSL 1.1.1.

--- a/t/local/66_curves.t
+++ b/t/local/66_curves.t
@@ -1,0 +1,196 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More;
+use Socket;
+use File::Spec;
+use Net::SSLeay;
+use Config;
+
+# for debugging only
+my $DEBUG = 0;
+my $PCAP = 0;
+require Net::PcapWriter if $PCAP;
+
+my @set_list = (
+    defined &Net::SSLeay::CTX_set1_groups_list ? (\&Net::SSLeay::CTX_set1_groups_list) : (),
+    defined &Net::SSLeay::CTX_set1_curves_list ? (\&Net::SSLeay::CTX_set1_curves_list) : (),
+);
+
+plan skip_all => "no support for CTX_set_curves_list" if ! @set_list;
+my $tests = 4*@set_list;
+plan tests => $tests;
+
+Net::SSLeay::randomize();
+Net::SSLeay::load_error_strings();
+Net::SSLeay::ERR_load_crypto_strings();
+Net::SSLeay::SSLeay_add_ssl_algorithms();
+
+my $SSL_ERROR; # set in _minSSL
+my %TRANSFER;  # set in _handshake
+
+my $client = _minSSL->new();
+my $server = _minSSL->new( cert => [
+    File::Spec->catfile('t','data','cert.pem'),
+    File::Spec->catfile('t','data','key.pem')
+]);
+
+
+my $set_curves;
+while ($set_curves = shift @set_list) {
+    ok(_handshake($client,$server,'P-521:P-384','P-521',1), 'first curve');
+    ok(_handshake($client,$server,'P-521:P-384','P-384',1), 'second curve');
+    ok(_handshake($client,$server,'P-521:P-384','P-256',0), 'wrong curve failed');
+    ok(_handshake($client,$server,'P-521:P-384','P-384:P-521',1), 'both curve');
+}
+
+
+my $i;
+sub _handshake {
+    my ($client,$server,$server_curve,$client_curve,$expect_ok) = @_;
+    $client->state_connect($client_curve);
+    $server->state_accept($server_curve);
+
+    my $pcap = $PCAP && do {
+	my $fname = 'test'.(++$i).'.pcap';
+	open(my $fh,'>',$fname);
+	diag("pcap in $fname");
+	$fh->autoflush;
+	Net::PcapWriter->new($fh)->tcp_conn('1.1.1.1',1000,'2.2.2.2',443);
+    };
+
+    my ($client_done,$server_done,@hs);
+    %TRANSFER = ();
+    for(my $tries = 0; $tries < 10 and !$client_done || !$server_done; $tries++ ) {
+	$client_done ||= $client->handshake || 0;
+	$server_done ||= $server->handshake  || 0;
+
+	my $transfer = 0;
+	if (defined(my $data = $client->bio_read())) {
+	    $pcap && $pcap->write(0,$data);
+	    $DEBUG && warn "client -> server: ".length($data)." bytes\n";
+	    $server->bio_write($data);
+	    push @hs,'>';
+	    $TRANSFER{client} += length($data);
+	    $transfer++;
+	}
+	if (defined(my $data = $server->bio_read())) {
+	    $pcap && $pcap->write(1,$data);
+	    $DEBUG && warn "server -> client: ".length($data)." bytes\n";
+	    $client->bio_write($data);
+	    # assume certificate was sent if length>700
+	    push @hs, length($data) > 700 ? '<[C]':'<';
+	    $TRANSFER{server} += length($data);
+	    $transfer++;
+	}
+	if (!$transfer) {
+	    # no more data to transfer - assume we are done
+	    $client_done = $server_done = 1;
+	}
+    }
+
+    return $expect_ok 
+	? $client_done && $server_done && "@hs" eq "> <[C] > <"
+	: $client_done && $server_done && "@hs" eq "> <"; # alert only
+}
+
+
+{
+    package _minSSL;
+    sub new {
+	my ($class,%args) = @_;
+	my $ctx = Net::SSLeay::CTX_tlsv1_new();
+	Net::SSLeay::CTX_set_options($ctx,Net::SSLeay::OP_ALL());
+	Net::SSLeay::CTX_set_cipher_list($ctx,'ECDHE');
+	my $id = 'client';
+	if ($args{cert}) {
+	    my ($cert,$key) = @{ delete $args{cert} };
+	    Net::SSLeay::set_cert_and_key($ctx, $cert, $key)
+		|| die "failed to use cert file $cert,$key";
+	    $id = 'server';
+	}
+
+	my $self = bless { id => $id, ctx => $ctx }, $class;
+	return $self;
+    }
+
+    sub state_accept {
+	my ($self,$curve) = @_;
+	_reset($self,$curve);
+	Net::SSLeay::set_accept_state($self->{ssl});
+    }
+
+    sub state_connect {
+	my ($self,$curve) = @_;
+	_reset($self,$curve);
+	Net::SSLeay::set_connect_state($self->{ssl});
+    }
+
+    sub handshake {
+	my $self = shift;
+	my $rv = Net::SSLeay::do_handshake($self->{ssl});
+	$rv = _error($self,$rv);
+	return $rv;
+    }
+
+    sub ssl_read {
+	my ($self) = @_;
+	my ($data,$rv) = Net::SSLeay::read($self->{ssl});
+	return _error($self,$rv || -1) if !$rv || $rv<0;
+	return $data;
+    }
+
+    sub bio_write {
+	my ($self,$data) = @_;
+	defined $data and $data ne '' or return;
+	Net::SSLeay::BIO_write($self->{rbio},$data);
+    }
+
+    sub ssl_write {
+	my ($self,$data) = @_;
+	my $rv = Net::SSLeay::write($self->{ssl},$data);
+	return _error($self,$rv || -1) if !$rv || $rv<0;
+	return $rv;
+    }
+
+    sub bio_read {
+	my ($self) = @_;
+	return Net::SSLeay::BIO_read($self->{wbio});
+    }
+
+    sub _ssl { shift->{ssl} }
+    sub _ctx { shift->{ctx} }
+
+    sub _reset {
+	my ($self,$curve) = @_;
+	$set_curves->($self->{ctx},$curve) if $curve;
+	my $ssl = Net::SSLeay::new($self->{ctx});
+	my @bio = (
+	    Net::SSLeay::BIO_new(Net::SSLeay::BIO_s_mem()),
+	    Net::SSLeay::BIO_new(Net::SSLeay::BIO_s_mem()),
+	);
+	Net::SSLeay::set_bio($ssl,$bio[0],$bio[1]);
+	$self->{ssl} = $ssl;
+	$self->{rbio} = $bio[0];
+	$self->{wbio} = $bio[1];
+    }
+
+    sub _error {
+	my ($self,$rv) = @_;
+	if ($rv>0) {
+	    $SSL_ERROR = undef;
+	    return $rv;
+	}
+	my $err = Net::SSLeay::get_error($self->{ssl},$rv);
+	if ($err == Net::SSLeay::ERROR_WANT_READ()
+	    || $err == Net::SSLeay::ERROR_WANT_WRITE()) {
+	    $SSL_ERROR = $err;
+	    $DEBUG && warn "[$self->{id}] rw:$err\n";
+	    return;
+	}
+	$DEBUG && warn "[$self->{id}] ".Net::SSLeay::ERR_error_string($err)."\n";
+	return;
+    }
+
+}

--- a/t/local/66_curves.t
+++ b/t/local/66_curves.t
@@ -105,6 +105,8 @@ sub _handshake {
 	my $ctx = Net::SSLeay::CTX_tlsv1_new();
 	Net::SSLeay::CTX_set_options($ctx,Net::SSLeay::OP_ALL());
 	Net::SSLeay::CTX_set_cipher_list($ctx,'ECDHE');
+	Net::SSLeay::CTX_set_ecdh_auto($ctx,1)
+	    if defined &Net::SSLeay::CTX_set_ecdh_auto;
 	my $id = 'client';
 	if ($args{cert}) {
 	    my ($cert,$key) = @{ delete $args{cert} };

--- a/t/local/66_curves.t
+++ b/t/local/66_curves.t
@@ -90,9 +90,11 @@ sub _handshake {
 	}
     }
 
-    return $expect_ok 
-	? $client_done && $server_done && "@hs" eq "> <[C] > <"
-	: $client_done && $server_done && "@hs" eq "> <"; # alert only
+    my $result = "$client_done - $server_done - @hs";
+    return $result eq '1 - 1 - > <[C] > <' if $expect_ok;
+    return 1 if $result eq '1 - 1 - > <'; # failed connect with OpenSSL >= 1.1.0
+    return 1 if $result =~ qr{^\Q0 - 0 - > < < <}; # OpenSSL 1.0.2, LibreSSL
+    return 0; # unexpected result
 }
 
 


### PR DESCRIPTION
Hi,
this pull request adds support for automatically choosing the best curve using SSL_CTX_set_ecdh_auto in older OpenSSL versions or to explicitly set the supported curves/groups in newer OpenSSL versions. 