### PR TITLE
.appveyor.yml: use CPAN mirror at http://www.cpan.org

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -107,6 +107,7 @@ install:
   - set PATH=C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;%PATH%
   - perl -V
   - cd %APPVEYOR_BUILD_FOLDER%
+  - if /I "%ssleay_need_cpanm%" == "1" perl -pi.bak -e "s{\Qhttp://cpan.strawberryperl.com/\E}{http://www.cpan.org/}g" C:\strawberry\perl\lib\CPAN\Config.pm
   - if /I "%ssleay_need_cpanm%" == "1" cpan App::cpanminus
   - if /I "%ssleay_rename_mingw%" == "1" if exist C:\MinGW move C:\MinGW C:\MinGW-image
   - if /I "%ssleay_rename_mingw%" == "1" if exist C:\MinGW-W64 move C:\MinGW-W64 C:\MinGW-W64-image


### PR DESCRIPTION
To avoid intermittent problems with Strawberry Perl's CPAN mirror, set the CPAN command-line client's mirror to http://www.cpan.org in the AppVeyor configuration.

Closes #234.