### PR TITLE
Dynamically select SSL/TLS protocol versions in test suite

### DIFF
--- a/Changes
+++ b/Changes
@@ -24,6 +24,12 @@ Revision history for Perl extension Net::SSLeay.
 	  allowing the test suite to execute under OpenSSL security level 2 (now the
 	  default security level for OpenSSL in many Linux distributions).
 	- Initialise libssl consistently in the test suite.
+	- Don't rely on the availability of specific SSL/TLS protocol versions or
+	  cipher suites in the test suite; instead, dynamically select from any of
+	  the available protocol versions and cipher suites permitted by libssl.
+	  Fixes RT#132425. Thanks to Graham Ollis for the initial report of the test
+	  suite failing on Ubuntu 20.04 with the Ubuntu-packaged OpenSSL, whose
+	  configuration forbids the use of TLSv1.1 and below at run-time by default.
 
 1.89_02 2020-08-07
 	- Add support for the P_X509_CRL_add_extensions function. Thanks to

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -45,6 +45,7 @@ my %eumm_args = (
     'Scalar::Util' => '0',
     'SelectSaver' => '0',
     'Socket' => '0',
+    'Storable' => '0',
     'Test::More' => '0.60_01',
     'base' => '0',
   },

--- a/inc/Test/Net/SSLeay.pm
+++ b/inc/Test/Net/SSLeay.pm
@@ -20,10 +20,61 @@ our @EXPORT_OK = qw(
     data_file_path
     initialise_libssl
     is_libressl is_openssl
+    is_protocol_usable
+    new_ctx
+    protocols
     tcp_socket
 );
 
 my $data_path = catfile( dirname(__FILE__), '..', '..', '..', 't', 'data' );
