### PR TITLE
adjusting time in ASN1_TIME_timet based on current offset to GMT

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Perl extension Net::SSLeay.
 
 ????
+	- Adjust time in ASN1_TIME_timet based on current offset to GMT to
+	  address GH-148. Thanks to Steffen Ullrich.
 	- Correct X509_STORE_CTX_init() return value to integer. Previous
 	  versions of Net::SSLeay return nothing.
 	- Update tests to call close() to avoid problems seen with


### PR DESCRIPTION
Should address https://github.com/radiator-software/p5-net-ssleay/issues/148

The code is likely not the fastest, i.e. it would have been better to use timegm instead of mktime. Unfornatunatly timegm cannot be guaranteed to be available since this function is not standardized. Still, the code is likely not called that often so performance does not matter that much.