### PR TITLE
README.md: replace Travis CI badge with GitHub Actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.org/radiator-software/p5-net-ssleay.svg?branch=master)](https://travis-ci.org/radiator-software/p5-net-ssleay)
-[![Build status](https://ci.appveyor.com/api/projects/status/ss6vl40o4otdq8ii/branch/master?svg=true)](https://ci.appveyor.com/project/h-vn/p5-net-ssleay/branch/master)
+[![GitHub Actions build status](https://github.com/radiator-software/p5-net-ssleay/workflows/CI/badge.svg?branch=master)](https://github.com/radiator-software/p5-net-ssleay/actions?query=workflow%3ACI)
+[![AppVeyor build status](https://ci.appveyor.com/api/projects/status/ss6vl40o4otdq8ii/branch/master?svg=true)](https://ci.appveyor.com/project/h-vn/p5-net-ssleay/branch/master)
 
 Net::SSLeay Perl module for using OpenSSL and LibreSSL -
 https://metacpan.org/release/Net-SSLeay


### PR DESCRIPTION
Since we now use GitHub Actions in place of Travis CI, remove the Travis CI build status badge from `README.md` and replace it with the GitHub Actions one.