### PR TITLE
Fix OPENSSL_VERSION_NUMBER guards for SSL_(*_)set1_param

### DIFF
--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -6494,7 +6494,7 @@ OPENSSL_add_all_algorithms_conf()
 
 #endif
 
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+#if OPENSSL_VERSION_NUMBER >= 0x10000003L
 
 int
 SSL_CTX_set1_param(ctx, vpm)

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -2903,6 +2903,8 @@ Check openssl doc L<http://www.openssl.org/docs/ssl/SSL_CTX_sessions.html|http:/
 
 =item * CTX_set1_param
 
+B<COMPATIBILITY:> requires at least OpenSSL 1.0.0-beta3
+
 Applies X509 verification parameters $vpm on $ctx
 
  my $rv = Net::SSLeay::CTX_set1_param($ctx, $vpm);
@@ -4396,6 +4398,8 @@ Query whether a reused session was negotiated during handshake.
 Check openssl doc L<http://www.openssl.org/docs/ssl/SSL_session_reused.html|http://www.openssl.org/docs/ssl/SSL_session_reused.html>
 
 =item * set1_param
+
+B<COMPATIBILITY:> requires at least OpenSSL 1.0.0-beta3
 
 Applies X509 verification parameters $vpm on $ssl
 


### PR DESCRIPTION
The `OPENSSL_VERSION_NUMBER` guard for `SSL_set1_param` and `SSL_CTX_set1_param` in `SSLeay.xs` assumes they were added prior to OpenSSL 1.0.0-beta1, but they were actually added in 1.0.0-beta3, causing Net::SSLeay to crash at run-time with "undefined symbol" errors when built against OpenSSL versions 1.0.0-beta1 and 1.0.0-beta2. Fix the guards so these functions are not exported or used internally when they aren't available.

Closes #207.