### PR TITLE
GH-290 Update 30_error.t to match changes in OpenSSL 3.0.

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,6 +22,7 @@ Revision history for Perl extension Net::SSLeay.
 	  - TLSv1 and TLSv1.1 require security level 0 starting with 3.0 alpha 5.
 	  - SSL_CTX_set_ciphersuites() and SSL_set_ciphersuites() ignore
 	    unknown ciphersuites starting with 3.0 alpha 11.
+	  - Error code and error string packing and formatting changes.
 	- See OpenSSL manual page migration_guide(7) for more information about
 	  changes in OpenSSL 3.0.
 

--- a/t/local/30_error.t
+++ b/t/local/30_error.t
@@ -12,6 +12,14 @@ if ($@) {
 
 initialise_libssl();
 
+# See below near 'sub put_err' for more about how error string and
+# erro code contents have changed between library versions.
+my $err_string = "foo $$: 1 - error:10000080:BIO routines:";
+$err_string    = "foo $$: 1 - error:20000080:BIO routines:"
+    if  Net::SSLeay::SSLeay_version(Net::SSLeay::SSLEAY_VERSION()) =~ m/^OpenSSL 3.0.0-alpha[1-4] /s;
+$err_string    = "foo $$: 1 - error:2006D080:BIO routines:"
+    if (Net::SSLeay::constant("LIBRESSL_VERSION_NUMBER") || Net::SSLeay::constant("OPENSSL_VERSION_NUMBER") < 0x30000000);
+
 # Note, die_now usually just prints the process id and the argument string eg:
 # 57611: test
 # but on some systems, perhaps if diagnostics are enabled, it might [roduce something like:
@@ -55,22 +63,42 @@ initialise_libssl();
             throws_ok(sub {
                     Net::SSLeay::die_now('foo');
             }, qr/^$$: foo\n$/, 'die_now dies with errors and trace');
-    }, qr/foo $$: 1 - error:2006d080/i, 'die_now raises warnings about the occurred error when tracing');
+    }, qr/$err_string/i, 'die_now raises warnings about the occurred error when tracing');
 
     put_err();
     warning_like(sub {
             throws_ok(sub {
                 Net::SSLeay::die_if_ssl_error('foo');
             }, qr/^$$: foo\n$/, 'die_if_ssl_error dies with errors and trace');
-    }, qr/foo $$: 1 - error:2006d080/i, 'die_if_ssl_error raises warnings about the occurred error when tracing');
+    }, qr/$err_string/i, 'die_if_ssl_error raises warnings about the occurred error when tracing');
 }
 
+# The resulting error strings looks something like below. The number
+# after 'foo' is the process id. OpenSSL 3.0.0 drops function name and
+# changes how error code is packed.
+# - OpenSSL 3.0.0:        foo 61488: 1 - error:10000080:BIO routines::no such file
+# - OpenSSL 3.0.0-alpha5: foo 16380: 1 - error:10000080:BIO routines::no such file
+# - OpenSSL 3.0.0-alpha1: foo 16293: 1 - error:20000080:BIO routines::no such file
+# - OpenSSL 1.1.1l:       foo 61202: 1 - error:2006D080:BIO routines:BIO_new_file:no such file
+# - OpenSSL 1.1.0l:       foo 61295: 1 - error:2006D080:BIO routines:BIO_new_file:no such file
+# - OpenSSL 1.0.2u:       foo 61400: 1 - error:2006D080:BIO routines:BIO_new_file:no such file
+# - OpenSSL 1.0.1u:       foo 13621: 1 - error:2006D080:BIO routines:BIO_new_file:no such file
+# - OpenSSL 1.0.0t:       foo 14349: 1 - error:2006D080:BIO routines:BIO_new_file:no such file
+# - OpenSSL 0.9.8zh:      foo 14605: 1 - error:2006D080:BIO routines:BIO_new_file:no such file
+# - OpenSSL 0.9.8f:       foo 14692: 1 - error:2006D080:BIO routines:BIO_new_file:no such file
+#
+# 1.1.1 series and earlier create error by ORing together lib, func
+# and reason with 24 bit left shift, 12 bit left shift and without bit
+# shift, respectively.
+# 3.0.0 alpha1 drops function name from error string and alpha5
+# changes bit shift of lib to 23.
+# LibreSSL 2.5.1 drops function name from error string.
 sub put_err {
     Net::SSLeay::ERR_put_error(
-        32, #lib
-       109, #func
-       128, #reason
-         1, #file
-         1, #line
+        32, #lib    - 0x20 ERR_LIB_BIO 'BIO routines'
+       109, #func   - 0x6D BIO_F_BIO_NEW_FILE 'BIO_new_file'
+       128, #reason - 0x80 BIO_R_NO_SUCH_FILE 'no such file'
+         1, #file   - file name (not packed into error code)
+         1, #line   - line number (not packed into error code)
     );
 }


### PR DESCRIPTION
OpenSSL 3.0 changes error code packing and contents of their related human
readble error strings.

Test 30_error.t now has more information about how different OpenSSL and
LibreSSL versions do error code packing and error string formatting.