### PR TITLE
Consistently initialise libssl in test suite scripts

### DIFF
--- a/Changes
+++ b/Changes
@@ -23,6 +23,7 @@ Revision history for Perl extension Net::SSLeay.
 	  RSA private keys and CSRs, certificates and CRLs with SHA-256 digests,
 	  allowing the test suite to execute under OpenSSL security level 2 (now the
 	  default security level for OpenSSL in many Linux distributions).
+	- Initialise libssl consistently in the test suite.
 
 1.89_02 2020-08-07
 	- Add support for the P_X509_CRL_add_extensions function. Thanks to

--- a/t/external/ocsp.t
+++ b/t/external/ocsp.t
@@ -1,6 +1,6 @@
 use lib 'inc';
 
-use Test::Net::SSLeay;
+use Test::Net::SSLeay qw(initialise_libssl);
 
 use IO::Socket::INET;
 
@@ -38,14 +38,11 @@ my @tests = (
 my $release_tests = $ENV{RELEASE_TESTING} ? 1:0;
 plan tests => $release_tests + @tests;
 
+initialise_libssl();
 
 my $timeout = 10; # used to TCP connect and SSL connect
 my $http_ua = eval { require HTTP::Tiny } && HTTP::Tiny->new(verify_SSL => 0);
 
-Net::SSLeay::randomize();
-Net::SSLeay::load_error_strings();
-Net::SSLeay::ERR_load_crypto_strings();
-Net::SSLeay::SSLeay_add_ssl_algorithms();
 my $sha1 = Net::SSLeay::EVP_get_digestbyname('sha1');
 
 

--- a/t/local/04_basic.t
+++ b/t/local/04_basic.t
@@ -5,14 +5,16 @@ use lib 'inc';
 use Net::SSLeay;
 use Test::Net::SSLeay;
 
-plan tests => 14;
+plan tests => 16;
 
 eval "use Test::Exception;";
 SKIP: {
-    skip 'Need Test::Exception for the some tests', 6 if $@;
-    lives_ok( sub { Net::SSLeay::randomize() }, 'randomizing' );
-    lives_ok( sub { Net::SSLeay::load_error_strings() }, 'loading error strings' );
-    lives_ok( sub { Net::SSLeay::SSLeay_add_ssl_algorithms() }, 'adding ssl algorithms' );
+    skip 'Test::Exception required for some tests', 8 if $@;
+    lives_ok( sub { Net::SSLeay::randomize() }, 'seed pseudorandom number generator' );
+    lives_ok( sub { Net::SSLeay::ERR_load_crypto_strings() }, 'load libcrypto error strings' );
+    lives_ok( sub { Net::SSLeay::load_error_strings() }, 'load libssl error strings' );
+    lives_ok( sub { Net::SSLeay::library_init() }, 'register default TLS ciphers and digest functions' );
+    lives_ok( sub { Net::SSLeay::OpenSSL_add_all_digests() }, 'register all digest functions' );
     #version numbers: 0x00903100 ~ 0.9.3, 0x0090600f ~ 0.6.9
     ok( Net::SSLeay::SSLeay() >= 0x00903100, 'SSLeay (version min 0.9.3)' );
     isnt( Net::SSLeay::SSLeay_version(), '', 'SSLeay (version string)' );

--- a/t/local/05_passwd_cb.t
+++ b/t/local/05_passwd_cb.t
@@ -3,14 +3,11 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw(data_file_path);
+use Test::Net::SSLeay qw( data_file_path initialise_libssl );
 
 plan tests => 36;
 
-Net::SSLeay::randomize();
-Net::SSLeay::load_error_strings();
-Net::SSLeay::add_ssl_algorithms();
-Net::SSLeay::OpenSSL_add_all_algorithms();
+initialise_libssl();
 
 my $key_pem      = data_file_path('simple-cert.key.enc.pem');
 my $key_password = 'test';

--- a/t/local/06_tcpecho.t
+++ b/t/local/06_tcpecho.t
@@ -1,7 +1,7 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw(can_fork tcp_socket);
+use Test::Net::SSLeay qw( can_fork initialise_libssl tcp_socket );
 
 BEGIN {
     if (not can_fork()) {
@@ -10,6 +10,8 @@ BEGIN {
         plan tests => 4;
     }
 }
+
+initialise_libssl();
 
 my $server = tcp_socket();
 my $msg = 'ssleay-tcp-test';

--- a/t/local/07_sslecho.t
+++ b/t/local/07_sslecho.t
@@ -1,7 +1,9 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw( can_fork data_file_path tcp_socket );
+use Test::Net::SSLeay qw(
+    can_fork data_file_path initialise_libssl tcp_socket
+);
 
 BEGIN {
     if (not can_fork()) {
@@ -10,6 +12,8 @@ BEGIN {
         plan tests => 122;
     }
 }
+
+initialise_libssl();
 
 $SIG{'PIPE'} = 'IGNORE';
 
@@ -27,12 +31,6 @@ my $cert_issuer  = '/C=PL/O=Net-SSLeay/OU=Test Suite/CN=Intermediate CA';
 my $cert_sha1_fp = '9C:2E:90:B9:A7:84:7A:3A:2B:BE:FD:A5:D1:46:EA:31:75:E9:03:26';
 
 $ENV{RND_SEED} = '1234567890123456789012345678901234567890';
-
-Net::SSLeay::randomize();
-Net::SSLeay::load_error_strings();
-Net::SSLeay::ERR_load_crypto_strings();
-Net::SSLeay::library_init();
-Net::SSLeay::OpenSSL_add_all_algorithms();
 
 {
     my $ctx = Net::SSLeay::CTX_new();

--- a/t/local/08_pipe.t
+++ b/t/local/08_pipe.t
@@ -1,7 +1,7 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw( can_really_fork data_file_path );
+use Test::Net::SSLeay qw( can_really_fork data_file_path initialise_libssl );
 
 use IO::Handle;
 use Symbol qw( gensym );
@@ -14,9 +14,7 @@ if (not can_really_fork()) {
     plan tests => 11;
 }
 
-Net::SSLeay::randomize();
-Net::SSLeay::load_error_strings();
-Net::SSLeay::OpenSSL_add_ssl_algorithms();
+initialise_libssl();
 
 my $cert = data_file_path('simple-cert.cert.pem');
 my $key  = data_file_path('simple-cert.key.pem');

--- a/t/local/09_ctx_new.t
+++ b/t/local/09_ctx_new.t
@@ -3,14 +3,11 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay;
+use Test::Net::SSLeay qw(initialise_libssl);
 
 plan tests => 44;
 
-Net::SSLeay::randomize();
-Net::SSLeay::load_error_strings();
-Net::SSLeay::add_ssl_algorithms();
-Net::SSLeay::OpenSSL_add_all_algorithms();
+initialise_libssl();
 
 sub is_known_proto_version {
     return 1 if $_[0] == 0x0000;                            # Automatic version selection

--- a/t/local/10_rand.t
+++ b/t/local/10_rand.t
@@ -3,9 +3,11 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw(data_file_path);
+use Test::Net::SSLeay qw( data_file_path initialise_libssl );
 
 plan tests => 52;
+
+initialise_libssl();
 
 is(Net::SSLeay::RAND_status(), 1, 'RAND_status');
 is(Net::SSLeay::RAND_poll(), 1, 'RAND_poll');

--- a/t/local/11_read.t
+++ b/t/local/11_read.t
@@ -4,7 +4,9 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw( can_fork data_file_path tcp_socket );
+use Test::Net::SSLeay qw(
+    can_fork data_file_path initialise_libssl tcp_socket
+);
 
 use Storable;
 
@@ -14,12 +16,13 @@ if (not can_fork()) {
     plan tests => 53;
 }
 
+initialise_libssl();
+
 my $pid;
 alarm(30);
 END { kill 9,$pid if $pid }
 
 my $server = tcp_socket();
-Net::SSLeay::initialize();
 
 # See that lengths differ for all msgs
 my $msg1 = "1 first message from server";

--- a/t/local/15_bio.t
+++ b/t/local/15_bio.t
@@ -1,9 +1,11 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay;
+use Test::Net::SSLeay qw(initialise_libssl);
 
 plan tests => 7;
+
+initialise_libssl();
 
 my $data = '0123456789' x 100;
 my $len  = length $data;

--- a/t/local/30_error.t
+++ b/t/local/30_error.t
@@ -1,7 +1,7 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay;
+use Test::Net::SSLeay qw(initialise_libssl);
 
 eval "use Test::Exception; use Test::Warn; use Test::NoWarnings; 1;";
 if ($@) {
@@ -10,7 +10,7 @@ if ($@) {
     plan tests => 11;
 }
 
-Net::SSLeay::load_error_strings();
+initialise_libssl();
 
 # Note, die_now usually just prints the process id and the argument string eg:
 # 57611: test

--- a/t/local/31_rsa_generate_key.t
+++ b/t/local/31_rsa_generate_key.t
@@ -1,7 +1,7 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay;
+use Test::Net::SSLeay qw(initialise_libssl);
 
 eval 'use Test::Exception';
 if ($@) {
@@ -10,10 +10,7 @@ if ($@) {
     plan tests => 14;
 }
 
-Net::SSLeay::randomize();
-Net::SSLeay::load_error_strings();
-Net::SSLeay::ERR_load_crypto_strings();
-Net::SSLeay::SSLeay_add_ssl_algorithms();
+initialise_libssl();
 
 lives_ok(sub {
         Net::SSLeay::RSA_generate_key(2048, 0x10001);

--- a/t/local/32_x509_get_cert_info.t
+++ b/t/local/32_x509_get_cert_info.t
@@ -1,7 +1,9 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw( data_file_path is_libressl is_openssl );
+use Test::Net::SSLeay qw(
+    data_file_path initialise_libssl is_libressl is_openssl
+);
 
 use lib '.';
 
@@ -11,10 +13,7 @@ my $tests =   ( is_openssl() && Net::SSLeay::SSLeay < 0x10100003 ) || is_libress
 
 plan tests => $tests;
 
-Net::SSLeay::randomize();
-Net::SSLeay::load_error_strings();
-Net::SSLeay::ERR_load_crypto_strings();
-Net::SSLeay::SSLeay_add_ssl_algorithms();
+initialise_libssl();
 
 # Check some basic X509 features added in 1.54:
 my $name = Net::SSLeay::X509_NAME_new();

--- a/t/local/33_x509_create_cert.t
+++ b/t/local/33_x509_create_cert.t
@@ -1,20 +1,13 @@
 use lib 'inc';
 
 use Net::SSLeay qw(MBSTRING_ASC MBSTRING_UTF8 EVP_PK_RSA EVP_PKT_SIGN EVP_PKT_ENC);
-use Test::Net::SSLeay qw( data_file_path is_openssl );
+use Test::Net::SSLeay qw( data_file_path initialise_libssl is_openssl );
 
 use utf8;
 
 plan tests => 139;
 
-Net::SSLeay::randomize();
-Net::SSLeay::load_error_strings();
-Net::SSLeay::ERR_load_crypto_strings();
-Net::SSLeay::SSLeay_add_ssl_algorithms();
-# SHA-256 isn't loaded by default until OpenSSL 0.9.8o
-if ( is_openssl() && Net::SSLeay::SSLeay < 0x009080ff ) {
-    Net::SSLeay::OpenSSL_add_all_digests();
-}
+initialise_libssl();
 
 my $ca_crt_pem = data_file_path('root-ca.cert.pem');
 my $ca_key_pem = data_file_path('root-ca.key.pem');
@@ -104,12 +97,6 @@ is(Net::SSLeay::X509_NAME_cmp($ca_issuer, $ca_subject), 0, "X509_NAME_cmp");
   like(my $key_pem1 = Net::SSLeay::PEM_get_string_PrivateKey($pk), qr/-----BEGIN (RSA )?PRIVATE KEY-----/, "PEM_get_string_PrivateKey+nopasswd");        
   like(my $key_pem2 = Net::SSLeay::PEM_get_string_PrivateKey($pk,"password"), qr/-----BEGIN (ENCRYPTED|RSA) PRIVATE KEY-----/, "PEM_get_string_PrivateKey+passwd");
   
-  Net::SSLeay::OpenSSL_add_all_algorithms();
-  if (Net::SSLeay::SSLeay >= 0x0090700f) {
-    #just test whether we can call the following functions
-    Net::SSLeay::OPENSSL_add_all_algorithms_conf();
-    Net::SSLeay::OPENSSL_add_all_algorithms_noconf();
-  }
   ok(my $alg1 = Net::SSLeay::EVP_get_cipherbyname("DES-EDE3-CBC"), "EVP_get_cipherbyname");
   like(my $key_pem3 = Net::SSLeay::PEM_get_string_PrivateKey($pk,"password",$alg1), qr/-----BEGIN (ENCRYPTED|RSA) PRIVATE KEY-----/, "PEM_get_string_PrivateKey+passwd+enc_alg");
 

--- a/t/local/34_x509_crl.t
+++ b/t/local/34_x509_crl.t
@@ -1,18 +1,11 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw( data_file_path is_openssl );
+use Test::Net::SSLeay qw( data_file_path initialise_libssl is_openssl );
 
 plan tests => 42;
 
-Net::SSLeay::randomize();
-Net::SSLeay::load_error_strings();
-Net::SSLeay::ERR_load_crypto_strings();
-Net::SSLeay::SSLeay_add_ssl_algorithms();
-# SHA-256 isn't loaded by default until OpenSSL 0.9.8o
-if ( is_openssl() && Net::SSLeay::SSLeay < 0x009080ff ) {
-    Net::SSLeay::OpenSSL_add_all_digests();
-}
+initialise_libssl();
 
 my $ca_crt_pem = data_file_path('intermediate-ca.cert.pem');
 my $ca_key_pem = data_file_path('intermediate-ca.key.pem');

--- a/t/local/35_ephemeral.t
+++ b/t/local/35_ephemeral.t
@@ -1,7 +1,7 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay;
+use Test::Net::SSLeay qw(initialise_libssl);
 
 if (Net::SSLeay::constant("LIBRESSL_VERSION_NUMBER") || Net::SSLeay::constant("OPENSSL_VERSION_NUMBER") >= 0x10100000) {
     plan skip_all => "LibreSSL and OpenSSL 1.1.0 removed support for ephemeral/temporary RSA private keys";
@@ -9,10 +9,7 @@ if (Net::SSLeay::constant("LIBRESSL_VERSION_NUMBER") || Net::SSLeay::constant("O
     plan tests => 3;
 }
 
-Net::SSLeay::randomize();
-Net::SSLeay::load_error_strings();
-Net::SSLeay::ERR_load_crypto_strings();
-Net::SSLeay::SSLeay_add_ssl_algorithms();
+initialise_libssl();
 
 ok( my $ctx = Net::SSLeay::CTX_new(), 'CTX_new' );
 ok( my $rsa = Net::SSLeay::RSA_generate_key(2048, Net::SSLeay::RSA_F4()), 'RSA_generate_key' );

--- a/t/local/36_verify.t
+++ b/t/local/36_verify.t
@@ -3,14 +3,13 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw(can_fork data_file_path is_libressl is_openssl tcp_socket);
+use Test::Net::SSLeay qw(
+    can_fork data_file_path initialise_libssl is_libressl is_openssl tcp_socket
+);
 
 plan tests => 103;
 
-Net::SSLeay::randomize();
-Net::SSLeay::load_error_strings();
-Net::SSLeay::add_ssl_algorithms();
-Net::SSLeay::OpenSSL_add_all_algorithms();
+initialise_libssl();
 
 my $root_ca_pem   = data_file_path('root-ca.cert.pem');
 my $ca_pem        = data_file_path('verify-ca.certchain.pem');

--- a/t/local/37_asn1_time.t
+++ b/t/local/37_asn1_time.t
@@ -1,9 +1,11 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay;
+use Test::Net::SSLeay qw(initialise_libssl);
 
 plan tests => 10;
+
+initialise_libssl();
 
 my $atime1 = Net::SSLeay::ASN1_TIME_new();
 ok($atime1, 'ASN1_TIME_new [1]');

--- a/t/local/38_priv-key.t
+++ b/t/local/38_priv-key.t
@@ -1,15 +1,11 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw(data_file_path);
+use Test::Net::SSLeay qw( data_file_path initialise_libssl );
 
 plan tests => 10;
 
-Net::SSLeay::randomize();
-Net::SSLeay::load_error_strings();
-Net::SSLeay::ERR_load_crypto_strings();
-Net::SSLeay::SSLeay_add_ssl_algorithms();
-Net::SSLeay::OpenSSL_add_all_algorithms();
+initialise_libssl();
 
 my $key_pem           = data_file_path('simple-cert.key.pem');
 my $key_pem_encrypted = data_file_path('simple-cert.key.enc.pem');

--- a/t/local/39_pkcs12.t
+++ b/t/local/39_pkcs12.t
@@ -1,14 +1,11 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw(data_file_path);
+use Test::Net::SSLeay qw( data_file_path initialise_libssl );
 
 plan tests => 19;
 
-Net::SSLeay::randomize();
-Net::SSLeay::load_error_strings();
-Net::SSLeay::ERR_load_crypto_strings();
-Net::SSLeay::SSLeay_add_ssl_algorithms();
+initialise_libssl();
 
 # Encrypted PKCS#12 archive, no chain:
 my $filename1          = data_file_path('simple-cert.enc.p12');

--- a/t/local/40_npn_support.t
+++ b/t/local/40_npn_support.t
@@ -1,7 +1,9 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw(can_fork data_file_path tcp_socket);
+use Test::Net::SSLeay qw(
+    can_fork data_file_path initialise_libssl tcp_socket
+);
 
 BEGIN {
     if (Net::SSLeay::SSLeay < 0x10001000) {
@@ -15,6 +17,8 @@ BEGIN {
     }
 }
 
+initialise_libssl();
+
 my $server = tcp_socket();
 my $msg = 'ssleay-npn-test';
 
@@ -24,7 +28,6 @@ my $cert_pem = data_file_path('simple-cert.cert.pem');
 my $key_pem  = data_file_path('simple-cert.key.pem');
 
 my @results;
-Net::SSLeay::initialize();
 
 {
     # SSL server

--- a/t/local/41_alpn_support.t
+++ b/t/local/41_alpn_support.t
@@ -1,7 +1,9 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw(can_fork data_file_path tcp_socket);
+use Test::Net::SSLeay qw(
+    can_fork data_file_path initialise_libssl tcp_socket
+);
 
 BEGIN {
     if (Net::SSLeay::SSLeay < 0x10002000) {
@@ -13,6 +15,8 @@ BEGIN {
     }
 }
 
+initialise_libssl();
+
 my $server = tcp_socket();
 my $pid;
 
@@ -22,7 +26,6 @@ my $cert_pem = data_file_path('simple-cert.cert.pem');
 my $key_pem  = data_file_path('simple-cert.key.pem');
 
 my @results;
-Net::SSLeay::initialize();
 
 {
     # SSL server

--- a/t/local/42_info_callback.t
+++ b/t/local/42_info_callback.t
@@ -1,7 +1,9 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw(can_fork data_file_path tcp_socket);
+use Test::Net::SSLeay qw(
+    can_fork data_file_path initialise_libssl tcp_socket
+);
 
 if (not can_fork()) {
     plan skip_all => "fork() not supported on this system";
@@ -9,12 +11,13 @@ if (not can_fork()) {
     plan tests => 2;
 }
 
+initialise_libssl();
+
 my $pid;
 alarm(30);
 END { kill 9,$pid if $pid }
 
 my $server = tcp_socket();
-Net::SSLeay::initialize();
 
 {
     # SSL server - just handle single connect and  shutdown connection

--- a/t/local/43_misc_functions.t
+++ b/t/local/43_misc_functions.t
@@ -1,13 +1,17 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw(can_fork data_file_path is_libressl tcp_socket);
+use Test::Net::SSLeay qw(
+    can_fork data_file_path initialise_libssl is_libressl tcp_socket
+);
 
 if (not can_fork()) {
     plan skip_all => "fork() not supported on this system";
 } else {
     plan tests => 34;
 }
+
+initialise_libssl();
 
 my $pid;
 alarm(30);
@@ -54,7 +58,6 @@ our %version_str2int =
     );
 
 my $server = tcp_socket();
-Net::SSLeay::initialize();
 
 {
     # SSL server - just handle single connect, send information to

--- a/t/local/44_sess.t
+++ b/t/local/44_sess.t
@@ -3,7 +3,9 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw(can_fork data_file_path tcp_socket);
+use Test::Net::SSLeay qw(
+    can_fork data_file_path initialise_libssl tcp_socket
+);
 
 use Storable;
 
@@ -12,6 +14,8 @@ if (not can_fork()) {
 } else {
     plan tests => 58;
 }
+
+initialise_libssl();
 
 my $pid;
 alarm(30);
@@ -124,7 +128,6 @@ sub server_remove_cb
 }
 
 my ($server_ctx, $client_ctx, $server_ssl, $client_ssl);
-Net::SSLeay::initialize();
 
 my $server = tcp_socket();
 

--- a/t/local/45_exporter.t
+++ b/t/local/45_exporter.t
@@ -3,7 +3,9 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw(can_fork data_file_path tcp_socket);
+use Test::Net::SSLeay qw(
+    can_fork data_file_path initialise_libssl tcp_socket
+);
 
 use Storable;
 
@@ -15,6 +17,8 @@ if (not can_fork()) {
     plan tests => 36;
 }
 
+initialise_libssl();
+
 my $pid;
 alarm(30);
 END { kill 9,$pid if $pid }
@@ -23,7 +27,6 @@ my @rounds = qw(TLSv1 TLSv1.1 TLSv1.2 TLSv1.3);
 my (%server_stats, %client_stats);
 
 my ($server_ctx, $client_ctx, $server_ssl, $client_ssl);
-Net::SSLeay::initialize();
 
 my $server = tcp_socket();
 

--- a/t/local/50_digest.t
+++ b/t/local/50_digest.t
@@ -1,9 +1,12 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw(data_file_path);
+use Test::Net::SSLeay qw( data_file_path initialise_libssl );
 
 plan tests => 203;
+
+initialise_libssl();
+Net::SSLeay::OpenSSL_add_all_digests();
 
 sub digest_chunked_f1 {
   my ($file, $digest) = @_;
@@ -154,8 +157,6 @@ sub digest_strings {
 my %all_digests;
 
 eval {
-  Net::SSLeay::initialize();
-  Net::SSLeay::OpenSSL_add_all_digests();
   if (Net::SSLeay::SSLeay >= 0x1000000f) {
 	my $ctx = Net::SSLeay::EVP_MD_CTX_create();
     %all_digests = map { $_=>1 } grep {

--- a/t/local/61_threads-cb-crash.t
+++ b/t/local/61_threads-cb-crash.t
@@ -1,7 +1,7 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw(can_thread data_file_path);
+use Test::Net::SSLeay qw( can_thread data_file_path initialise_libssl );
 
 use FindBin;
 
@@ -17,13 +17,11 @@ if (not can_thread()) {
 
 require threads;
 
+initialise_libssl();
+
 my $start_time = time;
 
 my $file = data_file_path('simple-cert.key.pem');
-
-Net::SSLeay::randomize();
-Net::SSLeay::load_error_strings();
-Net::SSLeay::SSLeay_add_ssl_algorithms();
 
 #exit the whole program if it runs too long
 threads->new( sub { sleep 20; warn "FATAL: TIMEOUT!"; exit } )->detach;

--- a/t/local/62_threads-ctx_new-deadlock.t
+++ b/t/local/62_threads-ctx_new-deadlock.t
@@ -1,7 +1,7 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw(can_thread);
+use Test::Net::SSLeay qw( can_thread initialise_libssl );
 
 use FindBin;
 
@@ -16,11 +16,9 @@ if (not can_thread()) {
 
 require threads;
 
-my $start_time = time;
+initialise_libssl();
 
-Net::SSLeay::randomize();
-Net::SSLeay::load_error_strings();
-Net::SSLeay::SSLeay_add_ssl_algorithms();
+my $start_time = time;
 
 #exit the whole program if it runs too long
 threads->new( sub { sleep 20; warn "FATAL: TIMEOUT!"; exit } )->detach;

--- a/t/local/63_ec_key_generate_key.t
+++ b/t/local/63_ec_key_generate_key.t
@@ -1,7 +1,7 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay;
+use Test::Net::SSLeay qw(initialise_libssl);
 
 if (!defined &Net::SSLeay::EC_KEY_generate_key) {
     plan skip_all => "no support for ECC in your OpenSSL";
@@ -9,10 +9,7 @@ if (!defined &Net::SSLeay::EC_KEY_generate_key) {
     plan tests => 4;
 }
 
-Net::SSLeay::randomize();
-Net::SSLeay::load_error_strings();
-Net::SSLeay::ERR_load_crypto_strings();
-Net::SSLeay::SSLeay_add_ssl_algorithms();
+initialise_libssl();
 
 my $ec = Net::SSLeay::EC_KEY_generate_key('prime256v1');
 ok($ec,'EC key created');

--- a/t/local/64_ticket_sharing.t
+++ b/t/local/64_ticket_sharing.t
@@ -1,7 +1,7 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw(data_file_path);
+use Test::Net::SSLeay qw( data_file_path initialise_libssl );
 
 if (!defined &Net::SSLeay::CTX_set_tlsext_ticket_getkey_cb) {
     plan skip_all => "no support for tlsext_ticket_key_cb";
@@ -9,15 +9,12 @@ if (!defined &Net::SSLeay::CTX_set_tlsext_ticket_getkey_cb) {
     plan tests => 15;
 }
 
+initialise_libssl();
+
 # for debugging only
 my $DEBUG = 0;
 my $PCAP = 0;
 require Net::PcapWriter if $PCAP;
-
-Net::SSLeay::randomize();
-Net::SSLeay::load_error_strings();
-Net::SSLeay::ERR_load_crypto_strings();
-Net::SSLeay::SSLeay_add_ssl_algorithms();
 
 my $SSL_ERROR; # set in _minSSL
 my %TRANSFER;  # set in _handshake

--- a/t/local/65_security_level.t
+++ b/t/local/65_security_level.t
@@ -1,7 +1,7 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay;
+use Test::Net::SSLeay qw(initialise_libssl);
 
 if (Net::SSLeay::SSLeay < 0x10100001) {
     plan skip_all => 'OpenSSL 1.1.0 required';
@@ -10,6 +10,8 @@ if (Net::SSLeay::SSLeay < 0x10100001) {
 } else {
     plan tests => 20;
 }
+
+initialise_libssl();
 
 my $ctx = Net::SSLeay::CTX_new();
 ok( defined Net::SSLeay::CTX_get_security_level($ctx),

--- a/t/local/65_ticket_sharing_2.t
+++ b/t/local/65_ticket_sharing_2.t
@@ -1,7 +1,7 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw(data_file_path);
+use Test::Net::SSLeay qw( data_file_path initialise_libssl );
 
 if (!defined &Net::SSLeay::set_session_ticket_ext_cb) {
     plan skip_all => "no support for session_ticket_ext_cb";
@@ -9,15 +9,12 @@ if (!defined &Net::SSLeay::set_session_ticket_ext_cb) {
     plan tests => 4;
 }
 
+initialise_libssl();
+
 # for debugging only
 my $DEBUG = 0;
 my $PCAP = 0;
 require Net::PcapWriter if $PCAP;
-
-Net::SSLeay::randomize();
-Net::SSLeay::load_error_strings();
-Net::SSLeay::ERR_load_crypto_strings();
-Net::SSLeay::SSLeay_add_ssl_algorithms();
 
 my $SSL_ERROR; # set in _minSSL
 my %TRANSFER;  # set in _handshake

--- a/t/local/66_curves.t
+++ b/t/local/66_curves.t
@@ -1,7 +1,9 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw(data_file_path);
+use Test::Net::SSLeay qw( data_file_path initialise_libssl );
+
+initialise_libssl();
 
 my @set_list = (
     defined &Net::SSLeay::CTX_set1_groups_list ? (\&Net::SSLeay::CTX_set1_groups_list) : (),
@@ -18,11 +20,6 @@ if (!@set_list) {
 my $DEBUG = 0;
 my $PCAP = 0;
 require Net::PcapWriter if $PCAP;
-
-Net::SSLeay::randomize();
-Net::SSLeay::load_error_strings();
-Net::SSLeay::ERR_load_crypto_strings();
-Net::SSLeay::SSLeay_add_ssl_algorithms();
 
 my $SSL_ERROR; # set in _minSSL
 my %TRANSFER;  # set in _handshake


### PR DESCRIPTION
The preambles of the scripts in the test suite are inconsistent in initialising libssl by calling different subsets of the following functions:

* `Net::SSLeay::ERR_load_crypto_strings()`
* `Net::SSLeay::OpenSSL_add_all_algorithms()`
* `Net::SSLeay::OpenSSL_add_ssl_algorithms()`
* `Net::SSLeay::SSLeay_add_ssl_algorithms()`
* `Net::SSLeay::add_ssl_algorithms()`
* `Net::SSLeay::initialize()`
* `Net::SSLeay::library_init()`
* `Net::SSLeay::load_error_strings()`
* `Net::SSLeay::randomize()`

Standardise the initialisation procedure by defining a new importable function `initialise_libssl()` in Test::Net::SSLeay that calls the following functions:

* `Net::SSLeay::randomize()`
* `Net::SSLeay::load_error_strings()`
* `Net::SSLeay::ERR_load_crypto_strings()`
* `Net::SSLeay::library_init()`

as well as `Net::SSLeay::OpenSSL_add_all_digests()` to register SHA-256 if using a version of OpenSSL that doesn't register SHA-256 by default, since it is used heavily in the current test suite PKI.

Import and call `initialise_libssl()` in test suite scripts that test libssl functionality. Specific initialisation functions must still be
called in some situations (e.g. `Net::SSLeay::OpenSSL_add_all_digests()` in `50_digest.t`, which tests a number of non-standard message digest functions).

Closes #220.