### PR TITLE
Change default cipher for PEM_get_string_PrivateKey

### DIFF
--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -4556,7 +4556,7 @@ PEM_get_string_PrivateKey(pk,passwd=NULL,enc_alg=NULL)
             if (passwd_len>0) {
                 /* encrypted key */
                 if (!enc_alg)
-                    PEM_write_bio_PrivateKey(bp,pk,EVP_des_cbc(),(unsigned char *)passwd,passwd_len,cb,u);
+                    PEM_write_bio_PrivateKey(bp,pk,EVP_des_ede(),(unsigned char *)passwd,passwd_len,cb,u);
                 else
                     PEM_write_bio_PrivateKey(bp,pk,enc_alg,(unsigned char *)passwd,passwd_len,cb,u);
             }

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -1712,7 +1712,7 @@ Converts public key $pk into PEM formatted string (optionally protected with pas
  my $rv = Net::SSLeay::PEM_get_string_PrivateKey($pk, $passwd, $enc_alg);
  # $pk - value corresponding to openssl's EVP_PKEY structure
  # $passwd - [optional] (string) password to use for key encryption
- # $enc_alg - [optional] algorithm to use for key encryption (default: DES_CBC) - value corresponding to openssl's EVP_CIPHER structure
+ # $enc_alg - [optional] algorithm to use for key encryption (default: DES_EDE) - value corresponding to openssl's EVP_CIPHER structure
  #
  # returns: PEM formatted string
 


### PR DESCRIPTION
If default cipher DES-CBC is disabled (by policy, because is insecure),
test for default cipher is failing. Changing this default to better
version.