### PR TITLE
64_ticket_sharing.t: remove dependency on AES128-SHA

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,8 @@ Revision history for Perl extension Net::SSLeay.
 	  CTX_set_alpn_select_cb() caused by the use of a pointer returned by
 	  SSL_select_next_proto() which may already have been freed under certain
 	  circumstances. Fixes GH-222. Thanks to dylc5190 for the report.
+	- Remove the dependency on the AES128-SHA cipher suite in the test script
+	  64_ticket_sharing.t. Fixes GH-231.
 
 1.89_03 2020-12-12
 	- Expose the following functions:

--- a/t/local/64_ticket_sharing.t
+++ b/t/local/64_ticket_sharing.t
@@ -8,14 +8,13 @@ use English qw( $EVAL_ERROR -no_match_vars );
 if ( !defined &Net::SSLeay::CTX_set_tlsext_ticket_getkey_cb ) {
     plan skip_all => "no support for tlsext_ticket_key_cb";
 }
-elsif ( !eval { Net::SSLeay::CTX_free( new_ctx( 'TLSv1', 'TLSv1.2' ) ); 1 } ) {
+elsif ( !eval { Net::SSLeay::CTX_free( new_ctx( undef, 'TLSv1.2' ) ); 1 } ) {
     my $err = $EVAL_ERROR;
-    # This test only reflects the session protocol found in TLSv1.2 and below
-    # (https://wiki.openssl.org/index.php/TLS1.3#Sessions), and relies on a
-    # cipher suite only present from TLSv1 onwards
+    # This test only reflects the session protocol found in TLSv1.2 and below:
+    # https://wiki.openssl.org/index.php/TLS1.3#Sessions
     # TODO(GH-224): write an equivalent test for TLSv1.3
     if ( $err =~ /no usable protocol versions/ ) {
-        plan skip_all => 'TLSv1-TLSv1.2 not available in this libssl';
+        plan skip_all => 'TLSv1.2 or below not available in this libssl';
     }
     else {
         die $err;
@@ -209,11 +208,9 @@ sub _handshake {
     sub new {
 	my ($class,%args) = @_;
 	my $ctx = new_ctx( 'TLSv1', 'TLSv1.2' );
-	# AES128-SHA must be used, otherwise the "no more data from client to
-	# server" test fails on Win32 with OpenSSL 1.0.1 and 1.0.2 (this behaviour
-    # has been observed with OpenSSL 1.0.1e, 1.0.1g and 1.0.2o)
-	Net::SSLeay::CTX_set_cipher_list( $ctx, 'AES128-SHA' );
-	Net::SSLeay::CTX_set_options($ctx,Net::SSLeay::OP_ALL());
+	# Explicitly disable compression, otherwise the "no more data from client to
+	# server" test may fail sometimes:
+	Net::SSLeay::CTX_set_options( $ctx, Net::SSLeay::OP_ALL() | Net::SSLeay::OP_NO_COMPRESSION() );
 	my $id = 'client';
 	if ($args{cert}) {
 	    my ($cert,$key) = @{ delete $args{cert} };


### PR DESCRIPTION
`t/local/64_ticket_sharing.t` requires the use of the AES128-SHA cipher suite, which is only available from TLSv1 onwards (and its use may be forbidden by libssl's run-time configuration even when it is available). Allow the server and client to automatically negotiate a cipher suite in this test script, removing the dependency on AES128-SHA. (This requires compression to be disabled explicitly, since compression may be enabled when a cipher suite is negotiated and will cause the "no more data from client to server" test to fail ~30% of the time if enabled.)

Closes #231.