### PR TITLE
fix github repository url

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -59,7 +59,7 @@ my %eumm_args = (
     resources => {
       repository => {
         type => 'git',
-        url => 'git@github.com/radiator-software/p5-net-ssleay.git',
+        url => 'git://github.com/radiator-software/p5-net-ssleay.git',
         web => 'https://github.com/radiator-software/p5-net-ssleay',
       },
       bugtracker  => {


### PR DESCRIPTION
The URL field is currently being omitted from META.json because it's not a valid URL.