### PR TITLE
CONTRIBUTING.md: several minor fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,22 +1,18 @@
 # How to contribute
 
-Contributions to Net::SSLeay are welcome.
+Contributions to Net-SSLeay are welcome.
 
 ## Source code repository
-The Net::SSLeay source code is currently hosted on
+The Net-SSLeay source code is currently hosted on
 [GitHub](https://github.com/radiator-software/p5-net-ssleay).
-
-If you clone Net::SSLeay from GitHub, a pre-requisite for building
-Net::SSLeay is Module::Install Perl module. Module::Install is not
-needed when building from release packages.
 
 ## Issue tracking
 Please open an [issue](https://github.com/radiator-software/p5-net-ssleay/issues)
 on GitHub to report any bugs or installation issues you encounter.
 
 ## Patches and code contributions
-Bug fixes, feature additions and other contributions to Net-SSLeay are
-welcomed - please open a [pull request](https://github.com/radiator-software/p5-net-ssleay/pulls)
+Please submit your bug fixes and feature additions by opening a
+[pull request](https://github.com/radiator-software/p5-net-ssleay/pulls)
 on GitHub.
 
 All contributions to Net-SSLeay are assumed to be provided under the


### PR DESCRIPTION
* The distribution's name is "Net-SSLeay" rather than "Net::SSLeay".
* Module::Install is no longer required to build Net-SSLeay from source, so remove the paragraph saying so.
* Minor language improvements.

Closes #257.