### PR TITLE
43_misc_functions.t: account for missing TLS1_3_VERSION in LibreSSL

### DIFF
--- a/Changes
+++ b/Changes
@@ -32,6 +32,8 @@ Revision history for Perl extension Net::SSLeay.
 	- In 36_verify.t, account for the presence of the X509_V_FLAG_LEGACY_VERIFY
 	  flag (signalling the use of the legacy X.509 verifier) in LibreSSL 3.3.2 and
 	  above.
+	- In 43_misc_functions.t, account for the fact that LibreSSL 3.2.0 and above
+	  implement TLSv1.3 without exposing a TLS1_3_VERSION constant.
 
 1.90 2021-01-21
 	- New stable release incorporating all changes from developer releases

--- a/t/local/43_misc_functions.t
+++ b/t/local/43_misc_functions.t
@@ -55,14 +55,14 @@ our %aead_cipher_to_keyblock_size = (%tls_1_2_aead_cipher_to_keyblock_size, %tls
 # Combine the hashes
 our %cipher_to_keyblock_size = (%non_aead_cipher_to_keyblock_size, %aead_cipher_to_keyblock_size);
 
-our %version_str2int =
-    (
-     'SSLv3'   => sub {return eval {Net::SSLeay::SSL3_VERSION();}},
-     'TLSv1'   => sub {return eval {Net::SSLeay::TLS1_VERSION();}},
-     'TLSv1.1' => sub {return eval {Net::SSLeay::TLS1_1_VERSION();}},
-     'TLSv1.2' => sub {return eval {Net::SSLeay::TLS1_2_VERSION();}},
-     'TLSv1.3' => sub {return eval {Net::SSLeay::TLS1_3_VERSION();}},
-    );
+our %version_str2int = (
+    'SSLv3'   => sub { return eval { Net::SSLeay::SSL3_VERSION(); } },
+    'TLSv1'   => sub { return eval { Net::SSLeay::TLS1_VERSION(); } },
+    'TLSv1.1' => sub { return eval { Net::SSLeay::TLS1_1_VERSION(); } },
+    'TLSv1.2' => sub { return eval { Net::SSLeay::TLS1_2_VERSION(); } },
+    # LibreSSL >= 3.2.0 implements TLSv1.3, but doesn't define TLS1_3_VERSION
+    'TLSv1.3' => sub { return is_libressl() ? 0x0304 : eval { Net::SSLeay::TLS1_3_VERSION(); } },
+);
 
 # Tests that don't need a connection
 client_test_ciphersuites();


### PR DESCRIPTION
LibreSSL contains an implementation of TLSv1.3 starting with version 3.2.0, but doesn't define OpenSSL's `TLS1_3_VERSION` constant. This confuses `t/local/43_misc_functions.t`, which verifies (among other things) that both sides of a test server and test client can agree on which version of the TLS protocol they negotiated by checking the return values of `SSL_get_version()` and `SSL_version()`. The expected return values of `SSL_version()` are derived from the value of the `TLS*_VERSION` constants, causing problems on LibreSSL because TLSv1.3 is successfully negotiated but the test has no idea which version number it should be
checking against.

Work around the lack of `TLS1_3_VERSION` in LibreSSL by hardcoding the TLSv1.3 protocol version number from RFC 8446 (0x0304) in place of `TLS1_3_VERSION` in `t/local/43_misc_functions.t`.

Fixes #300.