### PR TITLE
Support LibreSSL 3.2 series

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@
 #
 # - libssl: the latest patch release of every minor release between:
 #   - OpenSSL: 0.9.8 and 3.0
-#   - LibreSSL: 2.2 and 3.1, 3.4
+#   - LibreSSL: 2.2 and 3.4
 
 name: CI
 
@@ -110,6 +110,7 @@ jobs:
         libressl:
           - '3.4.1'
           - '3.3.5'
+          - '3.2.7'
           - '3.1.5'
           - '3.0.2'
           - '2.9.2'

--- a/Changes
+++ b/Changes
@@ -6,6 +6,9 @@ Revision history for Perl extension Net::SSLeay.
     const/non-const mismatch warning that broke the build on OpenVMS.
 	- Create SSL_CTXs with Test::Net::SSLeay's new_ctx() function for tests that
 	  are broken with LibreSSL 3.2. Partially fixes GH-232.
+	- In 36_verify.t, account for the presence of the X509_V_FLAG_LEGACY_VERIFY
+	  flag (signalling the use of the legacy X.509 verifier) in LibreSSL 3.2
+	  versions from 3.2.4 onwards. Fixes the remainder of GH-232.
 
 1.91_01 2021-10-24
 	- Correct X509_STORE_CTX_init() return value to integer. Previous

--- a/Changes
+++ b/Changes
@@ -9,6 +9,10 @@ Revision history for Perl extension Net::SSLeay.
 	- In 36_verify.t, account for the presence of the X509_V_FLAG_LEGACY_VERIFY
 	  flag (signalling the use of the legacy X.509 verifier) in LibreSSL 3.2
 	  versions from 3.2.4 onwards. Fixes the remainder of GH-232.
+	- Note in the Net::SSLeay documentation that the TLS 1.3 implementation in
+	  LibreSSL 3.1 - 3.3, parts of which are enabled by default, is not
+	  libssl-compatible. See the "KNOWN BUGS AND CAVEATS" section of
+	  lib/Net/SSLeay.pod for details.
 
 1.91_01 2021-10-24
 	- Correct X509_STORE_CTX_init() return value to integer. Previous

--- a/Changes
+++ b/Changes
@@ -4,6 +4,8 @@ Revision history for Perl extension Net::SSLeay.
   - On OpenVMS, detect vendor SSL111 product based on OpenSSL 1.1.x.
   - Cast the return value of OCSP_SINGLERESP_get0_id to fix a
     const/non-const mismatch warning that broke the build on OpenVMS.
+	- Create SSL_CTXs with Test::Net::SSLeay's new_ctx() function for tests that
+	  are broken with LibreSSL 3.2. Partially fixes GH-232.
 
 1.91_01 2021-10-24
 	- Correct X509_STORE_CTX_init() return value to integer. Previous

