### PR TITLE
GH-293 Expose functions needed for working with OSSL_PROVIDER

### DIFF
--- a/Changes
+++ b/Changes
@@ -23,6 +23,7 @@ Revision history for Perl extension Net::SSLeay.
 	  - SSL_CTX_set_ciphersuites() and SSL_set_ciphersuites() ignore
 	    unknown ciphersuites starting with 3.0 alpha 11.
 	  - Error code and error string packing and formatting changes.
+	  - PEM_get_string_PrivateKey default algorithm requires legacy provider.
 	- See OpenSSL manual page migration_guide(7) for more information about
 	  changes in OpenSSL 3.0.
 	- Automatically detect OpenSSL installed via Homebrew on ARM-based macOS
@@ -34,6 +35,17 @@ Revision history for Perl extension Net::SSLeay.
 	  above.
 	- In 43_misc_functions.t, account for the fact that LibreSSL 3.2.0 and above
 	  implement TLSv1.3 without exposing a TLS1_3_VERSION constant.
+	- Expose OpenSSL 3.0 functions
+	  OSSL_LIB_CTX_get0_global_default, OSSL_PROVIDER_load,
+	  OSSL_PROVIDER_try_load, OSSL_PROVIDER_unload,
+	  OSSL_PROVIDER_available, OSSL_PROVIDER_do_all
+	  OSSL_PROVIDER_get0_name and OSSL_PROVIDER_self_test.
+	  Add test files 22_provider.t, 22_provider_try_load.t and
+	  22_provider_try_load_zero_retain.t.
+	- With OpenSSL 3.0 and later, the legacy provider is loaded in
+	  33_x509_create_cert.t to allow PEM_get_string_PrivateKey to
+	  continue working until its default encryption method is
+	  updated. Fixes GH-272 and closes GH-273.
 
 1.90 2021-01-21
 	- New stable release incorporating all changes from developer releases

--- a/MANIFEST
+++ b/MANIFEST
@@ -199,6 +199,9 @@ t/local/11_read.t
 t/local/15_bio.t
 t/local/20_autoload.t
 t/local/21_constants.t
+t/local/22_provider.t
+t/local/22_provider_try_load.t
+t/local/22_provider_try_load_zero_retain.t
 t/local/30_error.t
 t/local/31_rsa_generate_key.t
 t/local/32_x509_get_cert_info.t

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -9277,6 +9277,129 @@ These functions are only available since OpenSSL 1.1.1.
 =back
 
 
