### PR TITLE
43_misc_functions.t: use LibreSSL's TLSv1.3 ciphersuite names

### DIFF
--- a/Changes
+++ b/Changes
@@ -27,6 +27,8 @@ Revision history for Perl extension Net::SSLeay.
 	  changes in OpenSSL 3.0.
 	- Automatically detect OpenSSL installed via Homebrew on ARM-based macOS
 	  systems. Thanks to Graham Knop for the patch.
+	- Account for the divergence in TLSv1.3 ciphersuite names between OpenSSL and
+	  LibreSSL, which was causing failures of some TLSv1.3 tests with LibreSSL.
 
 1.90 2021-01-21
 	- New stable release incorporating all changes from developer releases

--- a/t/local/43_misc_functions.t
+++ b/t/local/43_misc_functions.t
@@ -35,12 +35,19 @@ our %tls_1_2_aead_cipher_to_keyblock_size = (
      'AES256-GCM-SHA384' => 88,
     );
 
-our %tls_1_3_aead_cipher_to_keyblock_size = (
-     # Only in TLS 1.3
-     'TLS_AES_128_GCM_SHA256' => 56,
-     'TLS_AES_256_GCM_SHA384' => 88,
-     'TLS_CHACHA20_POLY1305_SHA256' => 88,
-    );
+# LibreSSL uses different names for the TLSv1.3 ciphersuites:
+our %tls_1_3_aead_cipher_to_keyblock_size =
+      is_libressl()
+    ? (
+          'AEAD-AES128-GCM-SHA256'        => 56,
+          'AEAD-AES256-GCM-SHA384'        => 88,
+          'AEAD-CHACHA20-POLY1305-SHA256' => 88,
+      )
+    : (
+         'TLS_AES_128_GCM_SHA256'       => 56,
+         'TLS_AES_256_GCM_SHA384'       => 88,
+         'TLS_CHACHA20_POLY1305_SHA256' => 88,
+      );
 
 # Combine the AEAD hashes
 our %aead_cipher_to_keyblock_size = (%tls_1_2_aead_cipher_to_keyblock_size, %tls_1_3_aead_cipher_to_keyblock_size);


### PR DESCRIPTION
LibreSSL's implementation of TLSv1.3 uses different ciphersuite names to OpenSSL's, causing failures in `t/local/43_misc_functions.t`. Use the alternative ciphersuite names in these tests when libssl is provided by LibreSSL.

Fixes #294.