### PR TITLE
CI: Travis: test against LibreSSL 2.9.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
     - OPENSSL_VERSION=1.0.1u
     - OPENSSL_VERSION=1.0.0t
     - OPENSSL_VERSION=0.9.8zh
-    - LIBRESSL_VERSION=2.9.0
+    - LIBRESSL_VERSION=2.9.1
     - LIBRESSL_VERSION=2.8.3
     - LIBRESSL_VERSION=2.7.5
     - LIBRESSL_VERSION=2.2.1
@@ -48,7 +48,7 @@ matrix:
   - perl: "5.8"
     env: LIBRESSL_VERSION=2.8.3
   - perl: "5.8"
-    env: LIBRESSL_VERSION=2.9.0
+    env: LIBRESSL_VERSION=2.9.1
   - perl: "5.10"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.10"
@@ -56,7 +56,7 @@ matrix:
   - perl: "5.10"
     env: LIBRESSL_VERSION=2.8.3
   - perl: "5.10"
-    env: LIBRESSL_VERSION=2.9.0
+    env: LIBRESSL_VERSION=2.9.1
   - perl: "5.12"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.12"
@@ -64,7 +64,7 @@ matrix:
   - perl: "5.12"
     env: LIBRESSL_VERSION=2.8.3
   - perl: "5.12"
-    env: LIBRESSL_VERSION=2.9.0
+    env: LIBRESSL_VERSION=2.9.1
   - perl: "5.14"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.14"
@@ -72,7 +72,7 @@ matrix:
   - perl: "5.14"
     env: LIBRESSL_VERSION=2.8.3
   - perl: "5.14"
-    env: LIBRESSL_VERSION=2.9.0
+    env: LIBRESSL_VERSION=2.9.1
   - perl: "5.16"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.16"
@@ -80,7 +80,7 @@ matrix:
   - perl: "5.16"
     env: LIBRESSL_VERSION=2.8.3
   - perl: "5.16"
-    env: LIBRESSL_VERSION=2.9.0
+    env: LIBRESSL_VERSION=2.9.1
   - perl: "5.18"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.18"
@@ -88,7 +88,7 @@ matrix:
   - perl: "5.18"
     env: LIBRESSL_VERSION=2.8.3
   - perl: "5.18"
-    env: LIBRESSL_VERSION=2.9.0
+    env: LIBRESSL_VERSION=2.9.1
 
 cache:
   directories:


### PR DESCRIPTION
Now that LibreSSL 2.9.1 has been released, configure Travis to build and test Net-SSLeay against it instead of 2.9.0.

Closes #134.