### PR TITLE
Makefile.PL: ensure libssl headers exist before writing Makefile

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,7 +41,6 @@ platform:
 #   Strawberry Perl's MinGW.
 # - See 1.86 developer builds for config that did more with cpanm.
 environment:
-  AUTOMATED_TESTING: 1
   PERL_MM_USE_DEFAULT: 1
   RELEASE_TESTING: 0
   OPENSSL_PREFIX: C:\strawberry\c

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ on:
       - master
 
 env:
-  AUTOMATED_TESTING: 1
   PERL_MM_USE_DEFAULT: 1
   RELEASE_TESTING: 0
 

--- a/Changes
+++ b/Changes
@@ -9,6 +9,9 @@ Revision history for Perl extension Net::SSLeay.
 	  to shutdown and free ssl structures.
 	- Fix multiple formatting errors in the documentation for Net::SSLeay.
 	  Thanks to John Jetmore.
+	- Check for presence of libssl headers in Makefile.PL, and exit with an
+	  error instead of generating an invalid Makefile if they cannot be found.
+	  Fixes RT#105189. Thanks to James E Keenan for the report.
 
 1.90 2021-01-21
 	- New stable release incorporating all changes from developer releases

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Config;
+use English qw( $OSNAME -no_match_vars );
 use ExtUtils::MakeMaker;
 use File::Basename ();
 use File::Spec;
@@ -34,6 +35,7 @@ my %eumm_args = (
   VERSION_FROM => 'lib/Net/SSLeay.pm',
   MIN_PERL_VERSION => '5.8.1',
   CONFIGURE_REQUIRES => {
+    'English' => '0',
     'ExtUtils::MakeMaker' => '0',
   },
   TEST_REQUIRES => {
@@ -131,7 +133,7 @@ EOM
     my %args = (
         CCCDLFLAGS => $opts->{cccdlflags},
         OPTIMIZE => $opts->{optimize},
-        INC => join(' ', map qq{-I"$_"}, @{$opts->{inc_paths}}),
+        INC => qq{-I"$opts->{inc_path}"},
         LIBS => join(' ', (map '-L'.maybe_quote($_), @{$opts->{lib_paths}}), (map {"-l$_"} @{$opts->{lib_links}})),
     );
     # From HMBRAND to handle multple version of OPENSSL installed
@@ -151,9 +153,22 @@ sub ssleay_get_build_opts {
         lib_links  => [],
         cccdlflags => '',
     };
-    for ("$prefix/include", "$prefix/inc32", '/usr/kerberos/include') {
-      push @{$opts->{inc_paths}}, $_ if -f "$_/openssl/ssl.h";
+
+    my @try_includes = (
+        'include' => sub { 1 },
+        'inc32'   => sub { $OSNAME eq 'MSWin32' },
+    );
+
+    while (
+           !defined $opts->{inc_path}
+        && defined( my $dir = shift @try_includes )
+        && defined( my $cond = shift @try_includes )
+    ) {
+        if ( $cond->() && -f "$prefix/$dir/openssl/ssl.h" ) {
+            $opts->{inc_path} = "$prefix/$dir";
+        }
     }
+
     for ($prefix, "$prefix/lib64", "$prefix/lib", "$prefix/out32dll") {
       push @{$opts->{lib_paths}}, $_ if -d $_;
     }

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,7 +8,18 @@ use English qw( $OSNAME -no_match_vars );
 use ExtUtils::MakeMaker;
 use File::Basename ();
 use File::Spec;
+use File::Spec::Functions qw(catfile);
 use Symbol qw(gensym);
+use Text::Wrap;
+
+# According to http://cpanwiki.grango.org/wiki/CPANAuthorNotes, the ideal
+# behaviour to exhibit when a prerequisite does not exist is to use exit code 0
+# to ensure smoke testers stop immediately without reporting a FAIL; in all
+# other environments, we want to fail more loudly
+use constant MISSING_PREREQ => ( $ENV{AUTOMATED_TESTING} ? 0 : 1 );
+
+# Error messages displayed with alert() will be this many columns wide
+use constant ALERT_WIDTH => 78;
 
 # Define this to one if you want to link the openssl libraries statically into 
 # the Net-SSLeay loadable object on Windows
@@ -37,6 +48,9 @@ my %eumm_args = (
   CONFIGURE_REQUIRES => {
     'English' => '0',
     'ExtUtils::MakeMaker' => '0',
+    'File::Spec::Functions' => '0',
+    'Text::Wrap' => '0',
+    'constant' => '0',
   },
   TEST_REQUIRES => {
     'Carp' => '0',
@@ -128,8 +142,34 @@ sub ssleay {
 EOM
         exit 0; # according https://wiki.cpantesters.org/wiki/CPANAuthorNotes this is best-practice when "missing library"
     }
+
+    my $opts = ssleay_get_build_opts($prefix);
+
+    # Ensure libssl headers exist before continuing - compilation will fail
+    # without them
+    if ( !defined $opts->{inc_path} ) {
+        my $detail =
+              'The libssl header files are required to build Net-SSLeay, but '
+            . 'they are missing from ' . $prefix . '. They would typically '
+            . 'reside in ' . catfile( $prefix, 'include', 'openssl' ) . '.';
+
+        if ( $OSNAME eq 'linux' ) {
+            $detail .=
+                  "\n\n"
+                . 'If you are using the version of OpenSSL/LibreSSL packaged '
+                . 'by your Linux distribution, you may need to install the '
+                . 'corresponding "development" package via your package '
+                . 'manager (e.g. libssl-dev for OpenSSL on Debian and Ubuntu, '
+                . 'or openssl-devel for OpenSSL on Red Hat Enterprise Linux '
+                . 'and Fedora).';
+        }
+
+        alert( 'Could not find libssl headers', $detail );
+
+        exit MISSING_PREREQ;
+    }
+
     check_openssl_version($prefix, $exec);
-    my $opts = ssleay_get_build_opts($prefix, $exec);
     my %args = (
         CCCDLFLAGS => $opts->{cccdlflags},
         OPTIMIZE => $opts->{optimize},
@@ -147,7 +187,7 @@ EOM
 sub maybe_quote { $_[0] =~ / / ? qq{"$_[0]"} : $_[0] }
 
 sub ssleay_get_build_opts {
-    my ($prefix, $exec) = @_;
+    my ($prefix) = @_;
 
     my $opts = {
         lib_links  => [],
@@ -378,4 +418,22 @@ sub fixpath {
     my $sep = File::Spec->catdir('');
     $text =~ s{\b/}{$sep}g;
     return $text;
+}
+
+sub alert {
+    my ( $err, $detail ) = @_;
+
+    local $Text::Wrap::columns = ALERT_WIDTH - 4;
+
+    print "\n";
+
+    print '*' x ALERT_WIDTH, "\n";
+    print '* ', uc($err), ' ' x ( ALERT_WIDTH - length($err) - 4 ), ' *', "\n";
+    print '*', ' ' x ( ALERT_WIDTH - 2 ), '*', "\n";
+
+    for ( split /\n/, Text::Wrap::wrap( '', '', $detail ) ) {
+        print '* ', $_, ' ' x ( ALERT_WIDTH - length($_) - 4 ), ' *', "\n";
+    }
+
+    print '*' x ALERT_WIDTH, "\n";
 }


### PR DESCRIPTION
This PR simplifies detection of the libssl include directory (returning a single path, rather than multiple paths), and checks that the libssl headers are present before generating a Makefile that would otherwise cause compilation to fail.

Fixes [RT#105189](https://rt.cpan.org/Ticket/Display.html?id=105189).