### PR TITLE
CI: test against Perl 5.34 on Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         perl:
+          - '5.34'
           - '5.32'
           - '5.30'
           - '5.28'


### PR DESCRIPTION
This is the latest minor Perl version.

Closes #306.