### PR TITLE
Support LibreSSL 3.3 series

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@
 #
 # - libssl: the latest patch release of every minor release between:
 #   - OpenSSL: 0.9.8 and 1.1.1
-#   - LibreSSL: 2.2 and 3.1
+#   - LibreSSL: 2.2 and 3.1, 3.3
 
 name: CI
 
@@ -48,6 +48,7 @@ jobs:
           - { name: 'openssl', display_name: 'OpenSSL', version: '1.0.1u' }
           - { name: 'openssl', display_name: 'OpenSSL', version: '1.0.0t' }
           - { name: 'openssl', display_name: 'OpenSSL', version: '0.9.8zh' }
+          - { name: 'libressl', display_name: 'LibreSSL', version: '3.3.4' }
           - { name: 'libressl', display_name: 'LibreSSL', version: '3.1.5' }
           - { name: 'libressl', display_name: 'LibreSSL', version: '3.0.2' }
           - { name: 'libressl', display_name: 'LibreSSL', version: '2.9.2' }

--- a/README
+++ b/README
@@ -24,9 +24,9 @@ One of the following libssl implementations:
 * Any stable release of OpenSSL (https://www.openssl.org) in the
   0.9.8 - 1.1.1 branches, except for OpenSSL 0.9.8 - 0.9.8b.
 * Any stable release of LibreSSL (https://www.libressl.org) in the
-  2.0 - 3.1 series.
+  2.0 - 3.1 series or 3.3 series.
 
-Net-SSLeay may not compile or pass its tests against newer releases
+Net-SSLeay may not compile or pass its tests against releases other
 than the ones listed above due to libssl API incompatibilities, or, in
 the case of LibreSSL, because of deviations from the libssl API.
 

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -55,11 +55,11 @@ branches, except for OpenSSL 0.9.8 - 0.9.8b.
 =item *
 
 Any stable release of L<LibreSSL|https://www.libressl.org> in the 2.0 - 3.1
-series.
+series or 3.3 series.
 
 =back
 
-Net::SSLeay may not function as expected with newer releases than the ones
+Net::SSLeay may not function as expected with releases other than the ones
 listed above due to libssl API incompatibilities, or, in the case of LibreSSL,
 because of deviations from the libssl API.
 


### PR DESCRIPTION
Now that Net::SSLeay is compatible with LibreSSL's 3.3 series, advertise support for it in the documentation, and run our CI tests against LibreSSL 3.3.4 (the latest release in that series) on Ubuntu.

Closes #302.