### PR TITLE
Developer release 1.89_04

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Revision history for Perl extension Net::SSLeay.
 
-1.89_04 ????-??-??
+1.89_04 2021-01-13
 	- Fix crashes in the callback functions CTX_set_next_proto_select_cb() and
 	  CTX_set_alpn_select_cb() caused by the use of a pointer returned by
 	  SSL_select_next_proto() which may already have been freed under certain

--- a/helper_script/generate-test-pki
+++ b/helper_script/generate-test-pki
@@ -14,6 +14,8 @@ use File::Temp;
 use Getopt::Long qw(GetOptionsFromArray);
 use IPC::Run qw( start finish timeout );
 
+our $VERSION = '1.89_04';
+
 local $SIG{__DIE__} = sub {
     my ($cause) = @_;
 
@@ -1252,7 +1254,7 @@ C<generate-test-pki> - Generate a PKI for the Net-SSLeay test suite
 
 =head1 VERSION
 
-This document describes version 1.89_03 of C<generate-test-pki>.
+This document describes version 1.89_04 of C<generate-test-pki>.
 
 =head1 USAGE
 

--- a/inc/Test/Net/SSLeay.pm
+++ b/inc/Test/Net/SSLeay.pm
@@ -13,7 +13,7 @@ use File::Basename qw(dirname);
 use File::Spec::Functions qw( abs2rel catfile );
 use Test::Net::SSLeay::Socket;
 
-our $VERSION = '1.89_03';
+our $VERSION = '1.89_04';
 
 our @EXPORT_OK = qw(
     can_fork can_really_fork can_thread
@@ -372,7 +372,7 @@ Test::Net::SSLeay - Helper module for the Net-SSLeay test suite
 
 =head1 VERSION
 
-This document describes version 1.89_03 of Test::Net::SSLeay.
+This document describes version 1.89_04 of Test::Net::SSLeay.
 
 =head1 SYNOPSIS
 

--- a/inc/Test/Net/SSLeay/Socket.pm
+++ b/inc/Test/Net/SSLeay/Socket.pm
@@ -13,7 +13,7 @@ use Socket qw(
     inet_aton inet_ntoa pack_sockaddr_in unpack_sockaddr_in
 );
 
-our $VERSION = '1.89_03';
+our $VERSION = '1.89_04';
 
 my %PROTOS = (
     tcp => SOCK_STREAM,
@@ -134,7 +134,7 @@ Test::Net::SSLeay::Socket - Socket class for the Net-SSLeay test suite
 
 =head1 VERSION
 
-This document describes version 1.89_03 of Test::Net::SSLeay::Socket.
+This document describes version 1.89_04 of Test::Net::SSLeay::Socket.
 
 =head1 SYNOPSIS
 

--- a/lib/Net/SSLeay.pm
+++ b/lib/Net/SSLeay.pm
@@ -70,7 +70,7 @@ $Net::SSLeay::how_random = 512;
 #   inc/Test/Net/SSLeay.pm
 #   inc/Test/Net/SSLeay/Socket.pm
 #   lib/Net/SSLeay/Handle.pm
-$VERSION = '1.89_03';
+$VERSION = '1.89_04';
 
 @ISA = qw(Exporter);
 

--- a/lib/Net/SSLeay/Handle.pm
+++ b/lib/Net/SSLeay/Handle.pm
@@ -57,7 +57,7 @@ you need to add to your program is the tie function as in:
 use vars qw(@ISA @EXPORT_OK $VERSION);
 @ISA = qw(Exporter);
 @EXPORT_OK = qw(shutdown);
-$VERSION = '1.89_03';
+$VERSION = '1.89_04';
 
 my $Initialized;       #-- only _initialize() once
 my $Debug = 0;         #-- pretty hokey


### PR DESCRIPTION
Bump all version numbers from 1.89_03 to 1.89_04, and associate all reported changes since then with version 1.89_04. Also assign a version number to `$VERSION` in `helper_script/generate-test-pki`.

Closes #245.