### PR TITLE
Use 127.0.0.1 instead of localhost in test suite

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,6 +22,11 @@ Revision history for Perl extension Net::SSLeay.
 	  that set the minimum OpenSSL security level to 2. Fixes RT#126270
 	  and the remainder of RT#128025. Thanks to Petr Písař and Slaven
 	  Rezić for the downstream reports.
+	- In t/local/06_tcpecho.t and t/local/07_sslecho.t, connect to
+	  127.0.0.1 instead of localhost. This fixes these tests when
+	  executed inside a network sandbox that disrupts the behaviour of
+	  gethostbyname(). Fixes RT#128207. Thanks to Kent Fredric for the
+	  downstream report.
 
 1.86_09 2019-03-12
 	- Add missing files to MANIFEST that prevented tests from passing

--- a/t/local/06_tcpecho.t
+++ b/t/local/06_tcpecho.t
@@ -62,7 +62,7 @@ my $port_trials = 1000;
 
 my @results;
 {
-    my ($got) = Net::SSLeay::tcpcat('localhost', $port, $msg);
+    my ($got) = Net::SSLeay::tcpcat('127.0.0.1', $port, $msg);
     push @results, [ $got eq uc($msg), 'sent and received correctly' ];
 }
 

--- a/t/local/07_sslecho.t
+++ b/t/local/07_sslecho.t
@@ -20,7 +20,7 @@ my $sock;
 my $pid;
 
 my $port = 1212;
-my $dest_ip = gethostbyname('localhost');
+my $dest_ip = "\x7F\0\0\x01";
 my $dest_serv_params  = sockaddr_in($port, $dest_ip);
 my $port_trials = 1000;
 
@@ -118,7 +118,7 @@ Net::SSLeay::library_init();
 
 my @results;
 {
-    my ($got) = Net::SSLeay::sslcat('localhost', $port, $msg);
+    my ($got) = Net::SSLeay::sslcat('127.0.0.1', $port, $msg);
     push @results, [ $got eq uc($msg), 'send and received correctly' ];
 
 }


### PR DESCRIPTION
Use `127.0.0.1` instead of `localhost` in the test suite - this avoids test failures when executing inside a network sandbox because of the failed call to `gethostbyname()`. Known to affect the installation of Gentoo's `dev-perl/Net-SSLeay` package, possibly others.

Fixes [RT#128207](https://rt.cpan.org/Ticket/Display.html?id=128207).