### PR TITLE
Don't version-guard SSL_get_SSL_CTX and SSL_ctrl

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,6 +15,9 @@ Revision history for Perl extension Net::SSLeay.
 	  - SESSION_up_ref (added in 1.1.0-pre4)
 	  - set_max_proto_version (added in 1.1.0-pre2)
 	  - set_min_proto_version (added in 1.1.0-pre2)
+    - Correct the minimum OpenSSL version required for get_SSL_CTX and SSL_ctrl
+      to be made available (previously they were declared to be present from
+      0.9.8f onwards, when in reality they are available in all 0.9.8 versions).
 
 1.89_02 2020-08-07
 	- Add support for the P_X509_CRL_add_extensions function. Thanks to

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -2614,15 +2614,16 @@ X509 *
 SSL_get_certificate(s)
      SSL *              s
 
-#if OPENSSL_VERSION_NUMBER >= 0x0090806fL
-#define REM18 "NOTE: requires 0.9.8f+"
-
 SSL_CTX *
 SSL_get_SSL_CTX(s)
      SSL *              s
 
+#if OPENSSL_VERSION_NUMBER >= 0x0090806fL
+
 SSL_CTX *
 SSL_set_SSL_CTX(SSL *ssl, SSL_CTX* ctx)
+
+#endif
 
 long
 SSL_ctrl(ssl,cmd,larg,parg)
@@ -2630,8 +2631,6 @@ SSL_ctrl(ssl,cmd,larg,parg)
 	 int cmd
 	 long larg
 	 char * parg
-
-#endif
 
 long
 SSL_CTX_ctrl(ctx,cmd,larg,parg)

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -3534,6 +3534,8 @@ Check openssl doc L<http://www.openssl.org/docs/ssl/SSL_get_SSL_CTX.html|http://
 
 =item * set_SSL_CTX
 
+B<COMPATIBILITY:> requires at least OpenSSL 0.9.8f
+
 Sets the SSL_CTX the corresponds to an SSL session.
 
  my $the_ssl_ctx = Net::SSLeay::set_SSL_CTX($ssl, $ssl_ctx);


### PR DESCRIPTION
The `OPENSSL_VERSION_NUMBER` guard for the `SSL_get_SSL_CTX` and `SSL_ctrl` functions implies they were added in OpenSSL 0.9.8f, but they're actually present in OpenSSL 0.9.8. Remove the version guard for these functions, and clarify in the documentation that `SSL_set_SSL_CTX` is the only function of the three that requires OpenSSL >= 0.9.8f.

Closes #217.