### PR TITLE
Call cb_data_advanced_drop after instead of before SSL_free and SSL_c…

### DIFF
--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -1925,8 +1925,8 @@ void
 SSL_CTX_free(ctx)
         SSL_CTX * ctx
      CODE:
-        cb_data_advanced_drop(ctx); /* clean callback related data from global hash */
         SSL_CTX_free(ctx);
+        cb_data_advanced_drop(ctx); /* clean callback related data from global hash */
 
 int
 SSL_CTX_add_session(ctx,ses)
@@ -2059,8 +2059,8 @@ void
 SSL_free(s)
         SSL * s
      CODE:
-        cb_data_advanced_drop(s); /* clean callback related data from global hash */
         SSL_free(s);
+        cb_data_advanced_drop(s); /* clean callback related data from global hash */
 
 #if 0 /* this seems to be gone in 0.9.0 */
 void


### PR DESCRIPTION
…tx_free

Some callbacks might be called during *_free but don't find their callback
func and data anymore since it was already removed before by calling
cb_data_advanced_drop. This was at least observed with
ssleay_ssl_ctx_sess_remove_cb_invoke called during SSL_ctx_free.
Since cb_data_advanced_drop just drops the CTX/SSL associated hash, no
harmful side effects are expected by this change.