### PR TITLE
GH-266 Fix X509_STORE_CTX_init return value to int.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Perl extension Net::SSLeay.
 
 ????
+	- Correct X509_STORE_CTX_init() return value to integer. Previous
+	  versions of Net::SSLeay return nothing.
 	- Update tests to call close() to avoid problems seen with
 	  test 44_sess.t, and possibly other tests, running on older
 	  Windows Perl versions. Also add some missing calls in tests

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -4103,7 +4103,7 @@ X509V3_EXT_d2i(ext)
 X509_STORE_CTX *
 X509_STORE_CTX_new()
 
-void
+int
 X509_STORE_CTX_init(ctx, store=NULL, x509=NULL, chain=NULL)
      X509_STORE_CTX * ctx
      X509_STORE * store

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -7509,6 +7509,8 @@ It must be called before each call to X509_verify_cert().
  # $chain - value corresponding to openssl's STACK_OF(X509) structure (optional)
  #
  # returns: 1 on success, 0 on failure
+ #
+ # Note: returns nothing with Net::SSLeay 1.90 and earlier.
 
 Check openssl doc L<https://www.openssl.org/docs/man1.0.2/crypto/X509_STORE_CTX_init.html|https://www.openssl.org/docs/man1.0.2/crypto/X509_STORE_CTX_init.html>
 

--- a/t/local/32_x509_get_cert_info.t
+++ b/t/local/32_x509_get_cert_info.t
@@ -8,8 +8,8 @@ use Test::Net::SSLeay qw(
 use lib '.';
 
 my $tests =   ( is_openssl() && Net::SSLeay::SSLeay < 0x10100003 ) || is_libressl()
-            ? 721
-            : 724;
+            ? 723
+            : 726;
 
 plan tests => $tests;
 
@@ -373,8 +373,8 @@ Net::SSLeay::X509_STORE_CTX_set_cert($ctx,$x509);
 my $ca_filename = data_file_path('root-ca.cert.pem');
 my $ca_bio = Net::SSLeay::BIO_new_file($ca_filename, 'rb');
 my $ca_x509 = Net::SSLeay::PEM_read_bio_X509($ca_bio);
-Net::SSLeay::X509_STORE_add_cert($x509_store,$ca_x509);
-Net::SSLeay::X509_STORE_CTX_init($ctx, $x509_store, $x509);
+is (Net::SSLeay::X509_STORE_add_cert($x509_store,$ca_x509), 1, 'X509_STORE_add_cert');
+is (Net::SSLeay::X509_STORE_CTX_init($ctx, $x509_store, $x509), 1, 'X509_STORE_CTX_init');
 SKIP: {
     skip('X509_STORE_CTX_get0_cert requires OpenSSL 1.1.0-pre5+ or LibreSSL 2.7.0+', 1) unless defined (&Net::SSLeay::X509_STORE_CTX_get0_cert);
     ok (my $x509_from_cert = Net::SSLeay::X509_STORE_CTX_get0_cert($ctx),'Get x509 from store ctx');

--- a/t/local/36_verify.t
+++ b/t/local/36_verify.t
@@ -7,7 +7,7 @@ use Test::Net::SSLeay qw(
     can_fork data_file_path initialise_libssl is_libressl is_openssl tcp_socket
 );
 
-plan tests => 103;
+plan tests => 105;
 
 initialise_libssl();
 
@@ -223,7 +223,7 @@ sub verify_local_trust {
     ok(my $store = Net::SSLeay::X509_STORE_new(), "X509_STORE_new creates new store");
     ok(Net::SSLeay::X509_STORE_add_cert($store, $ca), "X509_STORE_add_cert CA cert");
     ok(my $ctx = Net::SSLeay::X509_STORE_CTX_new(), "X509_STORE_CTX_new creates new store context");
-    Net::SSLeay::X509_STORE_CTX_init($ctx, $store, $cert);
+    is(Net::SSLeay::X509_STORE_CTX_init($ctx, $store, $cert), 1, 'X509_STORE_CTX_init succeeds');
     ok(!Net::SSLeay::X509_verify_cert($ctx), 'X509_verify_cert correctly fails');
     is(Net::SSLeay::X509_STORE_CTX_get_error($ctx),
         Net::SSLeay::X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY(), "X509_STORE_CTX_get_error returns unable to get local issuer certificate");
@@ -241,7 +241,7 @@ sub verify_local_trust {
     ok($store = Net::SSLeay::X509_STORE_new(), "X509_STORE_new creates new store");
     ok(Net::SSLeay::X509_STORE_add_cert($store, $ca), "X509_STORE_add_cert CA cert");
     ok($ctx = Net::SSLeay::X509_STORE_CTX_new(), "X509_STORE_CTX_new creates new store context");
-    Net::SSLeay::X509_STORE_CTX_init($ctx, $store, $cert, $x509_sk);
+    is(Net::SSLeay::X509_STORE_CTX_init($ctx, $store, $cert, $x509_sk), 1, 'X509_STORE_CTX_init succeeds');
     ok(Net::SSLeay::X509_verify_cert($ctx), 'X509_verify_cert correctly succeeds');
     is(Net::SSLeay::X509_STORE_CTX_get_error($ctx), Net::SSLeay::X509_V_OK(), "X509_STORE_CTX_get_error returns ok");
     Net::SSLeay::X509_STORE_free($store);


### PR DESCRIPTION
`X509_STORE_CTX_init `returns 0 or 1 as documented by OpenSSL. However, the
return value type in SSLeay.xs was void. This is a Net::SSLeay API change, but
it's hard to see how any existing code could depend on this function not
returning anything.

Closes #266