### PR TITLE
36_verify.t: don't expect legacy verifier flag with LibreSSL 3.4.1

### DIFF
--- a/Changes
+++ b/Changes
@@ -53,6 +53,9 @@ Revision history for Perl extension Net::SSLeay.
 	- Fully automate the process of changing the list of constants exported by
 	  Net::SSLeay. Fixes GH-313.
 	- Perform function autoloading tests in the test suite. Fixes GH-311.
+	- In 36_verify.t, account for the fact that the X509_V_FLAG_LEGACY_VERIFY flag
+	  (signalling the use of the legacy X.509 verifier) is no longer exposed as of
+	  LibreSSL 3.4.1. Fixes GH-324.
 
 1.90 2021-01-21
 	- New stable release incorporating all changes from developer releases

--- a/t/local/36_verify.t
+++ b/t/local/36_verify.t
@@ -41,11 +41,13 @@ SKIP: {
 SKIP: {
   skip 'openssl-0.9.8a required', 3 unless Net::SSLeay::SSLeay >= 0x0090801f;
 
-  # From version 3.3.2, LibreSSL signals the use of its legacy X.509 verifier
-  # via the X509_V_FLAG_LEGACY_VERIFY flag; this flag persists even after
-  # X509_VERIFY_PARAM_clear_flags() is called
+  # Between versions 3.3.2 and 3.4.0, LibreSSL signals the use of its legacy
+  # X.509 verifier via the X509_V_FLAG_LEGACY_VERIFY flag; this flag persists
+  # even after X509_VERIFY_PARAM_clear_flags() is called
   my $base_flags =
-      is_libressl() && Net::SSLeay::constant("LIBRESSL_VERSION_NUMBER") >= 0x3030200f
+      is_libressl()
+          && Net::SSLeay::constant("LIBRESSL_VERSION_NUMBER") >= 0x3030200f
+          && Net::SSLeay::constant("LIBRESSL_VERSION_NUMBER") <= 0x3040000f
     ? Net::SSLeay::X509_V_FLAG_LEGACY_VERIFY()
     : 0;
 


### PR DESCRIPTION
From LibreSSL 3.4.1 onwards, the use of the legacy X.509 verifier is no longer exposed in the return value of `X509_VERIFY_PARAM_get_flags()`, thus reverting to LibreSSL's pre-3.3.2 behaviour. Only expect the `X509_V_FLAG_LEGACY_VERIFY` flag to be set in this return value for versions of LibreSSL between 3.3.2 and 3.4.0.

Closes #324.