### PR TITLE
Implement SSL_CTX_set_msg_callback/SSL_set_msg_callback for ssl/tls record tracing

### DIFF
--- a/Changes
+++ b/Changes
@@ -12,6 +12,7 @@ Revision history for Perl extension Net::SSLeay.
 	- Check for presence of libssl headers in Makefile.PL, and exit with an
 	  error instead of generating an invalid Makefile if they cannot be found.
 	  Fixes RT#105189. Thanks to James E Keenan for the report.
+    - Added support for SSL_CTX_set_msg_callback/SSL_set_msg_callback
 
 1.90 2021-01-21
 	- New stable release incorporating all changes from developer releases

--- a/Changes
+++ b/Changes
@@ -12,7 +12,8 @@ Revision history for Perl extension Net::SSLeay.
 	- Check for presence of libssl headers in Makefile.PL, and exit with an
 	  error instead of generating an invalid Makefile if they cannot be found.
 	  Fixes RT#105189. Thanks to James E Keenan for the report.
-    - Added support for SSL_CTX_set_msg_callback/SSL_set_msg_callback
+	- Added support for SSL_CTX_set_msg_callback/SSL_set_msg_callback
+	  Thanks to Tim Aerts.
 
 1.90 2021-01-21
 	- New stable release incorporating all changes from developer releases

--- a/MANIFEST
+++ b/MANIFEST
@@ -215,6 +215,7 @@ t/local/42_info_callback.t
 t/local/43_misc_functions.t
 t/local/44_sess.t
 t/local/45_exporter.t