+=head3 Low level API: OSSL_LIB_CTX and OSSL_PROVIDER related functions
+
+=over
+
+=item * OSSL_LIB_CTX_get0_global_default
+
+Returns a concrete (non NULL) reference to the global default library context.
+
+ my $libctx = Net::SSLeay::OSSL_LIB_CTX_get0_global_default();
+ # returns: a value corresponding to OSSL_LIB_CTX structure or false on failure
+
+Typically it's simpler to use undef with functions that take an
+OSSL_LIB_CTX argument when global default library context is needed.
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/OSSL_LIB_CTX_get0_global_default.html|https://www.openssl.org/docs/manmaster/man3/OSSL_LIB_CTX_get0_global_default.html>
+
+=item * OSSL_PROVIDER_load
+
+Loads and initializes a provider
+
+ my $provider = Net::SSLeay::OSSL_PROVIDER_load($libctx, $name);
+ # $libctx - value corresponding to OSSL_LIB_CTX structure or undef
+ # $name - (string) provider name, e.g., 'legacy'
+ #
+ # returns: a value corresponding to OSSL_PROVIDER or false on failure
+
+Using undef loads the provider within the global default library context.
+
+ my $provider = Net::SSLeay::OSSL_PROVIDER_load(undef, 'legacy');
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/OSSL_PROVIDER_load.html|https://www.openssl.org/docs/manmaster/man3/OSSL_PROVIDER_load.html>
+
+=item * OSSL_PROVIDER_try_load
+
+Loads and initializes a provider similar to OSSL_PROVIDER_load with additional fallback control.
+
+ my $provider = Net::SSLeay::OSSL_PROVIDER_try_load($libctx, $name, $retain_fallbacks);
+ # $libctx - value corresponding to OSSL_LIB_CTX structure or undef
+ # $name - (string) provider name, e.g., 'legacy'
+ # $retain_fallbacks - (integer) 0 or 1
+ #
+ # returns: a value corresponding to OSSL_PROVIDER or false on failure
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/OSSL_PROVIDER_try_load.html|https://www.openssl.org/docs/manmaster/man3/OSSL_PROVIDER_try_load.html>
+
+=item * OSSL_PROVIDER_unload
+
+Unloads the given provider.
+
+ my $rv = Net::SSLeay::OSSL_PROVIDER_unload($provider);
+ # $provider - a value corresponding to OSSL_PROVIDER
+ #
+ # returns: (integer) 1 on success, 0 on error
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/OSSL_PROVIDER_unload.html|https://www.openssl.org/docs/manmaster/man3/OSSL_PROVIDER_unload.html>
+
+=item * OSSL_PROVIDER_available
+
+Checks if a named provider is available for use.
+
+ my $rv = Net::SSLeay::OSSL_PROVIDER_available($libctx, $name);
+ # $libctx - value corresponding to OSSL_LIB_CTX structure or undef
+ # $name - (string) provider name, e.g., 'legacy'
+ #
+ # returns: (integer) 1 if the named provider is available, otherwise 0.
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/OSSL_PROVIDER_available.html|https://www.openssl.org/docs/manmaster/man3/OSSL_PROVIDER_available.html>
+
+=item * OSSL_PROVIDER_do_all
+
+Iterates over all loaded providers. A callback is called for each provider.
+
+ my $rv = Net::SSLeay::OSSL_PROVIDER_do_all($libctx, $cb, $cbdata);
+ # $libctx - value corresponding to OSSL_LIB_CTX structure or undef
+ # $cb - reference to a perl callback function
+ $ $cbdata - data that will be passed to callback function
+ #
+ # returns: (integer) 1 if all callbacks returned 1, 0 the first time a callback returns 0.
+
+Example:
+
+ sub do_all_cb {
+     my ($provider, $cbdata) = @_;
+
+     my $name = Net::SSLeay::OSSL_PROVIDER_get0_name($provider);
+     print "Callback for provider: '$name', cbdata: '$cbdata'\n";
+     return 1;
+  }
+  my $data_for_cb = 'Hello';
+
+  # Triggers default provider automatic loading.
+  Net::SSLeay::OSSL_PROVIDER_available(undef, 'default') || die 'default provider not available';
+  Net::SSLeay::OSSL_PROVIDER_load(undef, 'legacy') || die 'load legacy';
+  Net::SSLeay::OSSL_PROVIDER_load(undef, 'null')   || die 'load null';
+  Net::SSLeay::OSSL_PROVIDER_do_all(undef, \&do_all_cb, $data_for_cb) || die 'a callback failed';
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/OSSL_PROVIDER_do_all.html|https://www.openssl.org/docs/manmaster/man3/OSSL_PROVIDER_do_all.html>
+
+=item * OSSL_PROVIDER_get0_name
+
+Returns the name of the given provider.
+
+ my $name = Net::SSLeay::OSSL_PROVIDER_get0_name($provider);
+ # $provider - a value corresponding to OSSL_PROVIDER
+ #
+ # returns: (string) provider name, e.g., 'legacy'
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/OSSL_PROVIDER_get0_name.html|https://www.openssl.org/docs/manmaster/man3/OSSL_PROVIDER_get0_name.html>
+
+=item * OSSL_PROVIDER_self_test
+
+Runs the provider's self tests.
+
+ my $rv = Net::SSLeay::OSSL_PROVIDER_self_test($provider);
+ # $libctx - value corresponding to OSSL_LIB_CTX structure or undef
+ # $provider - a value corresponding to OSSL_PROVIDER
+ #
+ # returns: (integer) returns 1 if the self tests pass, 0 on error
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/OSSL_PROVIDER_self_test.html|https://www.openssl.org/docs/manmaster/man3/OSSL_PROVIDER_self_test.html>
+
+=back
+
 =head2 Constants
 
 There are many openssl constants available in L<Net::SSLeay>. You can use them like this:

