### PR TITLE
Avoid memory allocation in NPN and ALPN select callback functions

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,9 @@ Revision history for Perl extension Net::SSLeay.
 	  pointer returned by SSL_select_next_proto() which may already have been
 	  freed under certain circumstances. Fixes GH-222. Thanks to dylc5190 for
 	  the report and patch.
+	- Fix a potential crash in the default callback function for
+	  CTX_set_alpn_select_cb() caused by the same use-after-free bug as the
+	  one in CTX_set_next_proto_select_cb().
 
 1.89_03 2020-12-12
 	- Expose the following functions:

--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 Revision history for Perl extension Net::SSLeay.
 
+1.89_04 ????-??-??
+	- Fix a crash in CTX_set_next_proto_select_cb() caused by the use of a
+	  pointer returned by SSL_select_next_proto() which may already have been
+	  freed under certain circumstances. Fixes GH-222. Thanks to dylc5190 for
+	  the report and patch.
+
 1.89_03 2020-12-12
 	- Expose the following functions:
 	  - X509_STORE_CTX_get0_cert, X509_STORE_CTX_get1_chain

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -1261,7 +1261,7 @@ int next_protos_advertised_cb_invoke(SSL *ssl, const unsigned char **out, unsign
 int alpn_select_cb_invoke(SSL *ssl, const unsigned char **out, unsigned char *outlen,
                                 const unsigned char *in, unsigned int inlen, void *arg)
 {
-    SV *cb_func, *cb_data;
+    SV *cb_func, *cb_data, *tmpsv;
     unsigned char *alpn_data;
     size_t alpn_len;
     SSL_CTX *ctx = SSL_get_SSL_CTX(ssl);
@@ -1273,7 +1273,6 @@ int alpn_select_cb_invoke(SSL *ssl, const unsigned char **out, unsigned char *ou
     if (SvROK(cb_func) && (SvTYPE(SvRV(cb_func)) == SVt_PVCV)) {
         int count = -1;
         AV *list = newAV();
-        SV *tmpsv;
         SV *alpn_data_sv;
         dSP;
 
@@ -1320,6 +1319,8 @@ int alpn_select_cb_invoke(SSL *ssl, const unsigned char **out, unsigned char *ou
 
         /* This is the same function that is used for NPN. */
         status = SSL_select_next_proto((unsigned char **)out, outlen, in, inlen, alpn_data, alpn_len);
+        tmpsv = newSVpv((const char*)*out, *outlen);
+        *out = (unsigned char *)SvPVX(tmpsv);
         Safefree(alpn_data);
         return status == OPENSSL_NPN_NEGOTIATED ? SSL_TLSEXT_ERR_OK : SSL_TLSEXT_ERR_NOACK;
     }


### PR DESCRIPTION
`SSL_select_next_proto()` stores the first item in the `client, client_len` list in `out, outlen` if no matching protocol is found. `out, outlen` are used in `Net::SSLeay::CTX_set_next_proto_select_cb()`, but the memory pointed to by `out` will already have been freed by the time it is used if `SSL_select_next_proto()` returns the first item in `client, client_len`. Temporarily store an internal copy of `out` to avoid the crash that would otherwise be caused.

Closes #222.