### PR TITLE
Clarify libssl version support policy

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for Perl extension Net::SSLeay.
 
+1.89_05 ????-??-??
+	- Clarify libssl version support policy: all stable versions of OpenSSL in
+	  the 0.9.8 - 1.1.1 branches (with the exception of 0.9.8 - 0.9.8b) and all
+	  stable releases of LibreSSL in the 2.0 - 3.1 series are supported.
+
 1.89_04 2021-01-13
 	- Fix crashes in the callback functions CTX_set_next_proto_select_cb() and
 	  CTX_set_alpn_select_cb() caused by the use of a pointer returned by

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -312,7 +312,12 @@ sub check_openssl_version {
 
 	if ( ($major, $minor, $letter) = $output =~ /^OpenSSL\s+(\d+\.\d+)\.(\d+)([a-z]?)/ ) {
 	    print "*** Found OpenSSL-${major}.${minor}${letter} installed in $prefix\n";
-	} elsif ( ($major, $minor) = $output =~ /^LibreSSL\s+(\d+\.\d+)\.(\d+)/ ) {
+	} elsif ( ($major, $minor) = $output =~ /^LibreSSL\s+(\d+\.\d+)(?:\.(\d+))?/ ) {
+	    # LibreSSL 2.0.x releases only identify themselves as "LibreSSL 2.0",
+	    # with no patch release number
+	    if ( !defined $minor ) {
+	        $minor = "x";
+	    }
 	    print "*** Found LibreSSL-${major}.${minor} installed in $prefix\n";
 	} else {
             die <<EOM
@@ -324,7 +329,7 @@ EOM
         }
     }
 