+t/local/46_msg_callback.t
 t/local/50_digest.t
 t/local/61_threads-cb-crash.t
 t/local/62_threads-ctx_new-deadlock.t

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -1479,8 +1479,8 @@ void ssleay_msg_cb_invoke(int write_p, int version, int content_type, const void
     dSP;
     SV *cb_func, *cb_data;
 
-    cb_func = cb_data_advanced_get((void*)ssl, "ssleay_msg_cb!!func");
-    cb_data = cb_data_advanced_get((void*)ssl, "ssleay_msg_cb!!data");
+    cb_func = cb_data_advanced_get(ssl, "ssleay_msg_cb!!func");
+    cb_data = cb_data_advanced_get(ssl, "ssleay_msg_cb!!data");
 
     if ( ! SvROK(cb_func) || (SvTYPE(SvRV(cb_func)) != SVt_PVCV))
     croak ("Net::SSLeay: ssleay_msg_cb_invoke called, but not set to point to any perl function.\n");

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -1489,12 +1489,12 @@ void ssleay_msg_cb_invoke(int write_p, int version, int content_type, const void
     SAVETMPS;
 
     PUSHMARK(SP);
-    XPUSHs(sv_2mortal(newSViv(PTR2IV(ssl))));
     XPUSHs(sv_2mortal(newSViv(write_p)));
     XPUSHs(sv_2mortal(newSViv(version)));
     XPUSHs(sv_2mortal(newSViv(content_type)));
     XPUSHs(sv_2mortal(newSVpv((const char*)buf, len)));
     XPUSHs(sv_2mortal(newSViv(len)));
+    XPUSHs(sv_2mortal(newSViv(PTR2IV(ssl))));
     XPUSHs(sv_2mortal(newSVsv(cb_data)));
     PUTBACK;
 
@@ -1522,12 +1522,12 @@ void ssleay_ctx_msg_cb_invoke(int write_p, int version, int content_type, const 
     SAVETMPS;
 
     PUSHMARK(SP);
-    XPUSHs(sv_2mortal(newSViv(PTR2IV(ssl))));
     XPUSHs(sv_2mortal(newSViv(write_p)));
     XPUSHs(sv_2mortal(newSViv(version)));
     XPUSHs(sv_2mortal(newSViv(content_type)));
     XPUSHs(sv_2mortal(newSVpv((const char*)buf, len)));
     XPUSHs(sv_2mortal(newSViv(len)));
+    XPUSHs(sv_2mortal(newSViv(PTR2IV(ssl))));
     XPUSHs(sv_2mortal(newSVsv(cb_data)));
     PUTBACK;
 

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -1474,6 +1474,71 @@ void ssleay_ctx_info_cb_invoke(const SSL *ssl, int where, int ret)
     LEAVE;
 }
 
+void ssleay_msg_cb_invoke(int write_p, int version, int content_type, const void *buf, size_t len, SSL *ssl, void *arg)
+{
+    dSP;
+    SV *cb_func, *cb_data;
+
+    cb_func = cb_data_advanced_get((void*)ssl, "ssleay_msg_cb!!func");
+    cb_data = cb_data_advanced_get((void*)ssl, "ssleay_msg_cb!!data");
+
+    if ( ! SvROK(cb_func) || (SvTYPE(SvRV(cb_func)) != SVt_PVCV))
+    croak ("Net::SSLeay: ssleay_msg_cb_invoke called, but not set to point to any perl function.\n");
+
+    ENTER;
+    SAVETMPS;
+
+    PUSHMARK(SP);
+    XPUSHs(sv_2mortal(newSViv(PTR2IV(ssl))));
+    XPUSHs(sv_2mortal(newSViv(write_p)));
+    XPUSHs(sv_2mortal(newSViv(version)));
+    XPUSHs(sv_2mortal(newSViv(content_type)));
+    XPUSHs(sv_2mortal(newSVpv((const char*)buf, len)));
+    XPUSHs(sv_2mortal(newSViv(len)));
+    XPUSHs(sv_2mortal(newSVsv(cb_data)));
+    PUTBACK;
+
+    call_sv(cb_func, G_VOID);
+
+    SPAGAIN;
+    PUTBACK;
+    FREETMPS;
+    LEAVE;
+}
+
+void ssleay_ctx_msg_cb_invoke(int write_p, int version, int content_type, const void *buf, size_t len, SSL *ssl, void *arg)
+{
+    dSP;
+    SV *cb_func, *cb_data;
+    SSL_CTX *ctx = SSL_get_SSL_CTX(ssl);
+
+    cb_func = cb_data_advanced_get(ctx, "ssleay_ctx_msg_cb!!func");
+    cb_data = cb_data_advanced_get(ctx, "ssleay_ctx_msg_cb!!data");
+
+    if ( ! SvROK(cb_func) || (SvTYPE(SvRV(cb_func)) != SVt_PVCV))
+    croak ("Net::SSLeay: ssleay_ctx_msg_cb_invoke called, but not set to point to any perl function.\n");
+
+    ENTER;
+    SAVETMPS;
+
+    PUSHMARK(SP);
+    XPUSHs(sv_2mortal(newSViv(PTR2IV(ssl))));
+    XPUSHs(sv_2mortal(newSViv(write_p)));
+    XPUSHs(sv_2mortal(newSViv(version)));
+    XPUSHs(sv_2mortal(newSViv(content_type)));
+    XPUSHs(sv_2mortal(newSVpv((const char*)buf, len)));
+    XPUSHs(sv_2mortal(newSViv(len)));
+    XPUSHs(sv_2mortal(newSVsv(cb_data)));
+    PUTBACK;
+
+    call_sv(cb_func, G_VOID);
+
+    SPAGAIN;
+    PUTBACK;
+    FREETMPS;
+    LEAVE;
+}
+
 /* 
  * Support for tlsext_ticket_key_cb_invoke was already in 0.9.8 but it was
  * broken in various ways during the various 1.0.0* versions.
@@ -5446,6 +5511,39 @@ SSL_CTX_set_info_callback(ctx,callback,data=&PL_sv_undef)
             cb_data_advanced_put(ctx, "ssleay_ctx_info_cb!!data", newSVsv(data));
             SSL_CTX_set_info_callback(ctx, ssleay_ctx_info_cb_invoke);
         }
+
+void
+SSL_set_msg_callback(ssl,callback,data=&PL_sv_undef)
+        SSL * ssl
+        SV * callback
+    SV * data
+    CODE:
+        if (callback==NULL || !SvOK(callback)) {
+            SSL_set_msg_callback(ssl, NULL);
+            cb_data_advanced_put(ssl, "ssleay_msg_cb!!func", NULL);
+            cb_data_advanced_put(ssl, "ssleay_msg_cb!!data", NULL);
+        } else {
+            cb_data_advanced_put(ssl, "ssleay_msg_cb!!func", newSVsv(callback));
+            cb_data_advanced_put(ssl, "ssleay_msg_cb!!data", newSVsv(data));
+            SSL_set_msg_callback(ssl, ssleay_msg_cb_invoke);
+        }
+
+void
+SSL_CTX_set_msg_callback(ctx,callback,data=&PL_sv_undef)
+        SSL_CTX * ctx
+        SV * callback
+    SV * data
+    CODE:
+        if (callback==NULL || !SvOK(callback)) {
+            SSL_CTX_set_msg_callback(ctx, NULL);
+            cb_data_advanced_put(ctx, "ssleay_ctx_msg_cb!!func", NULL);
+            cb_data_advanced_put(ctx, "ssleay_ctx_msg_cb!!data", NULL);
+        } else {
+            cb_data_advanced_put(ctx, "ssleay_ctx_msg_cb!!func", newSVsv(callback));
+            cb_data_advanced_put(ctx, "ssleay_ctx_msg_cb!!data", newSVsv(data));
+            SSL_CTX_set_msg_callback(ctx, ssleay_ctx_msg_cb_invoke);
+        }
+
 
 int
 SSL_set_purpose(s,purpose)

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -4625,6 +4625,32 @@ When callback is undef, an existing callback will be disabled.
 
 Check openssl doc L<http://www.openssl.org/docs/ssl/SSL_CTX_set_info_callback.html|http://www.openssl.org/docs/ssl/SSL_CTX_set_info_callback.html>
 
+=item * set_msg_callback
+
+Sets the callback function, that can be used to obtain protocol messages information for $ssl during connection setup and use.
+When callback is undef, the callback setting currently valid for ctx is used.
+
+ Net::SSLeay::set_msg_callback($ssl, $cb, [$data]);
+ # $ssl - value corresponding to openssl's SSL structure
+ # $cb - sub { my ($ssl,$write_p,$version,$content_type,$buffer,$len,$data) = @_; ... }
+ #
+ # returns: no return value
+
+Check openssl doc L<http://www.openssl.org/docs/ssl/SSL_set_msg_callback.html|http://www.openssl.org/docs/ssl/SSL_set_msg_callback.html>
+
+=item * CTX_set_msg_callback
+
+Sets the callback function on ctx, that can be used to obtain protocol messages information for ssl connection setup and use.
+When callback is undef, the existing callback will be disabled.
+
+ Net::SSLeay::CTX_set_msg_callback($ssl, $cb, [$data]);
+ # $ssl - value corresponding to openssl's SSL structure
+ # $cb - sub { my ($ssl,$write_p,$version,$content_type,$buffer,$len,$data) = @_; ... }
+ #
+ # returns: no return value
+
+Check openssl doc L<http://www.openssl.org/docs/ssl/CTX_SSL_set_msg_callback.html|http://www.openssl.org/docs/ssl/CTX_SSL_set_msg_callback.html>
+
 =item * set_pref_cipher
 
 Sets the list of available ciphers for $ssl using the control string $str.

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -4636,7 +4636,7 @@ When callback is undef, the callback setting currently valid for ctx is used.
  #
  # returns: no return value
 
-Check openssl doc L<http://www.openssl.org/docs/ssl/SSL_set_msg_callback.html|http://www.openssl.org/docs/ssl/SSL_set_msg_callback.html>
+Check openssl doc L<http://www.openssl.org/docs/manmaster/man3/SSL_set_msg_callback.html|http://www.openssl.org/docs/manmaster/man3/SSL_set_msg_callback.html>
 
 =item * CTX_set_msg_callback
 
@@ -4649,7 +4649,7 @@ When callback is undef, the existing callback will be disabled.
  #
  # returns: no return value
 
-Check openssl doc L<http://www.openssl.org/docs/ssl/CTX_SSL_set_msg_callback.html|http://www.openssl.org/docs/ssl/CTX_SSL_set_msg_callback.html>
+Check openssl doc L<http://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_msg_callback.html|http://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_msg_callback.html>
 
 =item * set_pref_cipher
 

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -4632,7 +4632,7 @@ When callback is undef, the callback setting currently valid for ctx is used.
 
  Net::SSLeay::set_msg_callback($ssl, $cb, [$data]);
  # $ssl - value corresponding to openssl's SSL structure
- # $cb - sub { my ($ssl,$write_p,$version,$content_type,$buffer,$len,$data) = @_; ... }
+ # $cb - sub { my ($ssl,$write_p,$version,$content_type,$buf,$len,$data) = @_; ... }
  #
  # returns: no return value
 
@@ -4645,7 +4645,7 @@ When callback is undef, the existing callback will be disabled.
 
  Net::SSLeay::CTX_set_msg_callback($ssl, $cb, [$data]);
  # $ssl - value corresponding to openssl's SSL structure
- # $cb - sub { my ($ssl,$write_p,$version,$content_type,$buffer,$len,$data) = @_; ... }
+ # $cb - sub { my ($ssl,$write_p,$version,$content_type,$buf,$len,$data) = @_; ... }
  #
  # returns: no return value
 

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -4629,10 +4629,11 @@ Check openssl doc L<http://www.openssl.org/docs/ssl/SSL_CTX_set_info_callback.ht
 
 Sets the callback function, that can be used to obtain protocol messages information for $ssl during connection setup and use.
 When callback is undef, the callback setting currently valid for ctx is used.
+Note that set_msg_callback_arg is not provided as there is no need to explicitly set $arg, this is handled by set_msg_callback.
 
- Net::SSLeay::set_msg_callback($ssl, $cb, [$data]);
+ Net::SSLeay::set_msg_callback($ssl, $cb, [$arg]);
  # $ssl - value corresponding to openssl's SSL structure
- # $cb - sub { my ($ssl,$write_p,$version,$content_type,$buf,$len,$data) = @_; ... }
+ # $cb - sub { my ($write_p,$version,$content_type,$buf,$len,$ssl,$arg) = @_; ... }
  #
  # returns: no return value
 
@@ -4642,10 +4643,11 @@ Check openssl doc L<http://www.openssl.org/docs/manmaster/man3/SSL_set_msg_callb
 
 Sets the callback function on ctx, that can be used to obtain protocol messages information for ssl connection setup and use.
 When callback is undef, the existing callback will be disabled.
+Note that CTX_set_msg_callback_arg is not provided as there is no need to explicitly set $arg, this is handled by CTX_set_msg_callback.
 
- Net::SSLeay::CTX_set_msg_callback($ssl, $cb, [$data]);
+ Net::SSLeay::CTX_set_msg_callback($ssl, $cb, [$arg]);
  # $ssl - value corresponding to openssl's SSL structure
- # $cb - sub { my ($ssl,$write_p,$version,$content_type,$buf,$len,$data) = @_; ... }
+ # $cb - sub { my ($write_p,$version,$content_type,$buf,$len,$ssl,$arg) = @_; ... }
  #
  # returns: no return value
 

--- a/t/local/46_msg_callback.t
+++ b/t/local/46_msg_callback.t
@@ -1,0 +1,80 @@
+use lib 'inc';
+
+use Net::SSLeay;
+use Test::Net::SSLeay qw(
+    can_fork data_file_path initialise_libssl new_ctx tcp_socket
+);
+
+if (not can_fork()) {
+    plan skip_all => "fork() not supported on this system";
+} else {
+    plan tests => 2;
+}
+
+initialise_libssl();
+
+my $pid;
+alarm(30);
+END { kill 9,$pid if $pid }
+
+my $server = tcp_socket();
+
+{
+    # SSL server - just handle single connect and  shutdown connection
+    my $cert_pem = data_file_path('simple-cert.cert.pem');
+    my $key_pem  = data_file_path('simple-cert.key.pem');
+
+    defined($pid = fork()) or BAIL_OUT("failed to fork: $!");
+    if ($pid == 0) {
+	for(qw(ctx ssl)) {
+	    my $cl = $server->accept();
+	    my $ctx = new_ctx();
+	    Net::SSLeay::set_cert_and_key($ctx, $cert_pem, $key_pem);
+	    my $ssl = Net::SSLeay::new($ctx);
+	    Net::SSLeay::set_fd($ssl, fileno($cl));
+	    Net::SSLeay::accept($ssl);
+	    for(1,2) {
+		last if Net::SSLeay::shutdown($ssl)>0;
+	    }
+	    close($cl) || die("server close: $!");
+	}
+	$server->close() || die("server listen socket close: $!");
+        exit;
+    }
+}
+
+sub client {
+    my ($where,$expect) = @_;
+    # SSL client - connect and shutdown, all the while getting state updates
+    #  with info callback
+
+    my @states;
+    my $infocb = sub {
+	my ($ssl,$write_p,$version,$content_type,$buf,$len) = @_;
+    $buf = unpack("H*", $buf);
+	push @states,[$write_p,$version,$content_type,$len];
+    };
+
+    my $cl = $server->connect();
+    my $ctx = new_ctx();
+    Net::SSLeay::CTX_set_options($ctx, &Net::SSLeay::OP_ALL);
+    Net::SSLeay::CTX_set_msg_callback($ctx, $infocb) if $where eq 'ctx';
+    my $ssl = Net::SSLeay::new($ctx);
+    Net::SSLeay::set_fd($ssl, $cl);
+    Net::SSLeay::set_msg_callback($ssl, $infocb) if $where eq 'ssl';
+    Net::SSLeay::connect($ssl);
+    for(1,2) {
+	last if Net::SSLeay::shutdown($ssl)>0;
+    }
+    close($cl) || die("client close: $!");
+
+    is_deeply(\@states, [
+    [1,0,256,5],[1,772,22,210],[0,0,256,5],[0,772,22,122],[0,0,256,5],[0,0,256,5],[0,772,257,1],[0,772,22,6],[0,0,256,5],[0,772,257,1],[0,772,22,905],[0,0,256,5],[0,772,257,1],[0,772,22,264],[0,0,256,5],[0,772,257,1],[0,772,22,52],[1,0,256,5],[1,772,20,1],[1,0,256,5],[1,772,257,1],[1,772,22,52],[1,0,256,5],[1,772,257,1],[1,772,21,2],[0,0,256,5],[0,772,257,1],[0,772,22,217],[0,0,256,5],[0,772,257,1],[0,772,22,217],[0,0,256,5],[0,772,257,1],[0,772,21,2]
+    ], "state ok");
+}
+
+client('ctx');
+client('ssl');
+$server->close() || die("client listen socket close: $!");
+waitpid $pid, 0;
+

--- a/t/local/46_msg_callback.t
+++ b/t/local/46_msg_callback.t
@@ -8,7 +8,7 @@ use Test::Net::SSLeay qw(
 if (not can_fork()) {
     plan skip_all => "fork() not supported on this system";
 } else {
-    plan tests => 2;
+    plan tests => 4;
 }
 
 initialise_libssl();
@@ -44,7 +44,7 @@ my $server = tcp_socket();
 }
 
 sub client {
-    my ($where,$expect) = @_;
+    my ($where) = @_;
     # SSL client - connect and shutdown, all the while getting state updates
     #  with info callback
 
@@ -85,7 +85,10 @@ sub client {
 	last if Net::SSLeay::shutdown($ssl)>0;
     }
     close($cl) || die("client close: $!");
-    is_deeply(\@states, [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1], "state ok");
+    ok(scalar(@states) > 1, "at least 2 messages logged: $where");
+    my $all_ok = 1;
+    $all_ok &= $_ for @states;
+    is($all_ok, 1, "all states are OK: length(buf) = len for $where");
 }
 
 client('ctx');

--- a/t/local/46_msg_callback.t
+++ b/t/local/46_msg_callback.t
@@ -50,9 +50,16 @@ sub client {
 
     my @states;
     my $infocb = sub {
-	my ($ssl,$write_p,$version,$content_type,$buf,$len) = @_;
-    $buf = unpack("H*", $buf);
-	push @states,[$write_p,$version,$content_type,$len];
+        my ($ssl,$write_p,$version,$content_type,$buf,$len) = @_;
+        # buffer is of course randomized/timestamped, this is hard to test, so
+        # skip this
+        $buf = unpack("H*", $buf);
+
+        # version appears to be different running in different test envs that
+        # have a different openssl version, so we skip that too. This isn't a
+        # good test for that, and it's not up to Net::SSLeay to make all
+        # openssl implementations look the same
+        push @states,[$write_p,$content_type,$len];
     };
 
     my $cl = $server->connect();
@@ -69,7 +76,7 @@ sub client {
     close($cl) || die("client close: $!");
 
     is_deeply(\@states, [
-    [1,0,256,5],[1,772,22,210],[0,0,256,5],[0,772,22,122],[0,0,256,5],[0,0,256,5],[0,772,257,1],[0,772,22,6],[0,0,256,5],[0,772,257,1],[0,772,22,905],[0,0,256,5],[0,772,257,1],[0,772,22,264],[0,0,256,5],[0,772,257,1],[0,772,22,52],[1,0,256,5],[1,772,20,1],[1,0,256,5],[1,772,257,1],[1,772,22,52],[1,0,256,5],[1,772,257,1],[1,772,21,2],[0,0,256,5],[0,772,257,1],[0,772,22,217],[0,0,256,5],[0,772,257,1],[0,772,22,217],[0,0,256,5],[0,772,257,1],[0,772,21,2]
+    [1,256,5],[1,22,210],[0,256,5],[0,22,122],[0,256,5],[0,256,5],[0,257,1],[0,22,6],[0,256,5],[0,257,1],[0,22,905],[0,256,5],[0,257,1],[0,22,264],[0,256,5],[0,257,1],[0,22,52],[1,256,5],[1,20,1],[1,256,5],[1,257,1],[1,22,52],[1,256,5],[1,257,1],[1,21,2],[0,256,5],[0,257,1],[0,22,217],[0,256,5],[0,257,1],[0,22,217],[0,256,5],[0,257,1],[0,21,2]
     ], "state ok");
 }
 


### PR DESCRIPTION
This adds support for the msg callback functionality to do some debugging for e.g. tls handshake.

- lib/Net/SSLeay.pod: update manpage
- updated Changes
- updated MANIFEST
- t/local/46_msg_callback.t added