### PR TITLE
CI: test against OpenSSL 1.1.1l on Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           - '5.10'
           - '5.8'
         libssl:
-          - { name: 'openssl', display_name: 'OpenSSL', version: '1.1.1h' }
+          - { name: 'openssl', display_name: 'OpenSSL', version: '1.1.1l' }
           - { name: 'openssl', display_name: 'OpenSSL', version: '1.1.0l' }
           - { name: 'openssl', display_name: 'OpenSSL', version: '1.0.2u' }
           - { name: 'openssl', display_name: 'OpenSSL', version: '1.0.1u' }


### PR DESCRIPTION
This is the latest patch release on the OpenSSL 1.1.1 branch.

Closes #304.