### PR TITLE
GH-147 Test::Pod 1.41 is now required with the Pod syntax we use.

### DIFF
--- a/Changes
+++ b/Changes
@@ -24,6 +24,9 @@ Revision history for Perl extension Net::SSLeay.
           OpenSSL with commit
           https://github.com/openssl/openssl/commit/db943f43a60d1b5b1277e4b5317e8f288e7a0a3a
           This fixes GitHub issue GH-160 reported by Brett T. Warden.
+        - t/local/01_pod.t now requires Test::Pod 1.41 to work with
+          Pod syntax used with Net::SSleay 1.88 and later. This fixes
+          GitHub issue GH-147 reported by Ulrik Haugen.
 
 1.88 2019-05-10
 	- New stable release incorporating all changes from developer

--- a/t/local/01_pod.t
+++ b/t/local/01_pod.t
@@ -3,8 +3,19 @@
 use strict;
 use warnings;
 use Test::More;
-eval "use Test::Pod 1.00";
-plan skip_all => "Test::Pod 1.00 required for testing POD" if $@;
+
+# Starting with Net::SSLeay 1.88, the Pod syntax uses constructs that
+# do not pass with older Test::Pod versions, such as 1.40 that comes
+# with RHEL 6.
+
+# Here's a snippet from Test::Pod Changes file for release 1.41:
+#
+# Test::Pod no longer complains about the construct L<text|url>, as it is
+# no longer illegal (as of Perl 5.11.3).
+my $min_test_pod = "1.41";
+
+eval "use Test::Pod $min_test_pod";
+plan skip_all => "Test::Pod $min_test_pod required for testing Pod" if $@;
 
 all_pod_files_ok(qw(
             blib/lib/Net/SSLeay.pm


### PR DESCRIPTION
Test t/local/01_pod.t was failing on RHEL 6 because Net::SSLeay 1.88 uses Pod syntax that requires Test::Pod 1.41 or later. RHEL 6 comes with Test::Pod 1.40.

This fixes GH-147.