### PR TITLE
Remove remaining references to alioth.debian.org

### DIFF
--- a/Changes
+++ b/Changes
@@ -260,71 +260,69 @@ Revision history for Perl extension Net::SSLeay.
           unused version control tags from comments.
 
 1.86_01 2018-07-04
-	[Version control system change]
-	- Chris Novakovic did a full conversion from the old Debian
-	  hosted SVN repository to git.
+	- Net::SSLeay functionality was not changed in this release.
 
-	- Fixes to commit metadata, branches and tags that git-svn
-	  couldn't handle or had no way of handling, were done
-	  manually or semi-automatically afterwards. For instance, the
-	  "git-svn-id:" lines that git-svn appends to commit messages
-	  were kept because Mike used SVN revision numbers in RT
-	  replies to indicate when bugs had been fixed/patches applied
-	  (which may be useful for future reference).
+	- Maintainer changes:
+	  - Mike McCauley, maintainer of Net-SSLeay since November 2005,
+	    has stepped down. Thanks to Mike for his 13 years of
+	    stewardship.
+	  - Net-SSLeay is now maintained by Chris Novakovic, Heikki
+	    Vatiainen and Tuure Vartiainen.
 
-	- All commits were replayed onto a single master branch rather
-	  than having separate dead-end branches for the old SVN
-	  version tags (as this seems more "git-like").
+	- Version control system changes:
+	  - The previous Debian-hosted SVN repository has been imported
+	    into Git. The source code is now maintained on GitHub, at
+	    https://github.com/radiator-software/p5-net-ssleay.
 
-	- New lightweight tags were created for each public release
-	  going back as far as the start of the SVN repository using
-	  data from MetaCPAN (cross-referencing with the changelog
-	  when it wasn't clear when a release was cut from the SVN
-	  repo).
+	  - Fixes to commit metadata, branches and tags that git-svn
+	    couldn't handle or had no way of handling, were done
+	    manually or semi-automatically afterwards. For instance, the
+	    "git-svn-id:" lines that git-svn appends to commit messages
+	    were kept because Mike used SVN revision numbers in RT
+	    replies to indicate when bugs had been fixed/patches applied
+	    (which may be useful for future reference).
 
-	- Florian's and Mike's email addresses were mapped to git
-	  author/committer IDs
+	  - All commits were replayed onto a single master branch rather
+	    than having separate dead-end branches for the old SVN
+	    version tags (as this seems more "git-like").
 
-	[Continuous integration]
-	- Travis CI configuration was added for automated testing on
-	   Linux using 64 bit Ubuntu Trusty. Build matrix dimensions
-	   are: Perl 5.8 - 5.26 x OpenSSL 0.9.8zh - 1.1.0h. Only the
-	   currently latest version for each major Perl and OpenSSL
-	   release is chosen.
+	  - New lightweight tags were created for each public release
+	    going back as far as the start of the SVN repository using
+	    data from MetaCPAN (cross-referencing with the changelog
+	    when it wasn't clear when a release was cut from the SVN
+	    repo).
 
-	- AppVeyor configuration was added for automated testing on
-	  Windows. Build matrix dimensions are: Perl 5.8 - 5.26 x
-	  32bit and 64bit Perl environment x Windows Server 2012R2 and
-	  Windows Server 2016. The Perl environment is Strawberry Perl
-	  and its OpenSSL is used with builds. Only the latest major
-	  versions are used, similarly to Travis CI. Net-SSLeay PPM
-	  and PPD files are made available as artifacts.
+	  - Florian's and Mike's email addresses were mapped to git
+	    author/committer IDs
 
-	- Added README.md with link to master branch build and test
-	  status. Did minor updates to README and other misc files.
+	- Continuous integration:
+	  - Travis CI configuration was added for automated testing on
+	    Linux using 64 bit Ubuntu Trusty. Build matrix dimensions
+	    are: Perl 5.8 - 5.26 x OpenSSL 0.9.8zh - 1.1.0h. Only the
+	    currently latest version for each major Perl and OpenSSL
+	    release is chosen.
 
