### PR TITLE
Stable release 1.90

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,22 @@
 Revision history for Perl extension Net::SSLeay.
 
+1.90 2021-01-21
+	- New stable release incorporating all changes from developer releases
+	  1.89_01 to 1.89_05.
+	- Summary of major changes since version 1.88:
+	  - Formalised libssl version support policy: all stable versions of OpenSSL
+	    in the 0.9.8 - 1.1.1 branches (with the exception of 0.9.8 - 0.9.8b) and
+	    all stable releases of LibreSSL in the 2.0 - 3.1 series are supported.
+	    The LibreSSL 3.2 series is not yet fully supported because its TLSv1.3
+	    implementation is not currently libssl-compatible.
+	  - Added support for LibreSSL on Windows when built with Visual C++.
+	  - Exposed P_X509_CRL_add_extensions, several SSL_CIPHER functions, and
+	    several stack functions.
+	  - Fixed crashes in the callback functions CTX_set_next_proto_select_cb and
+	    CTX_set_alpn_select_cb.
+	  - The test suite is now compatible with OpenSSL 1.1.1e onwards, as well as
+	    OpenSSL security level 2 (the default on many Linux distributions).
+
 1.89_05 2021-01-21
 	- Expose SSL_get_ciphers. Thanks to github user dylc5190.
 	- Expose SSL_CIPHER_get_version and fix SSL_CIPHER_description

--- a/helper_script/generate-test-pki
+++ b/helper_script/generate-test-pki
@@ -14,7 +14,7 @@ use File::Temp;
 use Getopt::Long qw(GetOptionsFromArray);
 use IPC::Run qw( start finish timeout );
 
-our $VERSION = '1.89_05';
+our $VERSION = '1.90';
 
 local $SIG{__DIE__} = sub {
     my ($cause) = @_;
@@ -1254,7 +1254,7 @@ C<generate-test-pki> - Generate a PKI for the Net-SSLeay test suite
 
 =head1 VERSION
 
-This document describes version 1.89_05 of C<generate-test-pki>.
+This document describes version 1.90 of C<generate-test-pki>.
 
 =head1 USAGE
 

--- a/inc/Test/Net/SSLeay.pm
+++ b/inc/Test/Net/SSLeay.pm
@@ -13,7 +13,7 @@ use File::Basename qw(dirname);
 use File::Spec::Functions qw( abs2rel catfile );
 use Test::Net::SSLeay::Socket;
 
-our $VERSION = '1.89_05';
+our $VERSION = '1.90';
 
 our @EXPORT_OK = qw(
     can_fork can_really_fork can_thread
@@ -372,7 +372,7 @@ Test::Net::SSLeay - Helper module for the Net-SSLeay test suite
 
 =head1 VERSION
 
-This document describes version 1.89_05 of Test::Net::SSLeay.
+This document describes version 1.90 of Test::Net::SSLeay.
 
 =head1 SYNOPSIS
 

--- a/inc/Test/Net/SSLeay/Socket.pm
+++ b/inc/Test/Net/SSLeay/Socket.pm
@@ -13,7 +13,7 @@ use Socket qw(
     inet_aton inet_ntoa pack_sockaddr_in unpack_sockaddr_in
 );
 
-our $VERSION = '1.89_05';
+our $VERSION = '1.90';
 
 my %PROTOS = (
     tcp => SOCK_STREAM,
@@ -134,7 +134,7 @@ Test::Net::SSLeay::Socket - Socket class for the Net-SSLeay test suite
 
 =head1 VERSION
 
-This document describes version 1.89_05 of Test::Net::SSLeay::Socket.
+This document describes version 1.90 of Test::Net::SSLeay::Socket.
 
 =head1 SYNOPSIS
 

--- a/lib/Net/SSLeay.pm
+++ b/lib/Net/SSLeay.pm
@@ -70,7 +70,7 @@ $Net::SSLeay::how_random = 512;
 #   inc/Test/Net/SSLeay.pm
 #   inc/Test/Net/SSLeay/Socket.pm
 #   lib/Net/SSLeay/Handle.pm
-$VERSION = '1.89_05';
+$VERSION = '1.90';
 
 @ISA = qw(Exporter);
 

--- a/lib/Net/SSLeay/Handle.pm
+++ b/lib/Net/SSLeay/Handle.pm
@@ -57,7 +57,7 @@ you need to add to your program is the tie function as in:
 use vars qw(@ISA @EXPORT_OK $VERSION);
 @ISA = qw(Exporter);
 @EXPORT_OK = qw(shutdown);
-$VERSION = '1.89_05';
+$VERSION = '1.90';
 
 my $Initialized;       #-- only _initialize() once
 my $Debug = 0;         #-- pretty hokey


### PR DESCRIPTION
Bump all version numbers from 1.89_04 to 1.90, and summarise major changes since 1.88.

Closes #251.