### PR TITLE
Update tests to fix problems seen on older Perl Windows versions

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 Revision history for Perl extension Net::SSLeay.
 
+????
+	- Update tests to call close() to avoid problems seen with
+	  test 44_sess.t, and possibly other tests, running on older
+	  Windows Perl versions. Also add some missing calls in tests
+	  to shutdown and free ssl structures.
+
 1.90 2021-01-21
 	- New stable release incorporating all changes from developer releases
 	  1.89_01 to 1.89_05.

--- a/t/local/06_tcpecho.t
+++ b/t/local/06_tcpecho.t
@@ -30,7 +30,7 @@ my $pid;
         ok(Net::SSLeay::tcp_write_all(uc($got)), 'tcp_write_all');
 
         close Net::SSLeay::SSLCAT_S;
-        $server->close();
+        $server->close() || die("server listen socket close: $!");
 
         exit;
     }
@@ -41,6 +41,8 @@ my @results;
     my ($got) = Net::SSLeay::tcpcat($server->get_addr(), $server->get_port(), $msg);
     push @results, [ $got eq uc($msg), 'sent and received correctly' ];
 }
+
+$server->close() || die("client listen socket close: $!");
 
 waitpid $pid, 0;
 push @results, [ $? == 0, 'server exited with 0' ];

--- a/t/local/07_sslecho.t
+++ b/t/local/07_sslecho.t
@@ -94,11 +94,11 @@ $ENV{RND_SEED} = '1234567890123456789012345678901234567890';
 	    }
 
             Net::SSLeay::free($ssl);
-            close $ns;
+            close($ns) || die("server close: $!");
         }
 
         Net::SSLeay::CTX_free($ctx);
-        $server->close();
+	$server->close() || die("server listen socket close: $!");
 
         exit;
     }
@@ -133,7 +133,7 @@ my @results;
     Net::SSLeay::CTX_free($ctx);
 
     shutdown($s, 2);
-    close $s;
+    close($s) || die("client close: $!");;
 
 }
 
@@ -199,9 +199,9 @@ my @results;
 	    push @results, [Net::SSLeay::shutdown($ssl3) >= 0, 'client side ssl3 shutdown' ];
             shutdown $s3, 2;
 
-            close $s1;
-            close $s2;
-            close $s3;
+            close($s1) || die("client close s1: $!");;
+            close($s2) || die("client close s2: $!");;
+            close($s3) || die("client close s3: $!");;
 
             Net::SSLeay::free($ssl1);
             Net::SSLeay::free($ssl2);
@@ -314,8 +314,10 @@ my @results;
     Net::SSLeay::free($ssl);
     Net::SSLeay::CTX_free($ctx);
 
-    close $s;
+    close($s) || die("client close: $!");
 }
+
+$server->close() || die("client listen socket close: $!");
 
 waitpid $pid, 0;
 push @results, [ $? == 0, 'server exited with 0' ];

--- a/t/local/07_sslecho.t
+++ b/t/local/07_sslecho.t
@@ -133,7 +133,7 @@ my @results;
     Net::SSLeay::CTX_free($ctx);
 
     shutdown($s, 2);
-    close($s) || die("client close: $!");;
+    close($s) || die("client close: $!");
 
 }
 
@@ -199,9 +199,9 @@ my @results;
 	    push @results, [Net::SSLeay::shutdown($ssl3) >= 0, 'client side ssl3 shutdown' ];
             shutdown $s3, 2;
 
-            close($s1) || die("client close s1: $!");;
-            close($s2) || die("client close s2: $!");;
-            close($s3) || die("client close s3: $!");;
+            close($s1) || die("client close s1: $!");
+            close($s2) || die("client close s2: $!");
+            close($s3) || die("client close s3: $!");
 
             Net::SSLeay::free($ssl1);
             Net::SSLeay::free($ssl2);

--- a/t/local/11_read.t
+++ b/t/local/11_read.t
@@ -59,8 +59,11 @@ sub server
 
 	    my $msg = Net::SSLeay::read($ssl);
 	    Net::SSLeay::write($ssl, $msg);
+	    Net::SSLeay::shutdown($ssl);
+	    Net::SSLeay::free($ssl);
+	    close($cl) || die("client close: $!");
 	}
-    $server->close();
+	$server->close() || die("server listen socket close: $!");
 	exit(0);
     }
 }
@@ -90,7 +93,9 @@ sub client
 
 	Net::SSLeay::shutdown($ssl);
 	Net::SSLeay::free($ssl);
+	close($cl) || die("client close: $!");
     }
+    $server->close() || die("client listen socket close: $!");
     return;
 }
 

--- a/t/local/36_verify.t
+++ b/t/local/36_verify.t
@@ -295,7 +295,7 @@ sub client {
 	test_wildcard_checks($ctx, $cl) if $task eq 'wildcard_checks';
 	last if $task eq 'finish'; # Leaves $cl alive
 
-	close($cl) || die("client close: $!");;
+	close($cl) || die("client close: $!");
     }
 
     # Tell the server to quit and see that our connection is still up
