### PR TITLE
CI: Travis: Fix download URL for old versions of OpenSSL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,8 +113,23 @@ before_install:
   - mkdir -p openssl_version_cache/build
 
 install:
-  - if [ -n "$OPENSSL_VERSION" ] && [ ! -f openssl_version_cache/src/openssl-$OPENSSL_VERSION.tar.gz ]; then wget -k -P openssl_version_cache/src https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz; fi
-  - if [ -n "$LIBRESSL_VERSION" ] && [ ! -f openssl_version_cache/src/libressl-$LIBRESSL_VERSION.tar.gz ]; then wget -k -P openssl_version_cache/src https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-$LIBRESSL_VERSION.tar.gz; fi
+  - |
+    if [ -n "$OPENSSL_VERSION" ] && [ ! -f openssl_version_cache/src/openssl-$OPENSSL_VERSION.tar.gz ]; then
+      case "$OPENSSL_VERSION" in
+        0.9.8*)
+          SRC_OLD_DIR=0.9.x
+          ;;
+        *)
+          SRC_OLD_DIR="$(echo "$OPENSSL_VERSION" | sed -e 's/[a-z]*$//')"
+          ;;
+      esac
+      wget -P openssl_version_cache/src https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz ||
+        wget -P openssl_version_cache/src https://www.openssl.org/source/old/$SRC_OLD_DIR/openssl-$OPENSSL_VERSION.tar.gz
+    fi
+  - |
+    if [ -n "$LIBRESSL_VERSION" ] && [ ! -f openssl_version_cache/src/libressl-$LIBRESSL_VERSION.tar.gz ]; then
+      wget -P openssl_version_cache/src https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-$LIBRESSL_VERSION.tar.gz
+    fi
 
 script:
   - |


### PR DESCRIPTION
Source archives for versions of OpenSSL that are no longer supported are now routinely moved beneath https://www.openssl.org/source/old/, causing Travis builds to fail for old versions of OpenSSL that we still support. Change the Travis install script to attempt to download from https://www.openssl.org/source/ initially, followed by a suitable subdirectory of https://www.openssl.org/source/old/ if that download fails.

Closes #170.