### PR TITLE
Support for LibreSSL on Visual C++ Perl

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -167,7 +167,7 @@ EOM
         my @pairs = ();
         # Library names depend on the compiler
         @pairs = (['eay32','ssl32'],['crypto.dll','ssl.dll'],['crypto','ssl']) if $Config{cc} =~ /gcc/;
-        @pairs = (['libeay32','ssleay32'],['libeay32MD','ssleay32MD'],['libeay32MT','ssleay32MT'],['libcrypto','libssl']) if $Config{cc} =~ /cl/;
+        @pairs = (['libeay32','ssleay32'],['libeay32MD','ssleay32MD'],['libeay32MT','ssleay32MT'],['libcrypto','libssl'],['crypto','ssl']) if $Config{cc} =~ /cl/;
         for my $dir (@{$opts->{lib_paths}}) {
           for my $p (@pairs) {
             $found = 1 if ($Config{cc} =~ /gcc/ && -f "$dir/lib$p->[0].a" && -f "$dir/lib$p->[1].a");

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -279,6 +279,10 @@ sub find_openssl_prefix {
     (undef, $dir) = check_no_path()
        and return $dir;
 
+    if(eval { require Alien::LibreSSL; Alien::LibreSSL->install_type('share'); }) {
+        return Alien::LibreSSL->dist_dir;
+    }
+
     return;
 }
 


### PR DESCRIPTION
LibreSSL is much easier to install on Windows with Visual C++ since it supports CMake.  I was able to get Net::SSLeay to install by adding a probe for the bare `crypto` and `ssl` lib files.

I've also included a fallback to using `Alien::LibreSSL` if it is already installed (and is a share install), this saves having to explicitly set `OPENSSL_PREFIX`.

I would tbh prefer to see it automatically fall back on `Alien::LibreSSL` or `Alien::OpenSSL` as a prerequisite if (and ONLY if) the system OpenSSL/LibreSSL cannot be found.  I think it would make Net::SSLeay overall much more reliable.  I submitted a patch here for an older version of Net-SSLeay

https://rt.cpan.org/Public/Bug/Display.html?id=123189

And I can re-work it to work with the new version if there is interest.