### PR TITLE
CI: Test against Perl 5.30, OpenSSL 1.1.1e/1.0.2u, LibreSSL 3.0.2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -46,6 +46,7 @@ environment:
   RELEASE_TESTING: 0
   OPENSSL_PREFIX: C:\strawberry\c
   matrix:
+    - perl: 5.30.0.1
     - perl: 5.28.0.1
     - perl: 5.26.2.1
     - perl: 5.24.4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 language: perl
 
 perl:
+  - "5.30"
   - "5.28"
   - "5.26"
   - "5.24"
@@ -24,12 +25,13 @@ env:
     - AUTOMATED_TESTING=1
     - RELEASE_TESTING=0
   matrix:
-    - OPENSSL_VERSION=1.1.1d
+    - OPENSSL_VERSION=1.1.1e
     - OPENSSL_VERSION=1.1.0l
-    - OPENSSL_VERSION=1.0.2t
+    - OPENSSL_VERSION=1.0.2u
     - OPENSSL_VERSION=1.0.1u
     - OPENSSL_VERSION=1.0.0t
     - OPENSSL_VERSION=0.9.8zh
+    - LIBRESSL_VERSION=3.0.2
     - LIBRESSL_VERSION=2.9.2
     - LIBRESSL_VERSION=2.8.3
     - LIBRESSL_VERSION=2.7.5
@@ -40,7 +42,7 @@ matrix:
   - perl: "5.8"
     env: OPENSSL_VERSION=1.1.0l
   - perl: "5.8"
-    env: OPENSSL_VERSION=1.1.1d
+    env: OPENSSL_VERSION=1.1.1e
   - perl: "5.8"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.8"
@@ -49,6 +51,8 @@ matrix:
     env: LIBRESSL_VERSION=2.8.3
   - perl: "5.8"
     env: LIBRESSL_VERSION=2.9.2
+  - perl: "5.8"
+    env: LIBRESSL_VERSION=3.0.2
   - perl: "5.10"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.10"
@@ -57,6 +61,8 @@ matrix:
     env: LIBRESSL_VERSION=2.8.3
   - perl: "5.10"
     env: LIBRESSL_VERSION=2.9.2
+  - perl: "5.10"
+    env: LIBRESSL_VERSION=3.0.2
   - perl: "5.12"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.12"
@@ -65,6 +71,8 @@ matrix:
     env: LIBRESSL_VERSION=2.8.3
   - perl: "5.12"
     env: LIBRESSL_VERSION=2.9.2
+  - perl: "5.12"
+    env: LIBRESSL_VERSION=3.0.2
   - perl: "5.14"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.14"
@@ -73,6 +81,8 @@ matrix:
     env: LIBRESSL_VERSION=2.8.3
   - perl: "5.14"
     env: LIBRESSL_VERSION=2.9.2
+  - perl: "5.14"
+    env: LIBRESSL_VERSION=3.0.2
   - perl: "5.16"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.16"
@@ -81,6 +91,8 @@ matrix:
     env: LIBRESSL_VERSION=2.8.3
   - perl: "5.16"
     env: LIBRESSL_VERSION=2.9.2
+  - perl: "5.16"
+    env: LIBRESSL_VERSION=3.0.2
   - perl: "5.18"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.18"
@@ -89,6 +101,8 @@ matrix:
     env: LIBRESSL_VERSION=2.8.3
   - perl: "5.18"
     env: LIBRESSL_VERSION=2.9.2
+  - perl: "5.18"
+    env: LIBRESSL_VERSION=3.0.2
 
 cache:
   directories:


### PR DESCRIPTION
Configure Travis and AppVeyor to build and test Net-SSLeay against Perl 5.30, the latest bugfix releases of OpenSSL 1.1.1 and 1.0.2, and LibreSSL 3.0.

Closes #163.