### PR TITLE
CI: Travis: test against OpenSSL 1.1.1b, 1.0.2r

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ env:
     - AUTOMATED_TESTING=1
     - RELEASE_TESTING=0
   matrix:
-    - OPENSSL_VERSION=1.1.1a
+    - OPENSSL_VERSION=1.1.1b
     - OPENSSL_VERSION=1.1.0j
-    - OPENSSL_VERSION=1.0.2q
+    - OPENSSL_VERSION=1.0.2r
     - OPENSSL_VERSION=1.0.1u
     - OPENSSL_VERSION=1.0.0t
     - OPENSSL_VERSION=0.9.8zh
@@ -40,7 +40,7 @@ matrix:
   - perl: "5.8"
     env: OPENSSL_VERSION=1.1.0j
   - perl: "5.8"
-    env: OPENSSL_VERSION=1.1.1a
+    env: OPENSSL_VERSION=1.1.1b
   - perl: "5.8"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.8"


### PR DESCRIPTION
Now that OpenSSL 1.1.1b and 1.0.2r have been released, configure Travis to build and test Net-SSLeay against those versions.

Closes #119.