--- a/README
+++ b/README
@@ -24,7 +24,7 @@ One of the following libssl implementations:
 * Any stable release of OpenSSL (https://www.openssl.org) in the
   0.9.8 - 3.0 branches, except for OpenSSL 0.9.8 - 0.9.8b.
 * Any stable release of LibreSSL (https://www.libressl.org) in the
-  2.0 - 3.1 series or 3.3 - 3.4 series.
+  2.0 - 3.4 series, except for LibreSSL 3.2.2 and 3.2.3.
 
 Net-SSLeay may not compile or pass its tests against releases other
 than the ones listed above due to libssl API incompatibilities, or, in

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -54,8 +54,8 @@ branches, except for OpenSSL 0.9.8 - 0.9.8b.
 
 =item *
 
-Any stable release of L<LibreSSL|https://www.libressl.org> in the 2.0 - 3.1
-series or 3.3 - 3.4 series.
+Any stable release of L<LibreSSL|https://www.libressl.org> in the 2.0 - 3.4
+series, except for LibreSSL 3.2.2 and 3.2.3.
 
 =back
 
@@ -9932,6 +9932,17 @@ Or alternatively you can just use the following convenience functions:
     $got = Net::SSLeay::ssl_read_all($ssl) or die "ssl read failure";
 
 =head1 KNOWN BUGS AND CAVEATS
+
+LibreSSL versions in the 3.1 - 3.3 series contain a TLS 1.3 implementation that
+is not fully compatible with the libssl API, but is still advertised during
+protocol auto-negotiation. If you encounter problems or unexpected behaviour
+with SSL or SSL_CTX objects whose protocol version was automatically negotiated
+and libssl is provided by any of these versions of LibreSSL, it could be because
+the peers negotiated to use TLS 1.3 - try setting the maximum protocol version
+to TLS 1.2 (via C<Net::SSLeay::set_max_proto_version()> or
+C<Net::SSLeay::CTX_set_max_proto_version()>) before establishing the connection.
+The first stable LibreSSL version with a fully libssl-compatible TLS 1.3
+implementation is 3.4.1.
 
 An OpenSSL bug CVE-2015-0290 "OpenSSL Multiblock Corrupted Pointer Issue" 
 can cause POST requests of over 90kB to fail or crash. This bug is reported to be fixed in

--- a/t/local/36_verify.t
+++ b/t/local/36_verify.t
@@ -4,7 +4,8 @@ use lib 'inc';
 
 use Net::SSLeay;
 use Test::Net::SSLeay qw(
-    can_fork data_file_path initialise_libssl is_libressl is_openssl tcp_socket
+    can_fork data_file_path initialise_libssl is_libressl is_openssl new_ctx
+    tcp_socket
 );
 
 plan tests => 105;
@@ -294,7 +295,7 @@ sub client {
 		      wildcard_checks
 		      finish))
     {
-	$ctx = Net::SSLeay::CTX_new();
+	$ctx = new_ctx();
 	is(Net::SSLeay::CTX_load_verify_locations($ctx, $ca_pem, $ca_dir), 1, "load_verify_locations($ca_pem $ca_dir)");
 
 	$cl = $server->connect();
@@ -310,7 +311,7 @@ sub client {
     }
 
     # Tell the server to quit and see that our connection is still up
-    $ctx = Net::SSLeay::CTX_new();
+    $ctx = new_ctx();
     my $ssl = Net::SSLeay::new($ctx);
     Net::SSLeay::set_fd($ssl, $cl);
     Net::SSLeay::connect($ssl);
@@ -333,7 +334,7 @@ sub run_server
     return if $pid != 0;
 
     $SIG{'PIPE'} = 'IGNORE';
-    my $ctx = Net::SSLeay::CTX_new();
+    my $ctx = new_ctx();
     Net::SSLeay::set_cert_and_key($ctx, $cert_pem, $key_pem);
     my $ret = Net::SSLeay::CTX_check_private_key($ctx);
     BAIL_OUT("Server: CTX_check_private_key failed: $cert_pem, $key_pem") unless $ret == 1;

--- a/t/local/36_verify.t
+++ b/t/local/36_verify.t
@@ -42,12 +42,12 @@ SKIP: {
 SKIP: {
   skip 'openssl-0.9.8a required', 3 unless Net::SSLeay::SSLeay >= 0x0090801f;
 
-  # Between versions 3.3.2 and 3.4.0, LibreSSL signals the use of its legacy
+  # Between versions 3.2.4 and 3.4.0, LibreSSL signals the use of its legacy
   # X.509 verifier via the X509_V_FLAG_LEGACY_VERIFY flag; this flag persists
   # even after X509_VERIFY_PARAM_clear_flags() is called
   my $base_flags =
       is_libressl()
-          && Net::SSLeay::constant("LIBRESSL_VERSION_NUMBER") >= 0x3030200f
+          && Net::SSLeay::constant("LIBRESSL_VERSION_NUMBER") >= 0x3020400f
           && Net::SSLeay::constant("LIBRESSL_VERSION_NUMBER") <= 0x3040000f
     ? Net::SSLeay::X509_V_FLAG_LEGACY_VERIFY()
     : 0;


### PR DESCRIPTION
Ensure the test suite passes with versions of LibreSSL in the 3.2 series from 3.2.4 onwards, advertise support for it in the documentation (while mentioning the caveats of using Net::SSLeay in combination with it), and run our CI tests against LibreSSL 3.2.7 (the latest stable release in the series) on Ubuntu.

Closes #232.