### PR TITLE
Visual C, C89 and Win32 Shining Light precompiled fixes

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -263,6 +263,8 @@ sub find_openssl_prefix {
 	'/usr/sfw/bin/openssl'           => '/usr/sfw', # Open Solaris
 	'C:\OpenSSL\bin\openssl.exe'     => 'C:\OpenSSL',
 	'C:\OpenSSL-Win32\bin\openssl.exe'        => 'C:\OpenSSL-Win32',
+	'C:\Program Files\OpenSSL\bin\openssl.exe'     => 'C:\Program Files\OpenSSL',
+	'C:\Program Files\OpenSSL-Win32\bin\openssl.exe'        => 'C:\Program Files\OpenSSL-Win32',
 	$Config{prefix} . '\bin\openssl.exe'      => $Config{prefix},           # strawberry perl
 	$Config{prefix} . '\..\c\bin\openssl.exe' => $Config{prefix} . '\..\c', # strawberry perl
 	'/sslexe/openssl.exe'            => '/sslroot',  # VMS, openssl.org

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -168,14 +168,14 @@ EOM
         # Library names depend on the compiler
         @pairs = (['eay32','ssl32'],['crypto.dll','ssl.dll'],['crypto','ssl']) if $Config{cc} =~ /gcc/;
         @pairs = (['libeay32','ssleay32'],['libeay32MD','ssleay32MD'],['libeay32MT','ssleay32MT'],['libcrypto','libssl'],['crypto','ssl']) if $Config{cc} =~ /cl/;
-        for my $dir (@{$opts->{lib_paths}}) {
+        FOUND: for my $dir (@{$opts->{lib_paths}}) {
           for my $p (@pairs) {
             $found = 1 if ($Config{cc} =~ /gcc/ && -f "$dir/lib$p->[0].a" && -f "$dir/lib$p->[1].a");
             $found = 1 if ($Config{cc} =~ /cl/ && -f "$dir/$p->[0].lib" && -f "$dir/$p->[1].lib");
             if ($found) {
               $opts->{lib_links} = [$p->[0], $p->[1], 'crypt32']; # Some systems need this system lib crypt32 too
               $opts->{lib_paths} = [$dir];
-              last;
+              last FOUND;
             }
           }
         }

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -132,7 +132,10 @@
  */
 
 /* Prevent warnings about strncpy from Windows compilers */
-#define _CRT_SECURE_NO_DEPRECATE
+
+#ifndef _CRT_SECURE_NO_DEPRECATE
+#  define _CRT_SECURE_NO_DEPRECATE
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Only test fail I get with Perl 5.25 (yes dev) and VC 2013 is

```
t/local/38_priv-key.t .................. ok
t/local/39_pkcs12.t .................... OPENSSL_Uplink(526F6340,08): no OPENSSL
_Applink
t/local/39_pkcs12.t .................... Dubious, test returned 1 (wstat 256, 0x
100)
Failed 19/19 subtests
t/local/40_npn_support.t ............... skipped: fork() not supported on MSWin3
2
t/local/41_alpn_support.t .............. skipped: fork() not supported on MSWin3
```
but OpenSSL's applink is a whole nother complicated story for another PR and I already had a try at
applink in 2015 and it was never merged and I never got around to reviewing my patch on CPAN RT
about applink (a C std lib swap/vtable/abstraction layer OpenSSL invented for Win32 to deal with the
multiple CRTs DLLs in 1 process problem). After this PR a user only needs to install Shining Light 50 MB full size dev MSI and just "click next until it says finish" then no interaction "cpan install Net::SSLeay" and it just works. No env vars, no editing config files.  simcop2387 on IRC gets 1% credit for the loop fix.