### PR TITLE
Fix version guards for SSL_(*_)get0_param, X509_VERIFY_PARAM_*

### DIFF
--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -6596,7 +6596,7 @@ X509_VERIFY_PARAM_lookup(name)
 void
 X509_VERIFY_PARAM_table_cleanup()
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x2070000fL) /* OpenSSL 1.0.2, LibreSSL 2.7.0 */
+#if (OPENSSL_VERSION_NUMBER >= 0x10002001L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x2070000fL) /* OpenSSL 1.0.2-beta1, LibreSSL 2.7.0 */
 
 X509_VERIFY_PARAM *
 SSL_CTX_get0_param(ctx)
@@ -6617,27 +6617,6 @@ X509_VERIFY_PARAM_set1_host(param, name)
     RETVAL = X509_VERIFY_PARAM_set1_host(param, name, namelen);
     OUTPUT:
     RETVAL
-
-int
-X509_VERIFY_PARAM_add1_host(param, name)
-    X509_VERIFY_PARAM *param
-    PREINIT:
-    STRLEN namelen;
-    INPUT:
-    const char * name = SvPV(ST(1), namelen);
-    CODE:
-    RETVAL = X509_VERIFY_PARAM_add1_host(param, name, namelen);
-    OUTPUT:
-    RETVAL
-
-void
-X509_VERIFY_PARAM_set_hostflags(param, flags)
-    X509_VERIFY_PARAM *param
-    unsigned int flags
-
-char *
-X509_VERIFY_PARAM_get0_peername(param)
-    X509_VERIFY_PARAM *param
 
 int
 X509_VERIFY_PARAM_set1_email(param, email)
@@ -6668,7 +6647,32 @@ X509_VERIFY_PARAM_set1_ip_asc(param, ipasc)
     X509_VERIFY_PARAM *param
     const char *ipasc
 
-#endif /* OpenSSL 1.0.2, LibreSSL 2.7.0 */
+#endif /* OpenSSL 1.0.2-beta1, LibreSSL 2.7.0 */
+
+#if (OPENSSL_VERSION_NUMBER >= 0x10002002L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x2070000fL) /* OpenSSL 1.0.2-beta2, LibreSSL 2.7.0 */
+
+int
+X509_VERIFY_PARAM_add1_host(param, name)
+    X509_VERIFY_PARAM *param
+    PREINIT:
+    STRLEN namelen;
+    INPUT:
+    const char * name = SvPV(ST(1), namelen);
+    CODE:
+    RETVAL = X509_VERIFY_PARAM_add1_host(param, name, namelen);
+    OUTPUT:
+    RETVAL
+
+void
+X509_VERIFY_PARAM_set_hostflags(param, flags)
+    X509_VERIFY_PARAM *param
+    unsigned int flags
+
+char *
+X509_VERIFY_PARAM_get0_peername(param)
+    X509_VERIFY_PARAM *param
+
+#endif /* OpenSSL 1.0.2-beta2, LibreSSL 2.7.0 */
 
 void
 X509_policy_tree_free(tree)

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -2325,7 +2325,7 @@ Can be used to set some application defined value/data.
 
 =item * CTX_get0_param
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.82 and before; requires at least OpenSSL 1.0.2
+B<COMPATIBILITY:> not available in Net-SSLeay-1.82 and before; requires at least OpenSSL 1.0.2-beta1 or LibreSSL 2.7.0
 
 Returns the current verification parameters.
 
@@ -3510,7 +3510,7 @@ Check openssl doc L<http://www.openssl.org/docs/ssl/SSL_free.html|http://www.ope
 
 =item * get0_param
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.82 and before; requires at least OpenSSL 1.0.2
+B<COMPATIBILITY:> not available in Net-SSLeay-1.82 and before; requires at least OpenSSL 1.0.2-beta1 or LibreSSL 2.7.0
 
 Returns the current verification parameters.
 
@@ -7648,7 +7648,7 @@ Check openssl doc L<http://www.openssl.org/docs/crypto/X509_VERIFY_PARAM_set_fla
 
 =item * X509_VERIFY_PARAM_add1_host
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.82 and before; requires at least OpenSSL 1.0.2
+B<COMPATIBILITY:> not available in Net-SSLeay-1.82 and before; requires at least OpenSSL 1.0.2-beta2 or LibreSSL 2.7.0
 
 Adds an additional reference identifier that can match the peer's certificate.
 
