### PR TITLE
Tests: Add diag() with error after connect()

### DIFF
--- a/t/local/44_sess.t
+++ b/t/local/44_sess.t
@@ -250,7 +250,10 @@ sub client {
 	$ssl = Net::SSLeay::new($ctx);
 
 	Net::SSLeay::set_fd($ssl, $cl);
-	Net::SSLeay::connect($ssl);
+	my $ret = Net::SSLeay::connect($ssl);
+	if ($ret <= 0) {
+	    diag("Protocol $proto, connect() returns $ret, Error: ".Net::SSLeay::ERR_error_string(Net::SSLeay::ERR_get_error()));
+	}
 	my $msg = Net::SSLeay::read($ssl);
 	#print "server said: $msg\n";
 

--- a/t/local/45_exporter.t
+++ b/t/local/45_exporter.t
@@ -82,7 +82,10 @@ sub client {
             my $ctx = new_ctx( $round, $round );
             my $ssl = Net::SSLeay::new($ctx);
             Net::SSLeay::set_fd( $ssl, $cl );
-            Net::SSLeay::connect($ssl);
+            my $ret = Net::SSLeay::connect($ssl);
+            if ($ret <= 0) {
+                diag("Protocol $round, connect() returns $ret, Error: ".Net::SSLeay::ERR_error_string(Net::SSLeay::ERR_get_error()));
+            }
 
             my $msg = Net::SSLeay::read($ssl);
 


### PR DESCRIPTION
This diagnostics is helping in connection issues.

e.g. testing openssl 3.0.0. alpha17 on Fedora and TLS1 and TLS1.1 is
failing.

Result:
```
# Protocol TLSv1, connect() returns -1, Error: error:0A000438:SSL
routines::tlsv1 alert internal error
# Protocol TLSv1.1, connect() returns -1, Error: error:0A000438:SSL
routines::tlsv1 alert internal error
```