### PR TITLE
Remove RSAref checks from Makefile.PL

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,8 @@ Revision history for Perl extension Net::SSLeay.
 	  circumstances. Fixes GH-222. Thanks to dylc5190 for the report.
 	- Remove the dependency on the AES128-SHA cipher suite in the test script
 	  64_ticket_sharing.t. Fixes GH-231.
+	- Remove checks and warnings in Makefile.PL relating to the use of RSAref,
+	  which was removed from OpenSSL in version 0.9.7.
 
 1.89_03 2020-12-12
 	- Expose the following functions:

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -157,15 +157,12 @@ sub ssleay_get_build_opts {
       push @{$opts->{lib_paths}}, $_ if -d $_;
     }
 
-    my $rsaref  = ssleay_is_rsaref();
-
     print <<EOM;
 *** Be sure to use the same compiler and options to compile your OpenSSL, perl,
     and Net::SSLeay. Mixing and matching compilers is not supported.
 EOM
 
     if ($^O eq 'MSWin32') {
-        print "*** RSAREF build on Windows not supported out of box" if $rsaref;
         if ($win_link_statically) {
             # Link to static libs
             push @{ $opts->{lib_paths} }, "$prefix/lib/VC/static" if -d "$prefix/lib/VC/static";
@@ -211,11 +208,7 @@ EOM
         @{ $opts->{lib_links} } = map { $_ =~ s/32\b//g } @{ $opts->{lib_links} } if $Config{use64bitall};
     }
     else {
-        push @{ $opts->{lib_links} },
-             ($rsaref
-              ? qw( ssl crypto RSAglue rsaref z )
-              : qw( ssl crypto z )
-             );
+        push @{ $opts->{lib_links} }, qw( ssl crypto z );
 
         if (($Config{cc} =~ /aCC/i) && $^O eq 'hpux') {
             print "*** Enabling HPUX aCC options (+e)\n";
@@ -228,10 +221,6 @@ EOM
         }
     }
     return $opts;
-}
-
-sub ssleay_is_rsaref {
-    return $ENV{OPENSSL_RSAREF};
 }
 
 my $other_try = 0;

--- a/README
+++ b/README
@@ -92,24 +92,6 @@ OS X:
 ---------------------------------	
 You should also be able to use CPAN.pm to install this module if you like.
 
-Linking with RSAref is no longer supported (the patent issue is moot
-due to patent expiring). If you want to try it, you are on your own,
-but here's how it used to work...
-
-  For linking against RSAref the the OPENSSL_RSAREF environment variable like this:
-
-	OPENSSL_RSAREF=1 ./Makefile.PL -t  # builds and tests it, link against RSAref
-
-  You must previously have built OpenSSL with RSAref support (which
-  implies first building rsaref itself), I use the RSAglue method. File
-  librsaref.a must be found in one of the locations searched by linker
-  (-L switches). Usually this means that you have to rename rsaref.a to
-  librsaref.a and copy it to suitable directory, e.g. /usr/local/ssl/lib.
-
-  N.B. AFAIK the patent that made using RSAref necessary has expired, so
-  this should be nonissue by now.
-
-
 Problems (read this before sending mail)
 ----------------------------------------
 


### PR DESCRIPTION
Versions of OpenSSL prior to 0.9.7 contained a reference implementation of RSA known as RSAref. All versions of OpenSSL currently supported by Net-SSLeay no longer contain any RSAref code, so remove checks and warnings relating to it from `Makefile.PL` and remove all references to it from the documentation.

Closes #240.