### PR TITLE
Makefile.PL: exit if OpenSSL executable not found

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,8 @@ Revision history for Perl extension Net::SSLeay.
 	- Fix the repository URL in Makefile.PL (git:// rather than git@),
 	  which was preventing it from being added to META.json. Thanks to
 	  Dan Book.
+	- When building Net-SSLeay, exit if an OpenSSL executable cannot be
+	  found in PATH. Fixes RT#131060. Thanks to Nigel Horne for the report.
 
 1.88 2019-05-10
 	- New stable release incorporating all changes from developer

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -105,7 +105,7 @@ MAKE
 sub ssleay {
     my $prefix = find_openssl_prefix();
     my $exec   = find_openssl_exec($prefix);
-    unless (-x $exec) {
+    unless (defined $exec && -x $exec) {
         print <<EOM;
 *** Could not find OpenSSL
     If it's already installed, please set the OPENSSL_PREFIX environment


### PR DESCRIPTION
When running `Makefile.PL`, explicitly exit with a helpful error message if an OpenSSL executable could not be found (i.e. if `find_openssl_exec()` returns `undef`). This prevents `Makefile.PL` from dying with the unhelpful message

```
Use of uninitialized value $exec in -x at Makefile.PL line 108.
```

if no executable was found.

Fixes [RT#131060](https://rt.cpan.org/Public/Bug/Display.html?id=131060).