### PR TITLE
Makefile.PL: standardise preamble

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,11 +1,12 @@
-use 5.8.1;
-
+use 5.008001;
+use utf8;
 use strict;
 use warnings;
-use ExtUtils::MakeMaker;
+
 use Config;
-use File::Spec;
+use ExtUtils::MakeMaker;
 use File::Basename ();
+use File::Spec;
 use Symbol qw(gensym);
 
 # Define this to one if you want to link the openssl libraries statically into 


### PR DESCRIPTION
Rewrite the preamble in `Makefile.PL` to match the style used in `Test::Net::SSLeay::*` and the test suite scripts:

- Enforce the minimum supported Perl version by decimal number rather than version string.
- Import utf8, since the source contains UTF-8 characters; this should fix the encoding error in Sampo's surname on Net::SSLeay's MetaCPAN pages.
- Sort imports lexicographically.