-    if ($major < 0.9 || ($major == 0.9 && $minor < 3)) {
+    if ($major < 0.9 || ($major == 0.9 && $minor < 8)) {
         print <<EOM;
 *** That's too old!
     Please upgrade OpenSSL to the latest version (http://www.openssl.org/)

--- a/README
+++ b/README
@@ -19,30 +19,40 @@ Prerequisites
 
 Perl 5.8.1 or higher.
 
-OpenSSL-0.9.6j through to at least OpenSSL-1.1 and probably later
-	       http://www.openssl.org/ - On Linux, you can either build and
-	       install OpenSSL from scratch (its very portable) or you can
-	       install the appropriate OpenSSL 'devel' package for your Linux
-	       distribution: (rpm openssl-devel, deb libssl-dev).
+One of the following libssl implementations:
 
+* Any stable release of OpenSSL (https://www.openssl.org) in the
+  0.9.8 - 1.1.1 branches, except for OpenSSL 0.9.8 - 0.9.8b.
+* Any stable release of LibreSSL (https://www.libressl.org) in the
+  2.0 - 3.1 series.
 
-Note: SSLeay is no longer supported. If you want to use Net::SSLeay with
-      SSLeay or early versions of OpenSSL, use version 1.03. The support
-      for SSLeay was dropped due to nobody maintaining it (all active
-      work goes on with OpenSSL) and due to incompatible API changes
-      in OpenSSL-0.9.2b. OpenSSL-0.9.1c support has also been dropped,
-      version 1.03 was the last one to support that.
+Net-SSLeay may not compile or pass its tests against newer releases
+than the ones listed above due to libssl API incompatibilities, or, in
+the case of LibreSSL, because of deviations from the libssl API.
 
-LibreSSL is also supported.
+If you are using a version of OpenSSL or LibreSSL distributed by your
+operating system vendor, you may also need to install a "development"
+package containing the header files that correspond to the OpenSSL or
+LibreSSL library package. Examples include:
 
-You should use the same C compiler and options to compile OpenSSL,
-perl, and Net::SSLeay. This is the only supported configuration.
-If you insist on using different compilers (perhaps because you
-obtained either OpenSSL or perl as binaries from a vendor and they
-used a compiler that you do not have) then all requests for support
-will be ignored. If the only way for you to use the same compiler
-for all three components is to recompile your openssl or perl, then
-that is exactly what I expect you to do before asking for support.
+* libssl-dev for OpenSSL on Debian and Ubuntu;
+* openssl-devel for OpenSSL on Red Hat Enterprise Linux and Fedora.
+
+On Linux, zlib is also required, even when libssl is built without
+support for TLS compression. zlib is probably also available via your
+Linux distribution's package manager, e.g.:
+
+* zlib1g-dev on Debian and Ubuntu;
+* zlib-devel on Red Hat Enterprise Linux and Fedora.
+
+A future version of Net-SSLeay will remove this requirement when
+building against a libssl without support for TLS compression.
+
+The same C compiler and options should be used to compile all of Perl,
+OpenSSL/LibreSSL, and Net-SSLeay. Mixing compilers and options often
+leads to build errors or run-time malfunctions that are difficult to
+debug.
+
 
 Installing
 ----------
@@ -128,9 +138,6 @@ If build fails,
     but as I have not yet sorted it out, you'll simply have to ignore it
   - if you installed OpenSSL from some distribution, try getting a fresh
     copy from www.openssl.org and recompiling and installing it yourself
-  - make sure you are not being confused by the fact that OpenSSL-0.9.3
-    changed the location of include files to /usr/local/ssl/include/openssl/*
-    Consider deleting all old bogus headers
   - if using newer than supported OpenSSL, please downgrade to supported
     version to see if it makes difference
   - you must compile the module, perl, and openssl with the same C compiler

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -45,11 +45,11 @@
  *    for example: there already exists: PEM_get_string_X509_CRL + PEM_get_string_X509_REQ and you want
  *    to add PEM_get_string_SOMETHING - then no need to follow 3/ (do not prefix with "P_")
  *
- * Support for different openssl versions, different platforms, different compilers:
+ * Support for different Perl versions, libssl implementations, platforms, and compilers:
  *
- * 1/ SSleay.xs is expected to build/pass test suite
- *    - with openssl 0.9.6 and newer versions
- *    - with perl 5.8 and newer versions
+ * 1/ Net-SSLeay has a version support policy for Perl and OpenSSL/LibreSSL (described in the
+ *    "Prerequisites" section in the README file). The test suite must pass when run on any
+ *    of those version combinations.
  *
  * 2/ Fix all compiler warnings - we expect 100% clean build
  *

--- a/TODO
+++ b/TODO
@@ -25,16 +25,3 @@
 * Improve the search for installed openssl and zlib libs so it will recognize
   them only runtime is installed without the headers required for building the
   module.
-
-* Instruction on how to the the prerequisites
-  Installing OpenSSL
-  ------------------
-  On Debian and Debian based Operating systems one can install
-  by typing:
-
-  apt-get install libssl-dev
-
-  On some Ubuntu versions libssl-dev seems to be broken as it doesn't depend on
-  zlib1g-dev.
-
-  apt-get install zlib1g fixes that.

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -38,13 +38,57 @@ Net::SSLeay - Perl extension for using OpenSSL
 
 =head1 DESCRIPTION
 
-L<Net::SSLeay> module contains perl bindings to openssl (L<http://www.openssl.org|http://www.openssl.org>) library.
+This module provides Perl bindings for libssl (an SSL/TLS API) and libcrypto (a
+cryptography API).
 
-B<COMPATIBILITY NOTE:> L<Net::SSLeay> cannot be built with pre-0.9.3 openssl. It is strongly recommended
-to use at least 0.9.7 (as older versions are not tested during development). Some low level API functions
-may be available with certain openssl versions.
+=head1 COMPATIBILITY
 
-It is compatible with OpenSSL 1.0 and 1.1. Some functions are not available under OpenSSL 1.1.
+Net::SSLeay supports the following libssl implementations:
+
+=over
+
+=item *
+
+Any stable release of L<OpenSSL|https://www.openssl.org> in the 0.9.8 - 1.1.1
+branches, except for OpenSSL 0.9.8 - 0.9.8b.
+
+=item *
+
+Any stable release of L<LibreSSL|https://www.libressl.org> in the 2.0 - 3.1
+series.
+
+=back
+
+Net::SSLeay may not function as expected with newer releases than the ones
+listed above due to libssl API incompatibilities, or, in the case of LibreSSL,
+because of deviations from the libssl API.
+
+Net::SSLeay is only as secure as the underlying libssl implementation you use.
+Although Net::SSLeay maintains compatibility with old versions of OpenSSL and
+LibreSSL, it is B<strongly recommended> that you use a version of OpenSSL or
+LibreSSL that is supported by the OpenSSL/LibreSSL developers and/or your
+operating system vendor. Many unsupported versions of OpenSSL and LibreSSL are
+known to contain severe security vulnerabilities. Refer to the
+L<OpenSSL Release Strategy|https://www.openssl.org/policies/releasestrat.html>
+and L<LibreSSL Support Schedule|https://www.libressl.org/releases.html> for
+information on which versions are currently supported.
+
+The libssl API has changed significantly since OpenSSL 0.9.8: hundreds of
+functions have been added, deprecated or removed in the intervening versions.
+Although this documentation lists all of the functions and constants that
+Net::SSLeay may expose, they will not be available for use if they are missing
+from the underlying libssl implementation. Refer to the compatibility notes in
+this documentation, as well as the OpenSSL/LibreSSL manual pages, for
+information on which OpenSSL/LibreSSL versions support each function or
+constant. At run-time, you can check whether a function or constant is exposed
+before calling it using the following convention:
+
+    if ( defined &Net::SSLeay::libssl_function ) {
+        # libssl_function() (or SSL_libssl_function()) is available
+        Net::SSLeay::libssl_function(...);
+    }
+
+=head1 OVERVIEW
 
 L<Net::SSLeay> module basically comprise of:
 


### PR DESCRIPTION
In the documentation, clarify that Net-SSLeay supports the following versions of libssl:

* All stable releases in the OpenSSL 0.9.8 - 1.1.1 branches, with the exception of OpenSSL 0.9.8 - 0.9.8b.
* All stable releases of LibreSSL in the 2.0 - 3.1 branches.

Also expand on compatibility issues that may arise between different libssl versions in `SSLeay.pod`.

Provide some rudimentary enforcement of the above minimum version requirements in `Makefile.PL`.