### PR TITLE
.appveyor.yml: don't silently succeed when make fails

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -110,16 +110,16 @@ install:
 # Run make
 build_script:
   - perl Makefile.PL
-  - perl -MConfig -e "system $Config{make}"
+  - perl -MConfig -e "system($Config{make}) and exit($? >> 8)"
 
 # Run make test
 test_script:
-  - perl -MConfig -e "system $Config{make}, 'test'"
+  - perl -MConfig -e "system($Config{make}, 'test') and exit($? >> 8)"
 
 # Build some artifacts
 after_test:
   - tar zcvf Net-SSLeay.tar.gz blib
-  - perl -MConfig -e "system $Config{make}, 'ppd'"
+  - perl -MConfig -e "system($Config{make}, 'ppd') and exit($? >> 8)"
 
 # Make Net-SSLeay-a.bb.tar.gz available for closer looking
 artifacts:


### PR DESCRIPTION
In the AppVeyor configuration, `make` is invoked via Perl so that the correct program can be used depending on the version of Strawberry Perl in use in the environment (sometimes it's dmake, sometimes it's gmake). Because the return value of `system()` is never checked, the Perl command
always succeeds, and AppVeyor silently (and incorrectly) continues running the job even when the call to make failed.

Explicitly exit from Perl with a return code based on that of the command invoked by `system()`, so failures in make are correctly propagated to AppVeyor's shell and jobs fail when they should.

Closes #176.