-	[Release packaging]
-	- Files t/local/43_misc_functions.t and
-	  t/local/65_ticket_sharing_2.t were missing from MANIFEST.
+	  - AppVeyor configuration was added for automated testing on
+	    Windows. Build matrix dimensions are: Perl 5.8 - 5.26 x
+	    32bit and 64bit Perl environment x Windows Server 2012R2 and
+	    Windows Server 2016. The Perl environment is Strawberry Perl
+	    and its OpenSSL is used with builds. Only the latest major
+	    versions are used, similarly to Travis CI. Net-SSLeay PPM
+	    and PPD files are made available as artifacts.
 
-	- Updated inc/ directory with Module::Install 1.19. Updated
-	  Makefile.PL author and resource information. Synced
-	  SSLeay.pm under ext/ with the latest changes under
-	  inc/. Reordered use imports so that META.yml gets correctly
-	  regenerated. More Module::Install related changes will
-	  follow.
+	  - Added README.md with link to master branch build and test
+	    status. Did minor updates to README and other misc files.
 
-	[Repository amd maintainer change]
-	- Net::SSLeay functionality was not changed in this
-	  release. Work was done to switch version contorol systems,
-	  add automated testing, update module packaging and change
-	  the primary maintainer. This coincided with the decommission
-	  of previous code repository service on alioth.debian.org.
+	- Release packaging:
+	  - Files t/local/43_misc_functions.t and
+	    t/local/65_ticket_sharing_2.t were missing from MANIFEST.
 
-	- The module is now primarily maintained by Tuure Vartiainen
-	  and Heikki Vatiainen of Radiator Software. The new
-	  repository location is
-	  https://github.com/radiator-software/p5-net-ssleay
+	  - Updated inc/ directory with Module::Install 1.19. Updated
+	    Makefile.PL author and resource information. Synced
+	    SSLeay.pm under ext/ with the latest changes under
+	    inc/. Reordered use imports so that META.yml gets correctly
+	    regenerated. More Module::Install related changes will
+	    follow.
 
 1.85 2018-03-14
 	Preparations for transferring maintenace to a new maintainer

--- a/Changes
+++ b/Changes
@@ -5,6 +5,8 @@ Revision history for Perl extension Net::SSLeay.
 	  been released under the terms of the Artistic License 2.0 since
 	  version 1.66; references to other licenses have been removed. Fixes
 	  RT#106314. Thanks to Kent Fredric for pointing out the ambiguity.
+	- Replace the HTTPS hosts in the external tests (some of which were
+	  no longer online) with more resilient ones. Closes issue #26.
 
 1.86_10 2019-05-04
 	- Use locally-generated certificate chain in local tests rather

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -33,8 +33,6 @@
 Makefile.old$
 Makefile$
 pm_to_blib$
-svn-commit\.tmp$
-\.svn
 \bblib/
 ^openssl_path$
 ^cover_db

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -9694,48 +9694,45 @@ Solutions:
 
 =back
 
-=head1 BUGS AND SUPPORT
+=head1 BUGS
 
-Please report any bugs or feature requests to
-C<bug-Net-SSLeay at rt.cpan.org>, or through the web interface at
-L<http://rt.cpan.org/Public/Dist/Display.html?Name=Net-SSLeay>.
-I will be notified, and then you'll automatically be notified of progress on
-your bug as I make changes.
+If you encounter a problem with this module that you believe is a bug,
+please report it in one of the following ways:
 
-Subversion access to the latest source code etc can be obtained at
-L<http://alioth.debian.org/projects/net-ssleay>
+=over
 
-The developer mailing list (for people interested in contributing
-to the source code) can be found at
-L<http://lists.alioth.debian.org/mailman/listinfo/net-ssleay-devel>
+=item *
 
-You can find documentation for this module with the C<perldoc> command.
+L<create a new issue|https://github.com/radiator-software/p5-net-ssleay/issues/new>
+under the Net-SSLeay GitHub project at
+L<https://github.com/radiator-software/p5-net-ssleay>;
 
-    perldoc Net::SSLeay
+=item *
 
-You can also look for information at:
+L<open a ticket|https://rt.cpan.org/Ticket/Create.html?Queue=Net-SSLeay> using
+the CPAN RT bug tracker's web interface at
+L<https://rt.cpan.org/Dist/Display.html?Queue=Net-SSLeay>;
 
-=over 4
+=item *
 
-=item * AnnoCPAN: Annotated CPAN documentation
-
-L<http://annocpan.org/dist/Net-SSLeay>
-
-=item * CPAN Ratings
-
-L<http://cpanratings.perl.org/d/Net-SSLeay>
-
-=item * Search CPAN
-
-L<http://search.cpan.org/dist/Net-SSLeay>
+send an email to the CPAN RT bug tracker at
+L<bug-Net-SSLeay@rt.cpan.org|mailto:bug-Net-SSLeay@rt.cpan.org>.
 
 =back
 
