### PR TITLE
CI: Test against latest stable Perl, OpenSSL and LibreSSL versions

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -46,7 +46,8 @@ environment:
   RELEASE_TESTING: 0
   OPENSSL_PREFIX: C:\strawberry\c
   matrix:
-    - perl: 5.30.0.1
+    - perl: 5.32.0.1
+    - perl: 5.30.3.1
     - perl: 5.28.0.1
     - perl: 5.26.2.1
     - perl: 5.24.4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: trusty
 language: perl
 
 perl:
+  - "5.32"
   - "5.30"
   - "5.28"
   - "5.26"
@@ -24,13 +25,13 @@ env:
     - AUTOMATED_TESTING=1
     - RELEASE_TESTING=0
   jobs:
-    - OPENSSL_VERSION=1.1.1g
+    - OPENSSL_VERSION=1.1.1h
     - OPENSSL_VERSION=1.1.0l
     - OPENSSL_VERSION=1.0.2u
     - OPENSSL_VERSION=1.0.1u
     - OPENSSL_VERSION=1.0.0t
     - OPENSSL_VERSION=0.9.8zh
-    - LIBRESSL_VERSION=3.1.3
+    - LIBRESSL_VERSION=3.1.4
     - LIBRESSL_VERSION=3.0.2
     - LIBRESSL_VERSION=2.9.2
     - LIBRESSL_VERSION=2.8.3
@@ -42,7 +43,7 @@ jobs:
   - perl: "5.8"
     env: OPENSSL_VERSION=1.1.0l
   - perl: "5.8"
-    env: OPENSSL_VERSION=1.1.1g
+    env: OPENSSL_VERSION=1.1.1h
   - perl: "5.8"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.8"
@@ -54,7 +55,7 @@ jobs:
   - perl: "5.8"
     env: LIBRESSL_VERSION=3.0.2
   - perl: "5.8"
-    env: LIBRESSL_VERSION=3.1.3
+    env: LIBRESSL_VERSION=3.1.4
   - perl: "5.10"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.10"
@@ -66,7 +67,7 @@ jobs:
   - perl: "5.10"
     env: LIBRESSL_VERSION=3.0.2
   - perl: "5.10"
-    env: LIBRESSL_VERSION=3.1.3
+    env: LIBRESSL_VERSION=3.1.4
   - perl: "5.12"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.12"
@@ -78,7 +79,7 @@ jobs:
   - perl: "5.12"
     env: LIBRESSL_VERSION=3.0.2
   - perl: "5.12"
-    env: LIBRESSL_VERSION=3.1.3
+    env: LIBRESSL_VERSION=3.1.4
   - perl: "5.14"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.14"
@@ -90,7 +91,7 @@ jobs:
   - perl: "5.14"
     env: LIBRESSL_VERSION=3.0.2
   - perl: "5.14"
-    env: LIBRESSL_VERSION=3.1.3
+    env: LIBRESSL_VERSION=3.1.4
   - perl: "5.16"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.16"
@@ -102,7 +103,7 @@ jobs:
   - perl: "5.16"
     env: LIBRESSL_VERSION=3.0.2
   - perl: "5.16"
-    env: LIBRESSL_VERSION=3.1.3
+    env: LIBRESSL_VERSION=3.1.4
   - perl: "5.18"
     env: LIBRESSL_VERSION=2.2.1
   - perl: "5.18"
@@ -114,7 +115,7 @@ jobs:
   - perl: "5.18"
     env: LIBRESSL_VERSION=3.0.2
   - perl: "5.18"
-    env: LIBRESSL_VERSION=3.1.3
+    env: LIBRESSL_VERSION=3.1.4
 
 cache:
   directories:


### PR DESCRIPTION
Update the CI configurations to build Net-SSLeay against the most recent stable releases of Perl, OpenSSL and LibreSSL:

* Perl: 5.32 (and Strawberry Perl 5.30.0.1 -> 5.30.3.1 on AppVeyor)
* OpenSSL: 1.1.1g -> 1.1.1h
* LibreSSL: 3.1.3 -> 3.1.4

Closes #205.