--- a/t/local/22_provider.t
+++ b/t/local/22_provider.t
@@ -1,0 +1,103 @@
+use lib 'inc';
+
+use Net::SSLeay;
+use Test::Net::SSLeay (initialise_libssl);
+
+# We don't do intialise_libssl() now because we want to want to
+# trigger automatic loading of the default provider.
+#
+# Quote from
+# https://www.openssl.org/docs/manmaster/man7/OSSL_PROVIDER-default.html
+# about default provider:
+#
+#   It is loaded automatically the first time that an algorithm is
+#   fetched from a provider or a function acting on providers is
+#   called and no other provider has been loaded yet.
+#
+#initialise_libssl(); # Don't do this
+
+if (defined &Net::SSLeay::OSSL_PROVIDER_load) {
+    plan(tests => 16);
+} else {
+    plan(skip_all => "no support for providers");
+}
+
+# provider loading, availability and unloading
+{
+    # See top of file why things are done in this order. We don't want
+    # to load the default provider automatically.
+
+    my $null_provider = Net::SSLeay::OSSL_PROVIDER_load(undef, 'null');
+    ok($null_provider, 'null provider load returns a pointer');
+    my $null_avail = Net::SSLeay::OSSL_PROVIDER_available(undef, 'null');
+    is($null_avail, 1, 'null provider loaded and available');
+
+    my $default_avail = Net::SSLeay::OSSL_PROVIDER_available(undef, 'default');
+    is($default_avail, 0, 'default provider not loaded, not available');
+    if ($default_avail)
+    {
+	diag('Default provider was already available. More provider tests in this and other provider test files may fail');
+	diag('If your configuration loads the default provider, consider ignoring the errors or using OPENSSL_CONF environment variable');
+	diag('For example: OPENSSL_CONF=/path/to/openssl/ssl/openssl.cnf.dist make test');
+    }
+
+    my $null_unload = Net::SSLeay::OSSL_PROVIDER_unload($null_provider);
+    is($null_unload, 1, 'null provider successfully unloaded');
+    $null_avail = Net::SSLeay::OSSL_PROVIDER_available(undef, 'null');
+    is($null_avail, 0, 'null provider is no longer available');
+
+    $default_avail = Net::SSLeay::OSSL_PROVIDER_available(undef, 'default');
+    is($default_avail, 0, 'default provider still not loaded, not available');
+
+    my $default_provider_undef_libctx = Net::SSLeay::OSSL_PROVIDER_load(undef, 'default');
+    ok($default_provider_undef_libctx, 'default provider with NULL libctx loaded successfully');
+
+    my $libctx = Net::SSLeay::OSSL_LIB_CTX_get0_global_default();
+    ok($libctx, 'OSSL_LIB_CTX_get0_global_default() returns a pointer');
+
+    my $default_provider_default_libctx = Net::SSLeay::OSSL_PROVIDER_load($libctx, 'default');
+    ok($default_provider_default_libctx, 'default provider with default libctx loaded successfully');
+    is($default_provider_default_libctx, $default_provider_undef_libctx, 'OSSL_PROVIDER_load with undef and defined libctx return the same pointer');
+}
+
+
+# get0_name, selftest
+{
+    my $null_provider = Net::SSLeay::OSSL_PROVIDER_load(undef, 'null');
+    my $default_provider = Net::SSLeay::OSSL_PROVIDER_load(undef, 'default');
+
+    is(Net::SSLeay::OSSL_PROVIDER_get0_name($null_provider), 'null', 'get0_name for null provider');
+    is(Net::SSLeay::OSSL_PROVIDER_get0_name($default_provider), 'default', 'get0_name for default provider');
+
+    is(Net::SSLeay::OSSL_PROVIDER_self_test($null_provider), 1, 'self_test for null provider');
+    is(Net::SSLeay::OSSL_PROVIDER_self_test($default_provider), 1, 'self_test for default provider');
+}
+
+
+# do_all
+{
+    my %seen_providers;
+    sub all_cb {
+	my ($provider_cb, $cbdata_cb) = @_;
+
+	fail('provider already seen') if exists $seen_providers{$provider_cb};
+	$seen_providers{$provider_cb} = $cbdata_cb;
+	return 1;
+    };
+
+    my $null_provider = Net::SSLeay::OSSL_PROVIDER_load(undef, 'null');
+    my $default_provider = Net::SSLeay::OSSL_PROVIDER_load(undef, 'default');
+    my $cbdata = 'data for cb';
+
+    Net::SSLeay::OSSL_PROVIDER_do_all(undef, \&all_cb, $cbdata);
+    foreach my $provider ($null_provider, $default_provider)
+    {
+	my $name = Net::SSLeay::OSSL_PROVIDER_get0_name($provider);
+	is(delete $seen_providers{$provider}, $cbdata, "provider '$name' was seen");
+    }
+    foreach my $provider (keys(%seen_providers))
+    {
+	my $name = Net::SSLeay::OSSL_PROVIDER_get0_name($provider);
+	diag("Provider '$name' was also seen by the callback");
+    }
+}