-Commercial support for Net::SSLeay may be obtained from
+Please make sure your bug report includes the following information:
 
-   Symlabs (netssleay@symlabs.com)
-   Tel: +351-214.222.630
-   Fax: +351-214.222.637
+=over
+
+=item * the code you are trying to run;
+
+=item * your operating system name and version;
+
+=item * the output of C<perl -V>;
+
+=item * the version of OpenSSL or LibreSSL you are using.
+
+=back
 
 =head1 AUTHOR
 

--- a/lib/Net/SSLeay/Handle.pm
+++ b/lib/Net/SSLeay/Handle.pm
@@ -348,6 +348,46 @@ I was able to associate attributes to globs created by this module
 
 Please see Net-SSLeay-Handle-0.50/Changes file.
 
+=head1 BUGS
+
+If you encounter a problem with this module that you believe is a bug,
+please report it in one of the following ways:
+
+=over
+
+=item *
+
+L<create a new issue|https://github.com/radiator-software/p5-net-ssleay/issues/new>
+under the Net-SSLeay GitHub project at
+L<https://github.com/radiator-software/p5-net-ssleay>;
+
+=item *
+
+L<open a ticket|https://rt.cpan.org/Ticket/Create.html?Queue=Net-SSLeay> using
+the CPAN RT bug tracker's web interface at
+L<https://rt.cpan.org/Dist/Display.html?Queue=Net-SSLeay>;
+
+=item *
+
+send an email to the CPAN RT bug tracker at
+L<bug-Net-SSLeay@rt.cpan.org|mailto:bug-Net-SSLeay@rt.cpan.org>.
+
+=back
+
+Please make sure your bug report includes the following information:
+
+=over
+
+=item * the code you are trying to run;
+
+=item * your operating system name and version;
+
+=item * the output of C<perl -V>;
+
+=item * the version of OpenSSL or LibreSSL you are using.
+
+=back
+
 =head1 AUTHOR
 
 Originally written by Jim Bowlin.

--- a/t/external/08_external.t
+++ b/t/external/08_external.t
@@ -7,10 +7,9 @@ use Test::More;
 use Net::SSLeay;
 
 my @sites = qw(
-        www.cdw.com
-        banking.wellsfargo.com
-        www.open.com.au
-        alioth.debian.org
+	www.google.com
+	www.microsoft.com
+	www.kernel.org
 );
 @sites = split(/:/, $ENV{SSLEAY_SITES}) if exists $ENV{SSLEAY_SITES};
 if (@sites) {

--- a/t/external/15_altnames.t
+++ b/t/external/15_altnames.t
@@ -6,7 +6,9 @@ use Test::More;
 use Net::SSLeay;
 
 my @sites = qw(
-        signin.ebay.de
+	www.google.com
+	www.microsoft.com
+	www.kernel.org
 );
 
 @sites = split(/:/, $ENV{SSLEAY_ALTNAME_SITES})

--- a/t/handle/external/10_destroy.t
+++ b/t/handle/external/10_destroy.t
@@ -5,8 +5,9 @@ use warnings;
 use Test::More;
 
 my @uris = qw(
-        debianforum.de
-        www.open.com.au
+	www.google.com
+	www.microsoft.com
+	www.kernel.org
 );
 @uris = split(/:/, $ENV{SSLEAY_URIS}) if exists $ENV{SSLEAY_URIS};
 if (@uris) {

--- a/t/handle/external/50_external.t
+++ b/t/handle/external/50_external.t
@@ -7,10 +7,9 @@ use Symbol qw(gensym);
 use Net::SSLeay::Handle;
 
 my @sites = qw(
-        www.cdw.com
-        banking.wellsfargo.com
-        www.open.com.au
-        alioth.debian.org
+	www.google.com
+	www.microsoft.com
+	www.kernel.org
 );
 @sites = split(/:/, $ENV{SSLEAY_SITES}) if exists $ENV{SSLEAY_SITES};
 if (@sites) {


### PR DESCRIPTION
There were still some lingering references to `alioth.debian.org`, both in the documentation and tests. These have been removed.

Closes #26 and #140.