### PR TITLE
Remove references to rt.cpan.org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,15 +11,13 @@ Net::SSLeay is Module::Install Perl module. Module::Install is not
 needed when building from release packages.
 
 ## Issue tracking
-Issues can be currently reported using CPAN [bug
-tracker](https://rt.cpan.org/Public/Dist/Display.html?Name=net-ssleay)
-or [GitHub](https://github.com/radiator-software/p5-net-ssleay)
-
-Choose the method that is more convenient for you.
+Please open an [issue](https://github.com/radiator-software/p5-net-ssleay/issues)
+on GitHub to report any bugs or installation issues you encounter.
 
 ## Patches and code contributions
-GitHub pull requests are preferred, but please do not hesitate to use
-the CPAN bug tracker or any other means to send your contribution.
+Bug fixes, feature additions and other contributions to Net-SSLeay are
+welcomed - please open a [pull request](https://github.com/radiator-software/p5-net-ssleay/pulls)
+on GitHub.
 
 All contributions to Net-SSLeay are assumed to be provided under the
 terms of the Artistic License 2.0. See [`LICENSE`](LICENSE) for details.

--- a/Changes
+++ b/Changes
@@ -8,6 +8,8 @@ Revision history for Perl extension Net::SSLeay.
 	- Clarify libssl version support policy: all stable versions of OpenSSL in
 	  the 0.9.8 - 1.1.1 branches (with the exception of 0.9.8 - 0.9.8b) and all
 	  stable releases of LibreSSL in the 2.0 - 3.1 series are supported.
+	- Direct bug reports to the GitHub repository, since rt.cpan.org will shut
+	  down on 2021-03-01.
 
 1.89_04 2021-01-13
 	- Fix crashes in the callback functions CTX_set_next_proto_select_cb() and

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -75,7 +75,7 @@ my %eumm_args = (
         web => 'https://github.com/radiator-software/p5-net-ssleay',
       },
       bugtracker  => {
-        web => 'https://rt.cpan.org/Public/Dist/Display.html?Name=net-ssleay',
+        web => 'https://github.com/radiator-software/p5-net-ssleay/issues',
       },
     },
     no_index => { directory => [ qw(helper_script examples) ] },

--- a/README
+++ b/README
@@ -102,7 +102,7 @@ OS X:
 ---------------------------------	
 You should also be able to use CPAN.pm to install this module if you like.
 
-Problems (read this before sending mail)
+Problems (read this before filing a bug)
 ----------------------------------------
 
 Please, do not send bug report before you have

--- a/helper_script/generate-test-pki
+++ b/helper_script/generate-test-pki
@@ -1955,28 +1955,9 @@ L<openssl-x509(1)>.
 =head1 BUGS
 
 If you encounter a problem with this program that you believe is a bug, please
-report it in one of the following ways:
-
-=over 4
-
-=item *
-
-create a new issue under the
-L<Net-SSLeay GitHub project|https://github.com/radiator-software/p5-net-ssleay/issues/new>;
-
-=item *
-
-open a ticket using the
-L<CPAN RT bug tracker's web interface|https://rt.cpan.org/Public/Bug/Report.html?Queue=Net-SSLeay>;
-
-=item *
-
-send an email to the
-L<CPAN RT bug tracker's bug-reporting system|mailto:bug-Net-SSLeay@rt.cpan.org>.
-
-=back
-
-Please make sure your bug report includes the following information:
+L<create a new issue|https://github.com/radiator-software/p5-net-ssleay/issues/new>
+in the Net-SSLeay GitHub repository. Please make sure your bug report includes
+the following information:
 
 =over
 

--- a/inc/Test/Net/SSLeay.pm
+++ b/inc/Test/Net/SSLeay.pm
@@ -569,28 +569,9 @@ on failure.
 =head1 BUGS
 
 If you encounter a problem with this module that you believe is a bug, please
-report it in one of the following ways:
-
-=over 4
-
-=item *
-
-create a new issue under the
-L<Net-SSLeay GitHub project|https://github.com/radiator-software/p5-net-ssleay/issues/new>;
-
-=item *
-
-open a ticket using the
-L<CPAN RT bug tracker's web interface|https://rt.cpan.org/Public/Bug/Report.html?Queue=Net-SSLeay>;
-
-=item *
-
-send an email to the
-L<CPAN RT bug tracker's bug-reporting system|mailto:bug-Net-SSLeay@rt.cpan.org>.
-
-=back
-
-Please make sure your bug report includes the following information:
+L<create a new issue|https://github.com/radiator-software/p5-net-ssleay/issues/new>
+in the Net-SSLeay GitHub repository. Please make sure your bug report includes
+the following information:
 
 =over
 

--- a/inc/Test/Net/SSLeay/Socket.pm
+++ b/inc/Test/Net/SSLeay/Socket.pm
@@ -276,28 +276,9 @@ from Net-SSLeay test scripts.
 =head1 BUGS
 
 If you encounter a problem with this module that you believe is a bug, please
-report it in one of the following ways:
-
-=over 4
-
-=item *
-
-create a new issue under the
-L<Net-SSLeay GitHub project|https://github.com/radiator-software/p5-net-ssleay/issues/new>;
-
-=item *
-
-open a ticket using the
-L<CPAN RT bug tracker's web interface|https://rt.cpan.org/Public/Bug/Report.html?Queue=Net-SSLeay>;
-
-=item *
-
-send an email to the
-L<CPAN RT bug tracker's bug-reporting system|mailto:bug-Net-SSLeay@rt.cpan.org>.
-
-=back
-
-Please make sure your bug report includes the following information:
+L<create a new issue|https://github.com/radiator-software/p5-net-ssleay/issues/new>
+in the Net-SSLeay GitHub repository. Please make sure your bug report includes
+the following information:
 
 =over
 

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -9920,31 +9920,10 @@ Solutions:
 
 =head1 BUGS
 
-If you encounter a problem with this module that you believe is a bug,
-please report it in one of the following ways:
-
-=over
-
-=item *
-
+If you encounter a problem with this module that you believe is a bug, please
 L<create a new issue|https://github.com/radiator-software/p5-net-ssleay/issues/new>
-under the Net-SSLeay GitHub project at
-L<https://github.com/radiator-software/p5-net-ssleay>;
-
-=item *
-
-L<open a ticket|https://rt.cpan.org/Ticket/Create.html?Queue=Net-SSLeay> using
-the CPAN RT bug tracker's web interface at
-L<https://rt.cpan.org/Dist/Display.html?Queue=Net-SSLeay>;
-
-=item *
-
-send an email to the CPAN RT bug tracker at
-L<bug-Net-SSLeay@rt.cpan.org|mailto:bug-Net-SSLeay@rt.cpan.org>.
-
-=back
-
-Please make sure your bug report includes the following information:
+in the Net-SSLeay GitHub repository. Please make sure your bug report includes
+the following information:
 
 =over
 

--- a/lib/Net/SSLeay/Handle.pm
+++ b/lib/Net/SSLeay/Handle.pm
@@ -350,31 +350,10 @@ Please see Net-SSLeay-Handle-0.50/Changes file.
 
 =head1 BUGS
 
-If you encounter a problem with this module that you believe is a bug,
-please report it in one of the following ways:
-
-=over
-
-=item *
-
+If you encounter a problem with this module that you believe is a bug, please
 L<create a new issue|https://github.com/radiator-software/p5-net-ssleay/issues/new>
-under the Net-SSLeay GitHub project at
-L<https://github.com/radiator-software/p5-net-ssleay>;
-
-=item *
-
-L<open a ticket|https://rt.cpan.org/Ticket/Create.html?Queue=Net-SSLeay> using
-the CPAN RT bug tracker's web interface at
-L<https://rt.cpan.org/Dist/Display.html?Queue=Net-SSLeay>;
-
-=item *
-
-send an email to the CPAN RT bug tracker at
-L<bug-Net-SSLeay@rt.cpan.org|mailto:bug-Net-SSLeay@rt.cpan.org>.
-
-=back
-
-Please make sure your bug report includes the following information:
+in the Net-SSLeay GitHub repository. Please make sure your bug report includes
+the following information:
 
 =over
 


### PR DESCRIPTION
Since rt.cpan.org is shutting down on 2021-03-01, remove all references to it from the documentation and direct all bug reports to the GitHub repository.

Closes #255.