### PR TITLE
examples/x509_cert_details.pl: version-guard EVP_PKEY_id()

### DIFF
--- a/examples/x509_cert_details.pl
+++ b/examples/x509_cert_details.pl
@@ -173,7 +173,9 @@ sub get_cert_details {
   $rv->{pubkey_alg} = Net::SSLeay::OBJ_obj2txt(Net::SSLeay::P_X509_get_pubkey_alg($x509));
   $rv->{pubkey_size} = Net::SSLeay::EVP_PKEY_size(Net::SSLeay::X509_get_pubkey($x509));
   $rv->{pubkey_bits} = Net::SSLeay::EVP_PKEY_bits(Net::SSLeay::X509_get_pubkey($x509));
-  $rv->{pubkey_id} = Net::SSLeay::EVP_PKEY_id(Net::SSLeay::X509_get_pubkey($x509));
+  if (Net::SSLeay::SSLeay >= 0x1000000f) {
+    $rv->{pubkey_id} = Net::SSLeay::EVP_PKEY_id(Net::SSLeay::X509_get_pubkey($x509));
+  }
 
   return $rv;
 }


### PR DESCRIPTION
`EVP_PKEY_id()` was added to OpenSSL in 1.0.0, but there is no version guard protecting that function call in `examples/x509_cert_details.pl`. Add a guard that checks for OpenSSL version >= 1.0.0 before calling `Net::SSLeay::EVP_PKEY_id()`.

Closes #201.