### PR TITLE
GH-287 Use security level 0 with TLSv1 and TLSv1.1 in tests.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,8 +1,6 @@
 Revision history for Perl extension Net::SSLeay.
 
 ????
-	- Adjust time in ASN1_TIME_timet based on current offset to GMT to
-	  address GH-148. Thanks to Steffen Ullrich.
 	- Correct X509_STORE_CTX_init() return value to integer. Previous
 	  versions of Net::SSLeay return nothing.
 	- Update tests to call close() to avoid problems seen with
@@ -16,6 +14,16 @@ Revision history for Perl extension Net::SSLeay.
 	  Fixes RT#105189. Thanks to James E Keenan for the report.
 	- Added support for SSL_CTX_set_msg_callback/SSL_set_msg_callback
 	  Thanks to Tim Aerts.
+	- Adjust time in ASN1_TIME_timet based on current offset to GMT to
+	  address GH-148. Thanks to Steffen Ullrich.
+	- Multiple updates to tests to match OpenSSL 3.0 behaviour.
+	  Thanks to Michal Josef Špaček.
+	- OpenSSL 3.0 related changes in tests include:
+	  - TLSv1 and TLSv1.1 require security level 0 starting with 3.0 alpha 5.
+	  - SSL_CTX_set_ciphersuites() and SSL_set_ciphersuites() ignore
+	    unknown ciphersuites starting with 3.0 alpha 11.
+	- See OpenSSL manual page migration_guide(7) for more information about
+	  changes in OpenSSL 3.0.
 
 1.90 2021-01-21
 	- New stable release incorporating all changes from developer releases

--- a/t/local/44_sess.t
+++ b/t/local/44_sess.t
@@ -163,6 +163,8 @@ sub server
 
 	    $ctx = new_ctx( $proto, $proto );
 
+	    Net::SSLeay::CTX_set_security_level($ctx, 0)
+		if Net::SSLeay::SSLeay() >= 0x30000000 && ($proto eq 'TLSv1' || $proto eq 'TLSv1.1');
 	    Net::SSLeay::set_cert_and_key($ctx, $cert_pem, $key_pem);
 	    Net::SSLeay::CTX_set_session_cache_mode($ctx, Net::SSLeay::SESS_CACHE_SERVER());
 	    # Need OP_NO_TICKET to enable server side (Session ID based) resumption.
@@ -243,6 +245,8 @@ sub client {
 
 	$ctx = new_ctx( $proto, $proto );
 
+	Net::SSLeay::CTX_set_security_level($ctx, 0)
+	    if Net::SSLeay::SSLeay() >= 0x30000000 && ($proto eq 'TLSv1' || $proto eq 'TLSv1.1');
 	Net::SSLeay::CTX_set_session_cache_mode($ctx, Net::SSLeay::SESS_CACHE_CLIENT());
         Net::SSLeay::CTX_set_options($ctx, Net::SSLeay::OP_ALL());
 	Net::SSLeay::CTX_sess_set_new_cb($ctx, sub {client_new_cb(@_, $ctx, $round);});

--- a/t/local/45_exporter.t
+++ b/t/local/45_exporter.t
@@ -56,6 +56,8 @@ sub server
 
 	    $ctx = new_ctx( $round, $round );
 
+	    Net::SSLeay::CTX_set_security_level($ctx, 0)
+		if Net::SSLeay::SSLeay() >= 0x30000000 && ($round eq 'TLSv1' || $round eq 'TLSv1.1');
 	    Net::SSLeay::set_cert_and_key($ctx, $cert_pem, $key_pem);
 	    $ssl = Net::SSLeay::new($ctx);
 	    Net::SSLeay::set_fd($ssl, fileno($cl));
@@ -80,6 +82,8 @@ sub client {
             my $cl = $server->connect();
 
             my $ctx = new_ctx( $round, $round );
+	    Net::SSLeay::CTX_set_security_level($ctx, 0)
+		if Net::SSLeay::SSLeay() >= 0x30000000 && ($round eq 'TLSv1' || $round eq 'TLSv1.1');
             my $ssl = Net::SSLeay::new($ctx);
             Net::SSLeay::set_fd( $ssl, $cl );
             my $ret = Net::SSLeay::connect($ssl);


### PR DESCRIPTION
OpenSSL 3.0 alpha 5 and later require security level set to 0. This requires
changes in tests that need to use TLS versions < 1.2.

The following is a quote from OpenSSL manual page migration_guide(7).

    The security strength of SHA1 and MD5 based signatures in TLS has been
    reduced.

    This results in SSL 3, TLS 1.0, TLS 1.1 and DTLS 1.0 no longer working at
    the default security level of 1 and instead requires security level 0.