@@ -7689,7 +7689,7 @@ Frees up the X509_VERIFY_PARAM structure.
 
 =item * X509_VERIFY_PARAM_get0_peername
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.82 and before; requires at least OpenSSL 1.0.2
+B<COMPATIBILITY:> not available in Net-SSLeay-1.82 and before; requires at least OpenSSL 1.0.2-beta2 or LibreSSL 2.7.0
 
 Returns the DNS hostname or subject CommonName from the peer certificate that matched one of the reference identifiers.
 
@@ -7779,7 +7779,7 @@ as the name of X509_VERIFY_PARAM structure $from.
 
 =item * X509_VERIFY_PARAM_set1_email
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.82 and before; requires at least OpenSSL 1.0.2
+B<COMPATIBILITY:> not available in Net-SSLeay-1.82 and before; requires at least OpenSSL 1.0.2-beta1 or LibreSSL 2.7.0
 
 Sets the expected RFC822 email address to email.
 
@@ -7793,7 +7793,7 @@ Check openssl doc L<https://www.openssl.org/docs/crypto/X509_VERIFY_PARAM_set_fl
 
 =item * X509_VERIFY_PARAM_set1_host
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.82 and before; requires at least OpenSSL 1.0.2
+B<COMPATIBILITY:> not available in Net-SSLeay-1.82 and before; requires at least OpenSSL 1.0.2-beta1 or LibreSSL 2.7.0
 
 Sets the expected DNS hostname to name clearing any previously specified host name or names.
 
@@ -7811,7 +7811,7 @@ Check openssl doc L<https://www.openssl.org/docs/crypto/X509_VERIFY_PARAM_set_fl
 
 =item * X509_VERIFY_PARAM_set1_ip
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.82 and before; requires at least OpenSSL 1.0.2
+B<COMPATIBILITY:> not available in Net-SSLeay-1.82 and before; requires at least OpenSSL 1.0.2-beta1 or LibreSSL 2.7.0
 
 Sets the expected IP address to ip.
 
@@ -7825,7 +7825,7 @@ Check openssl doc L<https://www.openssl.org/docs/crypto/X509_VERIFY_PARAM_set_fl
 
 =item * X509_VERIFY_PARAM_set1_ip_asc
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.82 and before; requires at least OpenSSL 1.0.2
+B<COMPATIBILITY:> not available in Net-SSLeay-1.82 and before; requires at least OpenSSL 1.0.2-beta1 or LibreSSL 2.7.0
 
 Sets the expected IP address to ipasc.
 
@@ -7873,6 +7873,8 @@ Sets the maximum verification depth to depth. That is the maximum number of untr
 Check openssl doc L<http://www.openssl.org/docs/crypto/X509_VERIFY_PARAM_set_flags.html|http://www.openssl.org/docs/crypto/X509_VERIFY_PARAM_set_flags.html>
 
 =item * X509_VERIFY_PARAM_set_hostflags
+
+B<COMPATIBILITY:> not available in Net-SSLeay-1.82 and before; requires at least OpenSSL 1.0.2-beta2 or LibreSSL 2.7.0
 
  Net::SSLeay::X509_VERIFY_PARAM_set_hostflags($param, $flags);
  # $param - value corresponding to openssl's X509_VERIFY_PARAM structure


### PR DESCRIPTION
The `OPENSSL_VERSION_NUMBER` guard for the following OpenSSL functions assumes they were added prior to OpenSSL 1.0.2-beta1, but they were actually added in the following beta versions:

1.0.2-beta1:
* `SSL_CTX_get0_param`
* `SSL_get0_param`
* `X509_VERIFY_PARAM_set1_host`
* `X509_VERIFY_PARAM_set1_email`
* `X509_VERIFY_PARAM_set1_ip`
* `X509_VERIFY_PARAM_set1_ip_asc`

1.0.2-beta2:
* `X509_VERIFY_PARAM_add1_host`
* `X509_VERIFY_PARAM_set_hostflags`
* `X509_VERIFY_PARAM_get0_peername`

The latter three cause Net::SSLeay to crash at run-time with "undefined symbol" errors when built against OpenSSL 1.0.2-beta1. Place the lists of functions above behind separate guards so they are not exported when they aren't available, and clarify which OpenSSL/LibreSSL versions they require in the documentation.

Closes #209.