### PR TITLE
Support OpenSSL 3.0 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@
 # - Perl: the latest patch release of every minor release since 5.8
 #
 # - libssl: the latest patch release of every minor release between:
-#   - OpenSSL: 0.9.8 and 1.1.1
+#   - OpenSSL: 0.9.8 and 3.0
 #   - LibreSSL: 2.2 and 3.1, 3.3
 
 name: CI
@@ -43,6 +43,7 @@ jobs:
           - '5.10'
           - '5.8'
         libssl:
+          - { name: 'openssl', display_name: 'OpenSSL', version: '3.0.0' }
           - { name: 'openssl', display_name: 'OpenSSL', version: '1.1.1l' }
           - { name: 'openssl', display_name: 'OpenSSL', version: '1.1.0l' }
           - { name: 'openssl', display_name: 'OpenSSL', version: '1.0.2u' }

--- a/README
+++ b/README
@@ -22,7 +22,7 @@ Perl 5.8.1 or higher.
 One of the following libssl implementations:
 
 * Any stable release of OpenSSL (https://www.openssl.org) in the
-  0.9.8 - 1.1.1 branches, except for OpenSSL 0.9.8 - 0.9.8b.
+  0.9.8 - 3.0 branches, except for OpenSSL 0.9.8 - 0.9.8b.
 * Any stable release of LibreSSL (https://www.libressl.org) in the
   2.0 - 3.1 series or 3.3 series.
 

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -49,7 +49,7 @@ Net::SSLeay supports the following libssl implementations:
 
 =item *
 
-Any stable release of L<OpenSSL|https://www.openssl.org> in the 0.9.8 - 1.1.1
+Any stable release of L<OpenSSL|https://www.openssl.org> in the 0.9.8 - 3.0
 branches, except for OpenSSL 0.9.8 - 0.9.8b.
 
 =item *


### PR DESCRIPTION
Now that Net::SSLeay is compatible with OpenSSL's 3.0 branch, advertise support for it in the documentation, and run our CI tests against OpenSSL 3.0.0 on Ubuntu.

Closes #308.