### PR TITLE
Adding in methods for STACK_OF(X509) and X509_STORE_CTX objects

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 Revision history for Perl extension Net::SSLeay.
 
 1.89_03 ????
+	- Expose the following functions:
+	  - X509_STORE_CTX_get0_cert, X509_STORE_CTX_get1_chain
+	  - sk_X509_pop, sk_X509_shift, sk_X509_unshift,
+	  - sk_X509_insert, sk_X509_delete, sk_x509_value, sk_X509_num
+	  Thanks to Dan Freed.
 	- Correct the minimum OpenSSL version required for the following functions
 	  to be made available (previously they were all declared to be present in
 	  1.1.0-pre1, which caused Net::SSLeay to crash at run-time when built

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -3714,6 +3714,15 @@ X509 *
 X509_STORE_CTX_get_current_cert(x509_store_ctx)
      X509_STORE_CTX * 	x509_store_ctx
 
+int 
+X509_STORE_CTX_get0_cert(x509_store_ctx)
+    X509_STORE_CTX *x509_store_ctx
+
+STACK_OF(X509) * 
+X509_STORE_CTX_get1_chain(x509_store_ctx)
+    X509_STORE_CTX *x509_store_ctx
+
+
 int
 X509_STORE_CTX_get_ex_new_index(argl,argp=NULL,new_func=NULL,dup_func=NULL,free_func=NULL)
      long argl
@@ -6063,6 +6072,39 @@ int
 sk_X509_push(stack, data)
     STACK_OF(X509) * stack
     X509 * data
+
+X509 *
+sk_X509_pop(stack)
+    STACK_OF(X509) * stack    
+
+X509 *
+sk_X509_shift(stack)
+    STACK_OF(X509) * stack    
+
+int 
+sk_X509_unshift(stack,x509)
+    STACK_OF(X509) * stack    
+    X509 * x509
+
+int
+sk_X509_insert(stack,x509,index)
+    STACK_OF(X509) * stack
+    X509 * x509
+    int index
+
+int
+sk_X509_delete(stack,index)
+    STACK_OF(X509) * stack
+    int index
+
+X509 *
+sk_X509_value(stack,index)
+    STACK_OF(X509) * stack
+    int index
+
+int
+sk_X509_num(stack)
+    STACK_OF(X509) * stack
 
 X509 *
 P_X509_INFO_get_x509(info)

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -3714,11 +3714,15 @@ X509 *
 X509_STORE_CTX_get_current_cert(x509_store_ctx)
      X509_STORE_CTX * 	x509_store_ctx
 
-int 
+#if (OPENSSL_VERSION_NUMBER >= 0x10100005L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x2070000fL) /* OpenSSL 1.1.0-pre5, LibreSSL 2.7.0 */
+
+X509 *
 X509_STORE_CTX_get0_cert(x509_store_ctx)
     X509_STORE_CTX *x509_store_ctx
 
-STACK_OF(X509) * 
+#endif
+
+STACK_OF(X509) *
 X509_STORE_CTX_get1_chain(x509_store_ctx)
     X509_STORE_CTX *x509_store_ctx
 
@@ -6075,15 +6079,15 @@ sk_X509_push(stack, data)
 
 X509 *
 sk_X509_pop(stack)
-    STACK_OF(X509) * stack    
+    STACK_OF(X509) * stack
 
 X509 *
 sk_X509_shift(stack)
-    STACK_OF(X509) * stack    
+    STACK_OF(X509) * stack
 
-int 
+int
 sk_X509_unshift(stack,x509)
-    STACK_OF(X509) * stack    
+    STACK_OF(X509) * stack
     X509 * x509
 
 int
@@ -6092,7 +6096,7 @@ sk_X509_insert(stack,x509,index)
     X509 * x509
     int index
 
-int
+X509 *
 sk_X509_delete(stack,index)
     STACK_OF(X509) * stack
     int index

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -6463,84 +6463,90 @@ Pushes an X509 structure onto a STACK_OF(X509) structure.
  # $sk_x509 - value corresponding to openssl's STACK_OF(X509) structure
  # $x509 - value corresponding to openssl's X509 structure
  #
- # returns: 1 if successful, 0 if unsuccessful
+ # returns: total number of elements after the operation, 0 on failure
 
 =item * sk_X509_pop
 
 Pops an single X509 structure from a STACK_OF(X509) structure.
-L<https://www.openssl.org/docs/man1.1.1/man3/sk_TYPE_is_sorted.html>
 
  my $x509 = NetSSLeay::sk_X509_pop($sk_x509)
  # $sk_x509 - value corresponding to openssl's STACK_OF(X509) structure
  #
- # returns: An pointer to an X509 structure or NULL.
+ # returns: a pointer to an X509 structure, undef on failure
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/sk_TYPE_pop.html>
 
 =item * sk_X509_shift
 
 Shifts an single X509 structure onto a STACK_OF(X509) structure.
-L<https://www.openssl.org/docs/man1.1.1/man3/sk_TYPE_is_sorted.html>
 
- my $rv = NetSSLeay::sk_X509_shift($sk_x509,$x509)
+ my $x509 = NetSSLeay::sk_X509_shift($sk_x509, $x509)
  # $sk_x509 - value corresponding to openssl's STACK_OF(X509) structure
  # $x509 - value corresponding to openssl's X509 structure
  #
- # returns: 1 on success, 0 on failure
+ # returns: a pointer to an X509 structure, undef on failure
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/sk_TYPE_shift.html>
 
 =item * sk_X509_unshift
 
 Unshifts an single X509 structure from a STACK_OF(X509) structure.
-L<https://www.openssl.org/docs/man1.1.1/man3/sk_TYPE_is_sorted.html>
 
- my $x509 = NetSSLeay::sk_X509_unshift($sk_x509)
+ my $rv = NetSSLeay::sk_X509_unshift($sk_x509)
  # $sk_x509 - value corresponding to openssl's STACK_OF(X509) structure
  #
- # returns: $x509 - value corresponding to openssl's X509 structure, or null
+ # returns: total number of elements after the operation, 0 on failure
 
-=item * sk_X509_free
-
-Frees the STACK_OF(X509) structure, but not the members contain in the structure.
-L<https://www.openssl.org/docs/man1.1.1/man3/sk_TYPE_is_sorted.html>
-
- my $rv = Net::SSLeay::sk_X509_pop_free($sk_x509);
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/sk_TYPE_unshift.html>
 
 =item * sk_X509_insert
 
-Inserts a single X509 struture into a STACK_OF(X509) at the specified index.
-L<https://www.openssl.org/docs/man1.1.1/man3/sk_TYPE_is_sorted.html>
+Inserts a single X509 structure into a STACK_OF(X509) at the specified index.
 
- my $rv = Net::SSLeay::sk_X509_insert($sk_x509,$x509,index);
+ my $rv = Net::SSLeay::sk_X509_insert($sk_x509, $x509, index);
  # $sk_x509 - value corresponding to openssl's STACK_OF(X509) structure
  # $x509 - value corresponding to openssl's X509 structure
  # index - integer - 0 based index
+ #
+ # returns: total number of elements after the operation, 0 on failure
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/sk_TYPE_insert.html>
 
 =item * sk_X509_delete
 
 Delete a single X509 structure from a STACK_OF(X509) at the specified index.
 
- my $x509 = Net::SSLeay::sk_X509_delete($sk_x509,index);
+ my $x509 = Net::SSLeay::sk_X509_delete($sk_x509, index);
  # $sk_x509 - value corresponding to openssl's STACK_OF(X509) structure
  # index - integer - 0 based index
  #
- # returns : X509 structure
+ # returns: a pointer to an X509 structure, undef on failure
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/sk_TYPE_delete.html>
 
 =item * sk_X509_value
 
 Return a single X509 structure from a STACK_OF(X509) at the specified index.
 
- my $x509 = Net::SSLeay::sk_X509_value($sk_x509,index)
+ my $x509 = Net::SSLeay::sk_X509_value($sk_x509, index)
  # $sk_x509 - value corresponding to openssl's STACK_OF(X509) structure
  # index - integer - 0 based index
  #
- # returns : X509 structure
+ # returns: a pointer to an X509 structure, undef on failure
 
-=item * sk_X509_num 
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/sk_TYPE_value.html>
+
+=item * sk_X509_num
 
 Return the number of X509 elements in a STACK_OF(X509).
 
  my $num = Net::SSLeay::sk_X509_num($sk_x509);
  # $sk_x509 - value corresponding to openssl's STACK_OF(X509) structure
  #
- # returns: integer
+ # returns: the number of elements in the stack, -1 if the passed stack is NULL
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/sk_TYPE_num.html>
+
 =back
 
 =head3 Low level API: X509_REQ_* related functions
@@ -7472,6 +7478,30 @@ Returns the certificate in ctx which caused the error or 0 if no certificate is 
  # returns: value corresponding to openssl's X509 structure (0 on failure)
 
 Check openssl doc L<http://www.openssl.org/docs/crypto/X509_STORE_CTX_get_error.html|http://www.openssl.org/docs/crypto/X509_STORE_CTX_get_error.html>
+
+=item * X509_STORE_CTX_get0_cert
+
+COMPATIBILITY: not available in Net-SSLeay-1.88 and before; requires at least OpenSSL 1.1.0pre6 or LibreSSL 2.7.0
+
+Returns an internal pointer to the certificate being verified by the ctx.
+
+ my $x509 = Net::SSLeay::X509_STORE_CTX_get0_cert($x509_store_ctx);
+ # $x509_store_ctx - value corresponding to openssl's X509_STORE_CTX structure
+ #
+ # returns: value corresponding to openssl's X509 structure
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/X509_STORE_CTX_get0_cert.html|https://www.openssl.org/docs/manmaster/man3/X509_STORE_CTX_get0_cert.html>
+
+=item * X509_STORE_CTX_get1_chain
+
+Returns a returns a complete validate chain if a previous call to X509_verify_cert() is successful.
+
+ my $rv = Net::SSLeay::X509_STORE_CTX_get1_chain($x509_store_ctx);
+ # $x509_store_ctx - value corresponding to openssl's X509_STORE_CTX structure
+ #
+ # returns: value corresponding to openssl's STACK_OF(X509) structure
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/X509_STORE_CTX_get1_chain.html|https://www.openssl.org/docs/manmaster/man3/X509_STORE_CTX_get1_chain.html>
 
 =item * X509_STORE_CTX_get_error
 

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -6465,6 +6465,82 @@ Pushes an X509 structure onto a STACK_OF(X509) structure.
  #
  # returns: 1 if successful, 0 if unsuccessful
 
+=item * sk_X509_pop
+
+Pops an single X509 structure from a STACK_OF(X509) structure.
+L<https://www.openssl.org/docs/man1.1.1/man3/sk_TYPE_is_sorted.html>
+
+ my $x509 = NetSSLeay::sk_X509_pop($sk_x509)
+ # $sk_x509 - value corresponding to openssl's STACK_OF(X509) structure
+ #
+ # returns: An pointer to an X509 structure or NULL.
+
+=item * sk_X509_shift
+
+Shifts an single X509 structure onto a STACK_OF(X509) structure.
+L<https://www.openssl.org/docs/man1.1.1/man3/sk_TYPE_is_sorted.html>
+
+ my $rv = NetSSLeay::sk_X509_shift($sk_x509,$x509)
+ # $sk_x509 - value corresponding to openssl's STACK_OF(X509) structure
+ # $x509 - value corresponding to openssl's X509 structure
+ #
+ # returns: 1 on success, 0 on failure
+
+=item * sk_X509_unshift
+
+Unshifts an single X509 structure from a STACK_OF(X509) structure.
+L<https://www.openssl.org/docs/man1.1.1/man3/sk_TYPE_is_sorted.html>
+
+ my $x509 = NetSSLeay::sk_X509_unshift($sk_x509)
+ # $sk_x509 - value corresponding to openssl's STACK_OF(X509) structure
+ #
+ # returns: $x509 - value corresponding to openssl's X509 structure, or null
+
+=item * sk_X509_free
+
+Frees the STACK_OF(X509) structure, but not the members contain in the structure.
+L<https://www.openssl.org/docs/man1.1.1/man3/sk_TYPE_is_sorted.html>
+
+ my $rv = Net::SSLeay::sk_X509_pop_free($sk_x509);
+
+=item * sk_X509_insert
+
+Inserts a single X509 struture into a STACK_OF(X509) at the specified index.
+L<https://www.openssl.org/docs/man1.1.1/man3/sk_TYPE_is_sorted.html>
+
+ my $rv = Net::SSLeay::sk_X509_insert($sk_x509,$x509,index);
+ # $sk_x509 - value corresponding to openssl's STACK_OF(X509) structure
+ # $x509 - value corresponding to openssl's X509 structure
+ # index - integer - 0 based index
+
+=item * sk_X509_delete
+
+Delete a single X509 structure from a STACK_OF(X509) at the specified index.
+
+ my $x509 = Net::SSLeay::sk_X509_delete($sk_x509,index);
+ # $sk_x509 - value corresponding to openssl's STACK_OF(X509) structure
+ # index - integer - 0 based index
+ #
+ # returns : X509 structure
+
+=item * sk_X509_value
+
+Return a single X509 structure from a STACK_OF(X509) at the specified index.
+
+ my $x509 = Net::SSLeay::sk_X509_value($sk_x509,index)
+ # $sk_x509 - value corresponding to openssl's STACK_OF(X509) structure
+ # index - integer - 0 based index
+ #
+ # returns : X509 structure
+
+=item * sk_X509_num 
+
+Return the number of X509 elements in a STACK_OF(X509).
+
+ my $num = Net::SSLeay::sk_X509_num($sk_x509);
+ # $sk_x509 - value corresponding to openssl's STACK_OF(X509) structure
+ #
+ # returns: integer
 =back
 
 =head3 Low level API: X509_REQ_* related functions

--- a/t/local/32_x509_get_cert_info.t
+++ b/t/local/32_x509_get_cert_info.t
@@ -260,7 +260,10 @@ my $ca_bio = Net::SSLeay::BIO_new_file($ca_filename, 'rb');
 my $ca_x509 = Net::SSLeay::PEM_read_bio_X509($ca_bio);
 Net::SSLeay::X509_STORE_add_cert($x509_store,$ca_x509);
 Net::SSLeay::X509_STORE_CTX_init($ctx, $x509_store, $x509);
-ok (my $x509_from_cert = Net::SSLeay::X509_STORE_CTX_get0_cert($ctx),'Get x509 from store ctx');
+SKIP: {
+    skip('X509_STORE_CTX_get0_cert requires OpenSSL 1.1.0-pre5+ or LibreSSL 2.7.0+', 1) unless defined (&Net::SSLeay::X509_STORE_CTX_get0_cert);
+    ok (my $x509_from_cert = Net::SSLeay::X509_STORE_CTX_get0_cert($ctx),'Get x509 from store ctx');
+};
 Net::SSLeay::X509_verify_cert($ctx);
 ok (my $sk_x509 = Net::SSLeay::X509_STORE_CTX_get1_chain($ctx),'Get STACK_OF(x509) from store ctx');
 my $size;
@@ -287,5 +290,3 @@ ok ($new_size == $size,'size is correct after shift');
 ok (Net::SSLeay::sk_X509_pop($sk_x509),'STACK_OF(X509) pop');
 $new_size = Net::SSLeay::sk_X509_num($sk_x509);
 ok ($new_size == $size-1,'size is correct after pop');
-
-


### PR DESCRIPTION
This exposes a some new methods to access the certificate and the cert chain in a X509_STORE_CTX: 

- X509_STORE_CTX_get0_cert 
- X509_STORE_CTX_get1_chain

This also exposes some methods for manipulation of STACK_OF(X509) objects:

- sk_X509_insert
- sk_X509_num
- sk_X509_delete
- sk_X509_unshift
- sk_X509_shift  
- sk_X509_pop