### PR TITLE
Implement non-core test functions in Test::Net::SSLeay

### DIFF
--- a/Changes
+++ b/Changes
@@ -46,6 +46,10 @@ Revision history for Perl extension Net::SSLeay.
 	  33_x509_create_cert.t to allow PEM_get_string_PrivateKey to
 	  continue working until its default encryption method is
 	  updated. Fixes GH-272 and closes GH-273.
+	- Remove the test suite's optional dependency on the non-core modules
+	  Test::Exception, Test::NoWarnings and Test::Warn. Tests that verify
+	  Net::SSLeay's behaviour when errors occur are now executed regardless of the
+	  availability of these modules.
 
 1.90 2021-01-21
 	- New stable release incorporating all changes from developer releases

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -63,6 +63,7 @@ my %eumm_args = (
     'SelectSaver' => '0',
     'Socket' => '0',
     'Storable' => '0',
+    'Test::Builder' => '0',
     'Test::More' => '0.60_01',
     'base' => '0',
   },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -59,7 +59,6 @@ my %eumm_args = (
     'English' => '0',
     'File::Basename' => '0',
     'File::Spec::Functions' => '0',
-    'List::Util' => '0',
     'Scalar::Util' => '0',
     'SelectSaver' => '0',
     'Socket' => '0',

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -59,6 +59,7 @@ my %eumm_args = (
     'English' => '0',
     'File::Basename' => '0',
     'File::Spec::Functions' => '0',
+    'List::Util' => '0',
     'Scalar::Util' => '0',
     'SelectSaver' => '0',
     'Socket' => '0',

--- a/inc/Test/Net/SSLeay.pm
+++ b/inc/Test/Net/SSLeay.pm
@@ -11,7 +11,6 @@ use Cwd qw(abs_path);
 use English qw( $EVAL_ERROR $OSNAME $PERL_VERSION -no_match_vars );
 use File::Basename qw(dirname);
 use File::Spec::Functions qw( abs2rel catfile );
-use List::Util qw(all);
 use Test::Builder;
 use Test::Net::SSLeay::Socket;
 
@@ -76,6 +75,16 @@ my ( $test_no_warnings, $test_no_warnings_name, @warnings );
 
 END {
     _test_no_warnings() if $test_no_warnings;
+}
+
+sub _all {
+    my ( $sub, @list ) = @_;
+
+    for (@list) {
+        $sub->() or return 0;
+    }
+
+    return 1;
 }
 
 sub _diag {
@@ -493,7 +502,7 @@ sub warns_like {
     $SIG{__WARN__} = 'DEFAULT';
 
     my $test =    scalar @got == scalar @expected
-               && all { $got[$_] =~ $expected[$_] } ( 0 .. $#got );
+               && _all( sub { $got[$_] =~ $expected[$_] }, 0 .. $#got );
 
     $tester->ok( $test, $name )
         or do {

--- a/inc/Test/Net/SSLeay.pm
+++ b/inc/Test/Net/SSLeay.pm
@@ -197,7 +197,7 @@ sub data_file_path {
 sub dies_like {
     my ( $sub, $expected, $name ) = @_;
 
-    my $got;
+    my $got = '';
 
     if ( eval { $sub->(); 1 } ) {
         $tester->ok ( 0, $name );

--- a/t/local/04_basic.t
+++ b/t/local/04_basic.t
@@ -3,24 +3,19 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay;
+use Test::Net::SSLeay qw(lives_ok);
 
 plan tests => 16;
 
-eval "use Test::Exception;";
-SKIP: {
-    skip 'Test::Exception required for some tests', 8 if $@;
-    lives_ok( sub { Net::SSLeay::randomize() }, 'seed pseudorandom number generator' );
-    lives_ok( sub { Net::SSLeay::ERR_load_crypto_strings() }, 'load libcrypto error strings' );
-    lives_ok( sub { Net::SSLeay::load_error_strings() }, 'load libssl error strings' );
-    lives_ok( sub { Net::SSLeay::library_init() }, 'register default TLS ciphers and digest functions' );
-    lives_ok( sub { Net::SSLeay::OpenSSL_add_all_digests() }, 'register all digest functions' );
-    #version numbers: 0x00903100 ~ 0.9.3, 0x0090600f ~ 0.6.9
-    ok( Net::SSLeay::SSLeay() >= 0x00903100, 'SSLeay (version min 0.9.3)' );
-    isnt( Net::SSLeay::SSLeay_version(), '', 'SSLeay (version string)' );
-    is( Net::SSLeay::SSLeay_version(),  Net::SSLeay::SSLeay_version(Net::SSLeay::SSLEAY_VERSION()), 'SSLeay_version optional argument' );
-}
-
+lives_ok( sub { Net::SSLeay::randomize() }, 'seed pseudorandom number generator' );
+lives_ok( sub { Net::SSLeay::ERR_load_crypto_strings() }, 'load libcrypto error strings' );
+lives_ok( sub { Net::SSLeay::load_error_strings() }, 'load libssl error strings' );
+lives_ok( sub { Net::SSLeay::library_init() }, 'register default TLS ciphers and digest functions' );
+lives_ok( sub { Net::SSLeay::OpenSSL_add_all_digests() }, 'register all digest functions' );
+#version numbers: 0x00903100 ~ 0.9.3, 0x0090600f ~ 0.6.9
+ok( Net::SSLeay::SSLeay() >= 0x00903100, 'SSLeay (version min 0.9.3)' );
+isnt( Net::SSLeay::SSLeay_version(), '', 'SSLeay (version string)' );
+is( Net::SSLeay::SSLeay_version(),  Net::SSLeay::SSLeay_version(Net::SSLeay::SSLEAY_VERSION()), 'SSLeay_version optional argument' );
 is(Net::SSLeay::hello(), 1, 'hello world');
 
 if (exists &Net::SSLeay::OpenSSL_version)

--- a/t/local/30_error.t
+++ b/t/local/30_error.t
@@ -1,14 +1,13 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw(initialise_libssl);
+use Test::Net::SSLeay qw(
+    doesnt_warn dies_like initialise_libssl lives_ok warns_like
+);
 
-eval "use Test::Exception; use Test::Warn; use Test::NoWarnings; 1;";
-if ($@) {
-    plan skip_all => 'Requires Test::Exception, Test::Warn and Test::NoWarnings';
-} else {
-    plan tests => 11;
-}
+plan tests => 11;
+
+doesnt_warn('tests run without outputting unexpected warnings');
 
 initialise_libssl();
 
@@ -28,7 +27,7 @@ $err_string    = "foo $$: 1 - error:2006D080:BIO routines:"
 # therefore the qr match strings below have been chnaged so they dont have tooccur at the 
 # beginning of the line.
 {
-    throws_ok(sub {
+    dies_like(sub {
             Net::SSLeay::die_now('test')
     }, qr/$$: test\n$/, 'die_now dies without errors');
 
@@ -37,12 +36,12 @@ $err_string    = "foo $$: 1 - error:2006D080:BIO routines:"
     }, 'die_if_ssl_error lives without errors');
 
     put_err();
-    throws_ok(sub {
+    dies_like(sub {
             Net::SSLeay::die_now('test');
     }, qr/$$: test\n$/, 'die_now dies with errors');
 
     put_err();
-    throws_ok(sub {
+    dies_like(sub {
             Net::SSLeay::die_if_ssl_error('test');
     }, qr/$$: test\n$/, 'die_if_ssl_error dies with errors');
 }
@@ -50,7 +49,7 @@ $err_string    = "foo $$: 1 - error:2006D080:BIO routines:"
 {
     local $Net::SSLeay::trace = 1;
 
-    throws_ok(sub {
+    dies_like(sub {
             Net::SSLeay::die_now('foo');
     }, qr/$$: foo\n$/, 'die_now dies without arrors and with trace');
 
@@ -59,15 +58,15 @@ $err_string    = "foo $$: 1 - error:2006D080:BIO routines:"
     }, 'die_if_ssl_error lives without errors and with trace');
 
     put_err();
-    warning_like(sub {
-            throws_ok(sub {
+    warns_like(sub {
+            dies_like(sub {
                     Net::SSLeay::die_now('foo');
             }, qr/^$$: foo\n$/, 'die_now dies with errors and trace');
     }, qr/$err_string/i, 'die_now raises warnings about the occurred error when tracing');
 
     put_err();
-    warning_like(sub {
-            throws_ok(sub {
+    warns_like(sub {
+            dies_like(sub {
                 Net::SSLeay::die_if_ssl_error('foo');
             }, qr/^$$: foo\n$/, 'die_if_ssl_error dies with errors and trace');
     }, qr/$err_string/i, 'die_if_ssl_error raises warnings about the occurred error when tracing');

--- a/t/local/30_error.t
+++ b/t/local/30_error.t
@@ -2,7 +2,7 @@ use lib 'inc';
 
 use Net::SSLeay;
 use Test::Net::SSLeay qw(
-    doesnt_warn dies_like initialise_libssl lives_ok warns_like
+    dies_like doesnt_warn initialise_libssl lives_ok warns_like
 );
 
 plan tests => 11;

--- a/t/local/31_rsa_generate_key.t
+++ b/t/local/31_rsa_generate_key.t
@@ -1,14 +1,9 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw(initialise_libssl);
+use Test::Net::SSLeay qw( dies_like initialise_libssl lives_ok );
 
-eval 'use Test::Exception';
-if ($@) {
-    plan skip_all => 'Test::Exception required';
-} else {
-    plan tests => 14;
-}
+plan tests => 14;
 
 initialise_libssl();
 
@@ -16,9 +11,9 @@ lives_ok(sub {
         Net::SSLeay::RSA_generate_key(2048, 0x10001);
 }, 'RSA_generate_key with valid callback');
 
-dies_ok(sub {
+dies_like(sub {
         Net::SSLeay::RSA_generate_key(2048, 0x10001, 1);
-}, 'RSA_generate_key with invalid callback');
+}, qr/Undefined subroutine &main::1 called/, 'RSA_generate_key with invalid callback');
 
 {
     my $called = 0;


### PR DESCRIPTION
Eliminate the test suite's dependency on the optional non-core modules Test::Exception, Test::NoWarnings and Test::Warn by reimplementing the basic functionality provided by the following test functions in Test::Net::SSLeay:

* Test::Exception:
  * `dies_ok` (reimplemented as `dies_ok`)
  * `lives_ok` (reimplemented as `lives_ok`)
  * `throws_ok` (reimplemented as `dies_like`)
* Test::NoWarnings:
  * `had_no_warnings` (reimplemented as `doesnt_warn`)
* Test::Warn:
  * `warning_like`/`warnings_like` (reimplemented as `warns_like`)

Closes #310.