### PR TITLE
Limit default SSL CTX to TLSv1.2 due to hangs

### DIFF
--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -1850,6 +1850,7 @@ SSL_CTX *
 SSL_CTX_new()
      CODE:
      RETVAL = SSL_CTX_new (SSLv23_method());
+     SSL_CTX_set_max_proto_version(RETVAL, TLS1_2_VERSION);
      OUTPUT:
      RETVAL
 
@@ -1881,6 +1882,7 @@ SSL_CTX *
 SSL_CTX_v23_new()
      CODE:
      RETVAL = SSL_CTX_new (SSLv23_method());
+     SSL_CTX_set_max_proto_version(RETVAL, TLS1_2_VERSION);
      OUTPUT:
      RETVAL
 
@@ -1888,6 +1890,7 @@ SSL_CTX *
 SSL_CTX_tlsv1_new()
      CODE:
      RETVAL = SSL_CTX_new (TLSv1_method());
+     SSL_CTX_set_max_proto_version(RETVAL, TLS1_2_VERSION);
      OUTPUT:
      RETVAL
 
@@ -1897,6 +1900,7 @@ SSL_CTX *
 SSL_CTX_tlsv1_1_new()
      CODE:
      RETVAL = SSL_CTX_new (TLSv1_1_method());
+     SSL_CTX_set_max_proto_version(RETVAL, TLS1_2_VERSION);
      OUTPUT:
      RETVAL
 
@@ -1908,6 +1912,7 @@ SSL_CTX *
 SSL_CTX_tlsv1_2_new()
      CODE:
      RETVAL = SSL_CTX_new (TLSv1_2_method());
+     SSL_CTX_set_max_proto_version(RETVAL, TLS1_2_VERSION);
      OUTPUT:
      RETVAL
 
@@ -1918,6 +1923,7 @@ SSL_CTX_new_with_method(meth)
      SSL_METHOD * meth
      CODE:
      RETVAL = SSL_CTX_new (meth);
+     SSL_CTX_set_max_proto_version(RETVAL, TLS1_2_VERSION);
      OUTPUT:
      RETVAL
 


### PR DESCRIPTION
As discussed on
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=914034 currently
using TLSv1.3 in perl ecosystem may result in hangs due to interaction
of SSL_MODE_AUTO_RETRY, TLSv1.3 by default, blocking/non-blocking io
w.r.t. non-application data.

I am in the process of upgrading OpenSSL from 1.1.0 to 1.1.1 in Ubuntu
18.04 LTS (bionic), and to prevent unintentiaonal regression in amount
of experienced hangs, I'd like to prevent automatic/transparent
enablement of TLSv1.3 and instead leave it as opt-in. Thus existing
users will continue to experience the same amount of potential hangs,
and those that opt into using TLSv1.3 can do so with appropriate
testing and handling of SSL_MODE_AUTO_RETRY and/or correct handling of
non-application data.

I understand that this might not be desirable to be merged upstream, but I at least hope to receive upstream code review. To check how (in)sane this patch is and to ensure I didn't miss any obvious places in the API to clamp this down.