### PR TITLE
CI: Test against LibreSSL 3.1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
     - OPENSSL_VERSION=1.0.1u
     - OPENSSL_VERSION=1.0.0t
     - OPENSSL_VERSION=0.9.8zh
+    - LIBRESSL_VERSION=3.1.3
     - LIBRESSL_VERSION=3.0.2
     - LIBRESSL_VERSION=2.9.2
     - LIBRESSL_VERSION=2.8.3
@@ -53,6 +54,8 @@ matrix:
     env: LIBRESSL_VERSION=2.9.2
   - perl: "5.8"
     env: LIBRESSL_VERSION=3.0.2
+  - perl: "5.8"
+    env: LIBRESSL_VERSION=3.1.3
   - perl: "5.10"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.10"
@@ -63,6 +66,8 @@ matrix:
     env: LIBRESSL_VERSION=2.9.2
   - perl: "5.10"
     env: LIBRESSL_VERSION=3.0.2
+  - perl: "5.10"
+    env: LIBRESSL_VERSION=3.1.3
   - perl: "5.12"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.12"
@@ -73,6 +78,8 @@ matrix:
     env: LIBRESSL_VERSION=2.9.2
   - perl: "5.12"
     env: LIBRESSL_VERSION=3.0.2
+  - perl: "5.12"
+    env: LIBRESSL_VERSION=3.1.3
   - perl: "5.14"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.14"
@@ -83,6 +90,8 @@ matrix:
     env: LIBRESSL_VERSION=2.9.2
   - perl: "5.14"
     env: LIBRESSL_VERSION=3.0.2
+  - perl: "5.14"
+    env: LIBRESSL_VERSION=3.1.3
   - perl: "5.16"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.16"
@@ -93,6 +102,8 @@ matrix:
     env: LIBRESSL_VERSION=2.9.2
   - perl: "5.16"
     env: LIBRESSL_VERSION=3.0.2
+  - perl: "5.16"
+    env: LIBRESSL_VERSION=3.1.3
   - perl: "5.18"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.18"
@@ -103,6 +114,8 @@ matrix:
     env: LIBRESSL_VERSION=2.9.2
   - perl: "5.18"
     env: LIBRESSL_VERSION=3.0.2
+  - perl: "5.18"
+    env: LIBRESSL_VERSION=3.1.3
 
 cache:
   directories:


### PR DESCRIPTION
Configure Travis to build and test Net-SSLeay against LibreSSL 3.1.3 with Perl >= 5.20.

Closes #190.