--- a/t/local/22_provider_try_load.t
+++ b/t/local/22_provider_try_load.t
@@ -1,0 +1,29 @@
+use lib 'inc';
+
+use Net::SSLeay;
+use Test::Net::SSLeay (initialise_libssl);
+
+# Avoid default provider automatic loading. See 22_provider.t for more
+# information.
+#
+#initialise_libssl(); # Don't do this
+#
+# We use a separate test file so that we get a newly loaded library
+# that still has triggers for automatic loading enabled.
+
+if (defined &Net::SSLeay::OSSL_PROVIDER_load) {
+    plan(tests => 3);
+} else {
+    plan(skip_all => "no support for providers");
+}
+
+my ($null_provider, $default_avail, $null_avail);
+
+$null_provider = Net::SSLeay::OSSL_PROVIDER_try_load(undef, 'null', 1);
+ok($null_provider, 'try_load("null", retain_fallbacks = 1) returns a pointer');
+
+$default_avail = Net::SSLeay::OSSL_PROVIDER_available(undef, 'default');
+is($default_avail, 1, 'default provider automatically loaded after try_load("null", retain_fallbacks = 1)');
+
+$null_avail = Net::SSLeay::OSSL_PROVIDER_available(undef, 'null');
+is($null_avail, 1, 'null provider loaded after try_load("null", retain_fallbacks = 1)');

--- a/t/local/22_provider_try_load_zero_retain.t
+++ b/t/local/22_provider_try_load_zero_retain.t
@@ -1,0 +1,29 @@
+use lib 'inc';
+
+use Net::SSLeay;
+use Test::Net::SSLeay (initialise_libssl);
+
+# Avoid default provider automatic loading. See 22_provider.t for more
+# information.
+#
+#initialise_libssl(); # Don't do this
+#
+# We use a separate test file so that we get a newly loaded library
+# that still has triggers for automatic loading enabled.
+
+if (defined &Net::SSLeay::OSSL_PROVIDER_load) {
+    plan(tests => 3);
+} else {
+    plan(skip_all => "no support for providers");
+}
+
+my ($null_provider, $default_avail, $null_avail);
+
+$null_provider = Net::SSLeay::OSSL_PROVIDER_try_load(undef, 'null', 0);
+ok($null_provider, 'try_load("null", retain_fallbacks = 0) returns a pointer');
+
+$default_avail = Net::SSLeay::OSSL_PROVIDER_available(undef, 'default');
+is($default_avail, 0, 'default provider not automatically loaded after try_load("null", retain_fallbacks = 0)');
+
+$null_avail = Net::SSLeay::OSSL_PROVIDER_available(undef, 'null');
+is($null_avail, 1, 'null provider loaded after try_load("null", retain_fallbacks = 0)');

--- a/t/local/33_x509_create_cert.t
+++ b/t/local/33_x509_create_cert.t
@@ -9,6 +9,13 @@ plan tests => 139;
 
 initialise_libssl();
 
+if (defined &Net::SSLeay::OSSL_PROVIDER_load)
+{
+    my $provider = Net::SSLeay::OSSL_PROVIDER_load(undef, 'legacy');
+    diag('Failed to load legacy provider: PEM_get_string_PrivateKey may fail')
+	unless $provider;
+}
+
 my $ca_crt_pem = data_file_path('root-ca.cert.pem');
 my $ca_key_pem = data_file_path('root-ca.key.pem');
 

--- a/typemap
+++ b/typemap
@@ -81,6 +81,9 @@ cb_ssl_int_int_ret_void *  T_PTR
 cb_ssl_int_int_ret_RSA *  T_PTR
 cb_ssl_int_int_ret_DH  *  T_PTR
 perl_filehandle_t T_PERL_IO_HANDLE
+OSSL_LIB_CTX * T_PTR
+OSSL_PROVIDER * T_PTR
+const OSSL_PROVIDER * T_PTR
 
 INPUT
 


### PR DESCRIPTION
Expose the following functions introduced in OpenSSL 3.0:
 * OSSL_LIB_CTX_get0_global_default

 * OSSL_PROVIDER_load
 * OSSL_PROVIDER_try_load
 * OSSL_PROVIDER_unload
 * OSSL_PROVIDER_available
 * OSSL_PROVIDER_do_all
 * OSSL_PROVIDER_get0_name
 * OSSL_PROVIDER_self_test

Update SSLeay.pod and add test files 22_provider*.t.

With OpenSSL 3.0 and later, the legacy provider is loaded in
33_x509_create_cert.t to allow PEM_get_string_PrivateKey continue working until
its default encryption method is updated. Fixes GH-272 and closes GH-273.