### PR TITLE
.appveyor.yml: don't install development dependencies before building

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -104,7 +104,7 @@ install:
   - if /I "%ssleay_need_cpanm%" == "1" cpan App::cpanminus
   - if /I "%ssleay_rename_mingw%" == "1" if exist C:\MinGW move C:\MinGW C:\MinGW-image
   - if /I "%ssleay_rename_mingw%" == "1" if exist C:\MinGW-W64 move C:\MinGW-W64 C:\MinGW-W64-image
-  - cpanm --no-man-pages --installdeps --with-develop --notest .
+  - cpanm --no-man-pages --installdeps --notest .
   - perl -V
 
 # Run make


### PR DESCRIPTION
 Since we don't execute the author tests on AppVeyor, there's no need to install Net-SSLeay's development dependencies in the `install` phase. This should speed up AppVeyor's CI jobs, which are slow compared to Travis's.

Closes #180.