### PR TITLE
use `brew --prefix` for OPENSSL_PREFIX if available

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -249,7 +249,7 @@ sub find_openssl_prefix {
     }
 
     # Homebrew (macOS) or LinuxBrew
-    if ($^O ne 'win32' and my $prefix = `brew --prefix openssl 2>@{[File::Spec->devnull]}`) {
+    if ($^O ne 'MSWin32' and my $prefix = `brew --prefix openssl 2>@{[File::Spec->devnull]}`) {
         return $prefix;
     }
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -250,6 +250,7 @@ sub find_openssl_prefix {
 
     # Homebrew (macOS) or LinuxBrew
     if ($^O ne 'MSWin32' and my $prefix = `brew --prefix openssl 2>@{[File::Spec->devnull]}`) {
+        chomp $prefix;
         return $prefix;
     }
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,7 +8,7 @@ use File::Spec;
 use File::Basename ();
 use Symbol qw(gensym);
 
-# Define this to one if you want to link the openssl libraries statically into 
+# Define this to one if you want to link the openssl libraries statically into
 # the Net-SSLeay loadable object on Windows
 my $win_link_statically = 0;
 
@@ -248,10 +248,12 @@ sub find_openssl_prefix {
         return $ENV{OPENSSL_PREFIX};
     }
 
+    # Homebrew (macOS) or LinuxBrew
+    if ($^O ne 'win32' and my $prefix = `brew --prefix openssl 2>&1`) {
+        return $prefix;
+    }
+
     my @guesses = (
-	'/home/linuxbrew/.linuxbrew/opt/openssl/bin/openssl' => '/home/linuxbrew/.linuxbrew/opt/openssl', # LinuxBrew openssl
-	'/usr/local/opt/openssl/bin/openssl' => '/usr/local/opt/openssl', # OSX homebrew openssl
-	'/usr/local/bin/openssl'         => '/usr/local', # OSX homebrew openssl
 	'/opt/local/bin/openssl'         => '/opt/local', # Macports openssl
 	'/usr/bin/openssl'               => '/usr',
 	'/usr/sbin/openssl'              => '/usr',

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -249,7 +249,7 @@ sub find_openssl_prefix {
     }
 
     # Homebrew (macOS) or LinuxBrew
-    if ($^O ne 'win32' and my $prefix = `brew --prefix openssl 2>&1`) {
+    if ($^O ne 'win32' and my $prefix = `brew --prefix openssl 2>@{[File::Spec->devnull]}`) {
         return $prefix;
     }
 


### PR DESCRIPTION
`brew --prefix openssl` is required when one uses a non-default homebrew root path.