### PR TITLE
03_use.t: declare plan before running tests

### DIFF
--- a/t/local/03_use.t
+++ b/t/local/03_use.t
@@ -5,9 +5,9 @@ use lib 'inc';
 
 use Test::Net::SSLeay;
 
-plan tests => 1;
-
 BEGIN {
+    plan tests => 1;
+
     use_ok('Net::SSLeay');
 }
 


### PR DESCRIPTION
`t/local/03_use.t` fails with Test::More 0.80 because it attempts to run a test - in this case, `use_ok` - before declaring a test plan. Ensure the plan is declared before the `use_ok` test runs.

Closes #237.