### PR TITLE
CI: Test against OpenSSL 1.1.1g

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
     - AUTOMATED_TESTING=1
     - RELEASE_TESTING=0
   matrix:
-    - OPENSSL_VERSION=1.1.1f
+    - OPENSSL_VERSION=1.1.1g
     - OPENSSL_VERSION=1.1.0l
     - OPENSSL_VERSION=1.0.2u
     - OPENSSL_VERSION=1.0.1u
@@ -42,7 +42,7 @@ matrix:
   - perl: "5.8"
     env: OPENSSL_VERSION=1.1.0l
   - perl: "5.8"
-    env: OPENSSL_VERSION=1.1.1f
+    env: OPENSSL_VERSION=1.1.1g
   - perl: "5.8"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.8"


### PR DESCRIPTION
Configure Travis to build and test Net-SSLeay against OpenSSL 1.1.1g.

Closes #184.