### PR TITLE
Improve AppVeyor build output in case of failure

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -100,12 +100,12 @@ install:
   - echo "Install command %sp_install_cmd%"
   - if not exist "C:\strawberry" %sp_install_cmd%
   - set PATH=C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;%PATH%
+  - perl -V
   - cd %APPVEYOR_BUILD_FOLDER%
   - if /I "%ssleay_need_cpanm%" == "1" cpan App::cpanminus
   - if /I "%ssleay_rename_mingw%" == "1" if exist C:\MinGW move C:\MinGW C:\MinGW-image
   - if /I "%ssleay_rename_mingw%" == "1" if exist C:\MinGW-W64 move C:\MinGW-W64 C:\MinGW-W64-image
-  - cpanm --no-man-pages --installdeps --notest .
-  - perl -V
+  - cpanm --no-man-pages --installdeps --notest . || type C:\Users\appveyor\.cpanm\work\*\build.log && exit /B 1
 
 # Run make
 build_script:


### PR DESCRIPTION
If the AppVeyor CI pipeline fails, make sure more information is included in the job output:

* Print the output of `perl -V` immediately after installing Strawberry Perl, rather than right at the end of the build (currently it will not be printed if the build fails).
* Output the contents of cpanminus's build log if cpanminus fails.

Closes #192.