### PR TITLE
GH-160 Call Net::SSLeay::shutdown() from SSLeay::sslcat() and t/local/07_sslecho.t

### DIFF
--- a/Changes
+++ b/Changes
@@ -16,6 +16,14 @@ Revision history for Perl extension Net::SSLeay.
 	  the global hash after freeing ctx, not before. This allows callbacks
 	  to be executed during freeing. Thanks to Steffen Ullrich for the
 	  patch.
+	- t/local/07_sslecho.t started failing with OpenSSL
+          1.1.1e. Updated the test file with missing calls to
+          Net::SSLeay::shutdown(). Also added one callin SSLeay.pm
+          sslcat() function. Enabling SSLeay trace level 3 showed
+          'unexpected eof while reading' errors which were added to
+          OpenSSL with commit
+          https://github.com/openssl/openssl/commit/db943f43a60d1b5b1277e4b5317e8f288e7a0a3a
+          This fixes GitHub issue GH-160 reported by Brett T. Warden.
 
 1.88 2019-05-10
 	- New stable release incorporating all changes from developer

--- a/lib/Net/SSLeay.pm
+++ b/lib/Net/SSLeay.pm
@@ -1120,6 +1120,7 @@ sub sslcat { # address, port, message, $crt, $key --> reply / (reply,errs,cert)
     goto cleanup unless $written;
 
     sleep $slowly if $slowly;  # Closing too soon can abort broken servers
+    Net::SSLeay::shutdown($ssl); # Useful starting with OpenSSL 1.1.1e
     CORE::shutdown SSLCAT_S, 1;  # Half close --> No more output, send EOF to server
 
     warn "waiting for reply...\n" if $trace>2;


### PR DESCRIPTION
Fix for GH-160 seems to require SSL_shutdown() calls which were missing from
t/local/07_sslecho.t and Net::SSLeay::sslcat()

These seem to relate to this change in OpenSSL
'Detect EOF while reading in libssl':
https://github.com/openssl/openssl/commit/db943f43a60d1b5b1277e4b5317e8f288e7a0a3a

The newly added OpenSSL error message 'unexpected eof while reading' was seen
before the SSL_shutdown() calls were added.