### PR TITLE
39_pkcs12.t: validate CA certificate CNs with all libssl versions

### DIFF
--- a/t/local/39_pkcs12.t
+++ b/t/local/39_pkcs12.t
@@ -3,7 +3,7 @@ use lib 'inc';
 use Net::SSLeay;
 use Test::Net::SSLeay qw( data_file_path initialise_libssl );
 
-plan tests => 19;
+plan tests => 17;
 
 initialise_libssl();
 
@@ -36,12 +36,24 @@ my $filename3 = data_file_path('simple-cert.p12');
   my $ca1_subj_name = Net::SSLeay::X509_get_subject_name($cachain[0]);
   my $ca2_subj_name = Net::SSLeay::X509_get_subject_name($cachain[1]);
   is(Net::SSLeay::X509_NAME_oneline($subj_name), '/C=PL/O=Net-SSLeay/OU=Test Suite/CN=simple-cert.net-ssleay.example', "X509_NAME_oneline [2/1]");
-  like(Net::SSLeay::X509_NAME_oneline($ca1_subj_name), qr/C=.*CN=.*/, "X509_NAME_oneline [2/2]");
-  like(Net::SSLeay::X509_NAME_oneline($ca2_subj_name), qr/C=.*CN=.*/, "X509_NAME_oneline [2/3]");
-  SKIP: {
-    skip("cert order in CA chain is different in openssl pre-1.0.0", 2) unless Net::SSLeay::SSLeay >= 0x01000000;
-    is(Net::SSLeay::X509_NAME_oneline($ca1_subj_name), '/C=PL/O=Net-SSLeay/OU=Test Suite/CN=Root CA', "X509_NAME_oneline [2/4]");
-    is(Net::SSLeay::X509_NAME_oneline($ca2_subj_name), '/C=PL/O=Net-SSLeay/OU=Test Suite/CN=Intermediate CA', "X509_NAME_oneline [2/5]");
+  # OpenSSL versions 1.0.0-beta2 to 3.0.0-alpha6 inclusive and all versions of
+  # LibreSSL return the CA certificate chain with the root CA certificate at the
+  # end; all other versions return the certificate chain with the root CA
+  # certificate at the start
+  if (
+         Net::SSLeay::SSLeay < 0x10000002
+      || (
+                Net::SSLeay::SSLeay == 0x30000000
+             && Net::SSLeay::SSLeay_version( Net::SSLeay::SSLEAY_VERSION() ) !~ /-alpha[1-6] /
+         )
+      || Net::SSLeay::SSLeay > 0x30000000
+  ) {
+      is(Net::SSLeay::X509_NAME_oneline($ca1_subj_name), '/C=PL/O=Net-SSLeay/OU=Test Suite/CN=Intermediate CA', "X509_NAME_oneline [2/3]");
+      is(Net::SSLeay::X509_NAME_oneline($ca2_subj_name), '/C=PL/O=Net-SSLeay/OU=Test Suite/CN=Root CA', "X509_NAME_oneline [2/4]");
+  }
+  else {
+      is(Net::SSLeay::X509_NAME_oneline($ca1_subj_name), '/C=PL/O=Net-SSLeay/OU=Test Suite/CN=Root CA', "X509_NAME_oneline [2/3]");
+      is(Net::SSLeay::X509_NAME_oneline($ca2_subj_name), '/C=PL/O=Net-SSLeay/OU=Test Suite/CN=Intermediate CA', "X509_NAME_oneline [2/4]");
   }
 }
 


### PR DESCRIPTION
When verifying common names in the PKCS#12 certificate chain, account for the fact that `PKCS12_parse()` returns the CA certificate chain in a different order in different versions of libssl.

Since the CA certificate chain tests now cover all versions of OpenSSL and LibreSSL, don't skip the order check for versions of OpenSSL before 1.0.0, and remove the generic tests that ensure `X509_NAME_oneline()` returns a valid-looking common name for each of the CA certificates (since they're now redundant).