@@ -308,7 +308,7 @@ sub client {
     Net::SSLeay::shutdown($ssl);
     ok($end eq Net::SSLeay::ssl_read_all($ssl), 'Successful termination');
     Net::SSLeay::free($ssl);
-    close($cl) || die("client final close: $!");;
+    close($cl) || die("client final close: $!");
     return;
 }
 

--- a/t/local/40_npn_support.t
+++ b/t/local/40_npn_support.t
@@ -58,8 +58,8 @@ my @results;
         Net::SSLeay::ssl_write_all($ssl, uc($got));
         Net::SSLeay::free($ssl);
         Net::SSLeay::CTX_free($ctx);
-        close $ns;
-        $server->close();
+        close($ns) || die("server close: $!");
+        $server->close() || die("server listen socket close: $!");
         exit;
     }
 }
@@ -84,7 +84,8 @@ my @results;
 
     Net::SSLeay::free($ssl1);
     Net::SSLeay::CTX_free($ctx1);
-    close $s1;
+    close($s1) || die("client close: $!");
+    $server->close() || die("client listen socket close: $!");
 }
 
 waitpid $pid, 0;

--- a/t/local/41_alpn_support.t
+++ b/t/local/41_alpn_support.t
@@ -63,8 +63,8 @@ my @results;
         Net::SSLeay::ssl_write_all($ssl, uc($got));
         Net::SSLeay::free($ssl);
         Net::SSLeay::CTX_free($ctx);
-        close $ns;
-        $server->close();
+        close($ns) || die("server close: $!");
+        $server->close() || die("server listen socket close: $!");
         exit;
     }
 }
@@ -88,7 +88,8 @@ my @results;
 
     Net::SSLeay::free($ssl1);
     Net::SSLeay::CTX_free($ctx1);
-    close $s1;
+    close($s1) || die("client close: $!");
+    $server->close() || die("client listen socket close: $!");
 }
 
 waitpid $pid, 0;

--- a/t/local/42_info_callback.t
+++ b/t/local/42_info_callback.t
@@ -36,7 +36,9 @@ my $server = tcp_socket();
 	    for(1,2) {
 		last if Net::SSLeay::shutdown($ssl)>0;
 	    }
+	    close($cl) || die("server close: $!");
 	}
+	$server->close() || die("server listen socket close: $!");
         exit;
     }
 }
@@ -90,6 +92,8 @@ sub client {
     } else {
 	fail("$where: @states");
     }
+    close($cl) || die("client close: $!");
+
 }
 
 my $expect = qr{^
@@ -101,5 +105,6 @@ my $expect = qr{^
 
 client('ctx',$expect);
 client('ssl',$expect);
+$server->close() || die("client listen socket close: $!");
 waitpid $pid, 0;
 

--- a/t/local/43_misc_functions.t
+++ b/t/local/43_misc_functions.t
@@ -96,6 +96,10 @@ my $server = tcp_socket();
 	# Echo back the termination request from client
 	my $end = Net::SSLeay::read($ssl);
 	Net::SSLeay::write($ssl, $end);
+	Net::SSLeay::shutdown($ssl);
+	Net::SSLeay::free($ssl);
+	close($cl) || die("server close: $!");
+	$server->close() || die("server listen socket close: $!");
 	exit(0);
     }
 }
@@ -121,6 +125,10 @@ sub client {
     my $end = "end";
     Net::SSLeay::write($ssl, $end);
     ok($end eq Net::SSLeay::read($ssl),  'Successful termination');
+    Net::SSLeay::shutdown($ssl);
+    Net::SSLeay::free($ssl);
+    close($cl) || die("client close: $!");
+    $server->close() || die("client listen socket close: $!");
     return;
 }
 

--- a/t/local/45_exporter.t
+++ b/t/local/45_exporter.t
@@ -66,7 +66,9 @@ sub server
 
 	    Net::SSLeay::shutdown($ssl);
 	    Net::SSLeay::free($ssl);
+	    close($cl) || die("server close: $!");
 	}
+	$server->close() || die("server listen socket close: $!");
 	exit(0);
     }
 }
@@ -90,6 +92,7 @@ sub client {
 
             Net::SSLeay::shutdown($ssl);
             Net::SSLeay::free($ssl);
+            close($cl) || die("client close: $!");
         }
         else {
             SKIP: {
@@ -97,6 +100,7 @@ sub client {
             }
         }
     }
+    $server->close() || die("client listen socket close: $!");
 
     return 1;
 }


### PR DESCRIPTION
44_sess.t sometimes failed with older Windows Perls such as 5.14, 5.16 and
5.18. When close() was explicitly called for sockets, the failures seem to go
away. Other tests that were missing close() were also updated. Some missing
calls to shutdown and free ssl structures were added.

Closes #262