+
+my $initialised = 0;
+
+my %protos = (
+    'TLSv1.3' => {
+        constant      => \&Net::SSLeay::TLS1_3_VERSION,
+        constant_type => 'version',
+        priority      => 6,
+    },
+    'TLSv1.2' => {
+        constant      => \&Net::SSLeay::TLSv1_2_method,
+        constant_type => 'method',
+        priority      => 5,
+    },
+    'TLSv1.1' => {
+        constant      => \&Net::SSLeay::TLSv1_1_method,
+        constant_type => 'method',
+        priority      => 4,
+    },
+    'TLSv1' => {
+        constant      => \&Net::SSLeay::TLSv1_method,
+        constant_type => 'method',
+        priority      => 3,
+    },
+    'SSLv3' => {
+        constant      => \&Net::SSLeay::SSLv3_method,
+        constant_type => 'method',
+        priority      => 2,
+    },
+    'SSLv2' => {
+        constant      => \&Net::SSLeay::SSLv2_method,
+        constant_type => 'method',
+        priority      => 1,
+    },
+);
+
+sub _libssl_fatal {
+    my ($context) = @_;
+
+    croak "$context: "
+        . Net::SSLeay::ERR_error_string( Net::SSLeay::ERR_get_error() );
+}
+
+sub _load_net_ssleay {
+    eval { require Net::SSLeay; 1; } or croak $EVAL_ERROR;
+
+    return 1;
+}
 
 sub import {
     my ( $class, @imports ) = @_;
@@ -102,7 +153,9 @@ sub data_file_path {
 }
 
 sub initialise_libssl {
-    eval { require Net::SSLeay; 1; } or croak $EVAL_ERROR;
+    return 1 if $initialised;
+
+    _load_net_ssleay();
 
     Net::SSLeay::randomize();
 
@@ -127,11 +180,13 @@ sub initialise_libssl {
         if    Net::SSLeay::constant('OPENSSL_VERSION_NUMBER') >= 0x10000000
            && Net::SSLeay::constant('OPENSSL_VERSION_NUMBER') < 0x1000001f;
 
+    $initialised = 1;
+
     return 1;
 }
 
 sub is_libressl {
-    eval { require Net::SSLeay; 1; } or croak $EVAL_ERROR;
+    _load_net_ssleay();
 
     # The most foolproof method of checking whether libssl is provided by
     # LibreSSL is by checking OPENSSL_VERSION_NUMBER: every version of
@@ -144,13 +199,163 @@ sub is_libressl {
 }
 
 sub is_openssl {
-    eval { require Net::SSLeay; 1; } or croak $EVAL_ERROR;
+    _load_net_ssleay();
 
     # "OpenSSL 2.0.0" is actually LibreSSL
     return 0
         if Net::SSLeay::constant('OPENSSL_VERSION_NUMBER') == 0x20000000;
 
     return 1;
+}
+
+sub is_protocol_usable {
+    my ($proto) = @_;
+
+    _load_net_ssleay();
+    initialise_libssl();
+
+    my $proto_data = $protos{$proto};
+
+    # If libssl does not support this protocol version, or if it was disabled at
+    # compile-time, the appropriate method for that version will be missing
+    if (
+          $proto_data->{constant_type} eq 'version'
+        ? !eval { &{ $proto_data->{constant} }; 1 }
+        : !defined &{ $proto_data->{constant} }
+    ) {
+        return 0;
+    }
+
+    # If libssl was built with support for this protocol version, the only
+    # reliable way to test whether its use is permitted by the security policy
+    # is to attempt to create a connection that uses it - if it is permitted,
+    # the state machine enters the following states:
+    #
+    #   SSL_CB_HANDSHAKE_START (ret=1)
+    #   SSL_CB_CONNECT_LOOP    (ret=1)
+    #   SSL_CB_CONNECT_EXIT    (ret=-1)
+    #
+    # If it is not permitted, the state machine instead enters the following
+    # states:
+    #
+    #   SSL_CB_HANDSHAKE_START (ret=1)
+    #   SSL_CB_CONNECT_EXIT    (ret=-1)
+    #
+    # Additionally, ERR_get_error() returns the error code 0x14161044, although
+    # this might not necessarily be guaranteed for all libssl versions, so
+    # testing for it may be unreliable
+
+    my $constant = $proto_data->{constant}->();
+    my $ctx;
+
+    if ( $proto_data->{constant_type} eq 'version' ) {
+        $ctx = Net::SSLeay::CTX_new_with_method( Net::SSLeay::TLS_method() )
+            or _libssl_fatal('Failed to create libssl SSL_CTX object');
+
+        Net::SSLeay::CTX_set_min_proto_version( $ctx, $constant );
+        Net::SSLeay::CTX_set_max_proto_version( $ctx, $constant );
+    }
+    else {
+        $ctx = Net::SSLeay::CTX_new_with_method($constant)
+            or _libssl_fatal('Failed to create SSL_CTX object');
+    }
+
+    my $ssl = Net::SSLeay::new($ctx)
+        or _libssl_fatal('Failed to create SSL structure');
+
+    # For the purposes of this test, it isn't necessary to link the SSL
+    # structure to a file descriptor, since no data actually needs to be sent or
+    # received
+    Net::SSLeay::set_fd( $ssl, -1 )
+        or _libssl_fatal('Failed to set file descriptor for SSL structure');
+
+    my @states;
+
+    Net::SSLeay::CTX_set_info_callback(
+        $ctx,
+        sub {
+            my ( $ssl, $where, $ret, $data ) = @_;
+
+            push @states, $where;
+        }
+    );
+
+    Net::SSLeay::connect($ssl)
+        or _libssl_fatal('Failed to initiate connection');
+
+    my $disabled =   Net::SSLeay::CB_HANDSHAKE_START()
+                   + Net::SSLeay::CB_CONNECT_EXIT();
+
+    my $enabled =   Net::SSLeay::CB_HANDSHAKE_START()
+                  + Net::SSLeay::CB_CONNECT_LOOP()
+                  + Net::SSLeay::CB_CONNECT_EXIT();
+
+    Net::SSLeay::free($ssl);
+    Net::SSLeay::CTX_free($ctx);
+
+    my $observed = 0;
+    for my $state (@states) {
+        $observed += $state;
+    }
+
+    return 0 if $observed == $disabled;
+    return 1 if $observed == $enabled;
+
+    croak 'Unexpected TLS state machine sequence: ' . join( ', ', @states );
+}
+
+sub new_ctx {
+    my ( $min_proto, $max_proto ) = @_;
+
+    my @usable_protos =
+        # Exclude protocol versions not supported by this libssl:
+        grep {
+            is_protocol_usable($_)
+        }
+        # Exclude protocol versions outside the desired range:
+        grep {
+               (
+                     defined $min_proto
+                   ? $protos{$_}->{priority} >= $protos{$min_proto}->{priority}
+                   : 1
+               )
+            && (
+                     defined $max_proto
+                   ? $protos{$_}->{priority} <= $protos{$max_proto}->{priority}
+                   : 1
+               )
+        }
+        protocols();
+
+    croak 'Failed to create libssl SSL_CTX object: no usable protocol versions'
+        if !@usable_protos;
+
+    my $proto    = shift @usable_protos;
+    my $constant = $protos{$proto}->{constant}->();
+    my $ctx;
+
+    if ( $protos{$proto}->{constant_type} eq 'version' ) {
+        $ctx = Net::SSLeay::CTX_new_with_method( Net::SSLeay::TLS_method() )
+            or _libssl_fatal('Failed to create libssl SSL_CTX object');
+
+        Net::SSLeay::CTX_set_min_proto_version( $ctx, $constant );
+        Net::SSLeay::CTX_set_max_proto_version( $ctx, $constant );
+    }
+    else {
+        $ctx = Net::SSLeay::CTX_new_with_method($constant)
+            or _libssl_fatal('Failed to create SSL_CTX object');
+    }
+
+    return wantarray ? ( $ctx, $proto )
+                     : $ctx;
+}
+
+sub protocols {
+    return
+        sort {
+            $protos{$b}->{priority} <=> $protos{$a}->{priority}
+        }
+        keys %protos;
 }
 
 sub tcp_socket {
@@ -263,7 +468,6 @@ Returns the relative path to a given file in the test suite data directory
 
 =head2 initialise_libssl
 
-    # In the preamble
     initialise_libssl();
 
     # Run tests that call Net::SSLeay functions
@@ -273,6 +477,9 @@ loading error strings, and registering the default TLS ciphers and digest
 functions. All digest functions are explicitly registered when Net::SSLeay is
 built against a libssl version that does not register SHA-256 by default, since
 SHA-256 is used heavily in the test suite PKI.
+
+libssl will only be initialised the first time this function is called, so it is
+safe for it to be called multiple times in the same test script.
 
 =head2 is_libressl
 
@@ -289,6 +496,58 @@ Returns true if libssl is provided by LibreSSL, or false if not.
     }
 
 Returns true if libssl is provided by OpenSSL, or false if not.
+
+=head2 is_protocol_usable
+
+    if ( is_protocol_usable('TLSv1.1') ) {
+        # Run TLSv1.1 tests
+    }
+
+Returns true if libssl can communicate using the given SSL/TLS protocol version
+(represented as a string of the format returned by L</protocols>), or false if
+not.
+
+Note that the availability of a particular SSL/TLS protocol version may vary
+based on the version of OpenSSL or LibreSSL in use, the options chosen when it
+was compiled (e.g., OpenSSL will not support SSLv3 if it was built with
+C<no-ssl3>), or run-time configuration (e.g., the use of TLSv1.0 will be
+forbidden if the OpenSSL configuration sets the default security level to 3 or
+higher; see L<SSL_CTX_set_security_level(3)>).
+
+=head2 new_ctx
+
+    my $ctx = new_ctx();
+    # $ctx is an SSL_CTX that uses the highest available protocol version
+
+    my ( $ctx, $version ) = new_ctx( 'TLSv1', 'TLSv1.2' );
+    # $ctx is an SSL_CTX that uses the highest available protocol version
+    # between TLSv1 and TLSv1.2 inclusive; $version contains the protocol
+    # version chosen
+
+Creates a libssl SSL_CTX object that uses the most recent SSL/TLS protocol
+version supported by libssl, optionally bounded by the given minimum and maximum
+protocol versions (represented as strings of the format returned by
+L</protocols>).
+
+If called in scalar context, returns the SSL_CTX object that was created. If
+called in array context, returns the SSL_CTX object and a string containing the
+protocol version used by the SSL_CTX object. Dies if libssl does not support any
+of the protocol versions in the given range, or if an SSL_CTX object that uses
+the chosen protocol version could not be created.
+
+=head2 protocols
+
+    my @protos = protocols();
+
+Returns an array containing strings that describe the SSL/TLS protocol versions
+supported by L<Net::SSLeay>: C<'TLSv1.3'>, C<'TLSv1.2'>, C<'TLSv1.1'>,
+C<'TLSv1'>, C<'SSLv3'>, and C<'SSLv2'>. The protocol versions are sorted in
+reverse order of age (i.e. in the order shown here).
+
+Note that it may not be possible to communicate using some of these protocol
+versions, depending on how libssl was compiled and is configured. These strings
+can be given as parameters to L</is_protocol_usable> to discover whether the
+protocol version is actually usable by libssl.
 
 =head2 tcp_socket
 

--- a/t/local/42_info_callback.t
+++ b/t/local/42_info_callback.t
@@ -2,7 +2,7 @@ use lib 'inc';
 
 use Net::SSLeay;
 use Test::Net::SSLeay qw(
-    can_fork data_file_path initialise_libssl tcp_socket
+    can_fork data_file_path initialise_libssl new_ctx tcp_socket
 );
 
 if (not can_fork()) {
@@ -28,7 +28,7 @@ my $server = tcp_socket();
     if ($pid == 0) {
 	for(qw(ctx ssl)) {
 	    my $cl = $server->accept();
-	    my $ctx = Net::SSLeay::CTX_tlsv1_new();
+	    my $ctx = new_ctx();
 	    Net::SSLeay::set_cert_and_key($ctx, $cert_pem, $key_pem);
 	    my $ssl = Net::SSLeay::new($ctx);
 	    Net::SSLeay::set_fd($ssl, fileno($cl));
@@ -53,7 +53,7 @@ sub client {
     };
 
     my $cl = $server->connect();
-    my $ctx = Net::SSLeay::CTX_tlsv1_new();
+    my $ctx = new_ctx();
     Net::SSLeay::CTX_set_options($ctx, &Net::SSLeay::OP_ALL);
     Net::SSLeay::CTX_set_info_callback($ctx, $infocb) if $where eq 'ctx';
     my $ssl = Net::SSLeay::new($ctx);

--- a/t/local/66_curves.t
+++ b/t/local/66_curves.t
@@ -94,9 +94,12 @@ sub _handshake {
 
 {
     package _minSSL;
+
+    use Test::Net::SSLeay qw(new_ctx);
+
     sub new {
 	my ($class,%args) = @_;
-	my $ctx = Net::SSLeay::CTX_tlsv1_new();
+	my $ctx = new_ctx();
 	Net::SSLeay::CTX_set_options($ctx,Net::SSLeay::OP_ALL());
 	Net::SSLeay::CTX_set_cipher_list($ctx,'ECDHE');
 	Net::SSLeay::CTX_set_ecdh_auto($ctx,1)


### PR DESCRIPTION
Many scripts in the test suite unnecessarily rely on the availability of specific SSL/TLS protocol versions and cipher suites, which may not be usable at run-time depending on the active libssl configuration (e.g. TLSv1 is forbidden at security level 3), thus causing the test suite to fail. Avoid these situations by choosing protocol versions for new SSL/TLS connections dynamically based on what is currently usable in libssl.

Add the following helper functions to Test::Net::SSLeay:

* `protocols()`, which returns an array of SSL/TLS protocol versions supported by Net::SSLeay;
* `is_protocol_usable()`, which returns a Boolean value indicating whether the given protocol version is usable with the current libssl;
* `new_ctx()`, which creates a new SSL_CTX object that uses the given protocol version.

Update the test scripts in `t/local` to make use of these helper functions instead of creating `SSL_CTX` objects that use specific protocol versions.

Other necessary changes to test scripts:

* In `40_npn_support.t`, `64_ticket_sharing.t` and `65_ticket_sharing_2.t`, create `SSL_CTX` objects with a protocol version no higher than TLSv1.2; NPN isn't well-defined in TLSv1.3, and the tests in the ticket sharing test scripts only reflect the session protocol found in TLSv1.2 and below.
* In `41_alpn_support.t`, make the server resilient to failure when TLSv1.3 is chosen.
* Rearchitect `44_sess.t` to make the execution of each round independent, and skip rounds that require a protocol version that isn't available; additionally, communicate the test results from the server to the client in the clear rather than using TLSv1 (which is unnecessarily complicated, and TLSv1 might not be usable). The successful execution of this test script no longer relies on the availability of every protocol version between TLSv1 and TLSv1.2.
* In `64_ticket_sharing.t` and `65_ticket_sharing_2.t`, don't always attempt to use the AES128-SHA cipher suite, since it is not guaranteed to be available (e.g. if `new_ctx()` returns an `SSL_CTX` object that uses SSLv3); the cipher suite selection isn't a critical part of the test, so let the server and client negotiate one instead.

Closes #219. Fixes [RT#132425](https://rt.cpan.org/Public/Bug/Display.html?id=132425).