### PR TITLE
.travis.yml: fix configuration validation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os: linux
 dist: trusty
-sudo: false
 
 language: perl
 
@@ -24,7 +23,7 @@ env:
     - PERL_MM_USE_DEFAULT=1
     - AUTOMATED_TESTING=1
     - RELEASE_TESTING=0
-  matrix:
+  jobs:
     - OPENSSL_VERSION=1.1.1g
     - OPENSSL_VERSION=1.1.0l
     - OPENSSL_VERSION=1.0.2u
@@ -38,7 +37,7 @@ env:
     - LIBRESSL_VERSION=2.7.5
     - LIBRESSL_VERSION=2.2.1
 
-matrix:
+jobs:
   exclude:
   - perl: "5.8"
     env: OPENSSL_VERSION=1.1.0l


### PR DESCRIPTION
Fix the following warnings in the Travis configuration file according to Travis's build config validator:

* `root`: deprecated key `sudo` (it has no effect any more)
* `env`: key matrix is an alias for `jobs`
* `root`: key matrix is an alias for `jobs`

Closes #203.