### PR TITLE
Fix OPENSSL_VERSION_NUMBER guards for functions added in 1.1.0-pre*

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,16 @@
 Revision history for Perl extension Net::SSLeay.
 
+1.89_03 ????
+	- Correct the minimum OpenSSL version required for the following functions
+	  to be made available (previously they were all declared to be present in
+	  1.1.0-pre1, which caused Net::SSLeay to crash at run-time when built
+	  against OpenSSL versions between 1.1.0-pre1 and 1.1.0-pre3):
+	  - CTX_set_max_proto_version (added in 1.1.0-pre2)
+	  - CTX_set_min_proto_version (added in 1.1.0-pre2)
+	  - SESSION_up_ref (added in 1.1.0-pre4)
+	  - set_max_proto_version (added in 1.1.0-pre2)
+	  - set_min_proto_version (added in 1.1.0-pre2)
+
 1.89_02 2020-08-07
 	- Add support for the P_X509_CRL_add_extensions function. Thanks to
 	  Manuel Mausz for the patch.

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -2585,7 +2585,7 @@ d2i_SSL_SESSION(pv)
     OUTPUT:
 	RETVAL
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x2070000fL)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100004L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x2070000fL)
 
 int
 SSL_SESSION_up_ref(sess)
@@ -4822,7 +4822,7 @@ TLS_client_method()
 #endif /* OpenSSL 1.1.0 or LibreSSL 2.2.2 */
 
 
-#if  (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x2060000fL)
+#if  (OPENSSL_VERSION_NUMBER >= 0x10100002L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x2060000fL)
 
 int
 SSL_CTX_set_min_proto_version(ctx, version)
@@ -4844,7 +4844,7 @@ SSL_set_max_proto_version(ssl, version)
      SSL *  ssl
      int    version
 
-#endif /* OpenSSL 1.1.0 or LibreSSL 2.6.0 */
+#endif /* OpenSSL 1.1.0-pre2 or LibreSSL 2.6.0 */
 
 
 #if OPENSSL_VERSION_NUMBER >= 0x1010007fL && !defined(LIBRESSL_VERSION_NUMBER)
@@ -7349,7 +7349,7 @@ OCSP_response_results(rsp,...)
 		if (!idsv) {
 		    /* getall: create new SV with OCSP_CERTID */
 		    unsigned char *pi,*pc;
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L && !defined(LIBRESSL_VERSION_NUMBER)
 		    int len = i2d_OCSP_CERTID(OCSP_SINGLERESP_get0_id(sir),NULL);
 #else
 		    int len = i2d_OCSP_CERTID(sir->certId,NULL);
@@ -7358,7 +7358,7 @@ OCSP_response_results(rsp,...)
 		    Newx(pc,len,unsigned char);
 		    if (!pc) croak("out of memory");
 		    pi = pc;
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L && !defined(LIBRESSL_VERSION_NUMBER)
 		    i2d_OCSP_CERTID(OCSP_SINGLERESP_get0_id(sir),&pi);
 #else
 		    i2d_OCSP_CERTID(sir->certId,&pi);

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -1855,7 +1855,7 @@ Check openssl doc L<http://www.openssl.org/docs/ssl/SSL_SESSION_free.html|http:/
 
 =item * SESSION_up_ref
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.0 or LibreSSL 2.7.0
+B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.0-pre4 or LibreSSL 2.7.0
 
 Increases the reference counter on a SSL_SESSION structure.
 
@@ -2683,7 +2683,7 @@ Check openssl doc L<http://www.openssl.org/docs/ssl/SSL_CTX_new.html|http://www.
 
 =item * CTX_set_min_proto_version, CTX_set_max_proto_version, set_min_proto_version and set_max_proto_version,
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.82 and before; requires at least OpenSSL 1.1.0 or LibreSSL 2.6.0
+B<COMPATIBILITY:> not available in Net-SSLeay-1.82 and before; requires at least OpenSSL 1.1.0-pre2 or LibreSSL 2.6.0
 
 Set the minimum and maximum supported protocol for $ctx or $ssl.
 


### PR DESCRIPTION
Various `OPENSSL_VERSION_NUMBER` guards in SSLeay.xs assume that the following functions were added prior to OpenSSL 1.1.0-pre1, but they were actually added later, causing Net::SSLeay to crash at run-time with "undefined symbol" errors when built against OpenSSL versions 1.1.0-pre1 to 1.1.0-pre3:

* `OCSP_SINGLERESP_get0_id` (added in 1.1.0-pre3)
* `SSL_CTX_set_max_proto_version` (added in 1.1.0-pre2)
* `SSL_CTX_set_min_proto_version` (added in 1.1.0-pre2)
* `SSL_SESSION_up_ref` (added in 1.1.0-pre4)
* `SSL_set_max_proto_version` (added in 1.1.0-pre2)
* `SSL_set_min_proto_version` (added in 1.1.0-pre2)

Fix the guards so these functions are not exported or used internally when they aren't available.

Closes #197.