### PR TITLE
GH-152 Enhance RAND_file_name tests to be environment independent.

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,11 +22,16 @@ Revision history for Perl extension Net::SSLeay.
 	- Expose SSL_CTX_set_keylog_callback and
 	  SSL_CTX_get_keylog_callback available with OpenSSL 1.1.1pre1
 	  and later.
-	- Enhance 10_rand.t tests so that they don't depend on the
-	  runtime environment variables, such as HOME and
-	  RANDFILE. Address differences between OpenSSL versions. Note
-	  in SSLeay.pod that RAND_file_name() can return undef with
-	  LibreSSL and recent OpenSSL versions. Fixes GH-152.
+	- Enhance 10_rand.t RAND_file_name tests: tests are no longer
+	  affected by the runtime environment variables, HOME and
+	  RANDFILE. These variables are insted controlled by the tests
+	  with local %ENV. Problems related to RAND_file_name were
+	  discussed in Github issues GH-152, and there might still be
+	  cases when, for example, setuid is used because of OpenSSL's
+	  use of glibc secure_getenv() and related functions. Address
+	  RAND_file_name differences between OpenSSL versions. Note in
+	  SSLeay.pod that RAND_file_name() can return undef with
+	  LibreSSL and recent OpenSSL versions.
 
 1.91_01 2021-10-24
 	- Correct X509_STORE_CTX_init() return value to integer. Previous

--- a/Changes
+++ b/Changes
@@ -22,6 +22,11 @@ Revision history for Perl extension Net::SSLeay.
 	- Expose SSL_CTX_set_keylog_callback and
 	  SSL_CTX_get_keylog_callback available with OpenSSL 1.1.1pre1
 	  and later.
+	- Enhance 10_rand.t tests so that they don't depend on the
+	  runtime environment variables, such as HOME and
+	  RANDFILE. Address differences between OpenSSL versions. Note
+	  in SSLeay.pod that RAND_file_name() can return undef with
+	  LibreSSL and recent OpenSSL versions. Fixes GH-152.
 
 1.91_01 2021-10-24
 	- Correct X509_STORE_CTX_init() return value to integer. Previous

--- a/Changes
+++ b/Changes
@@ -26,7 +26,7 @@ Revision history for Perl extension Net::SSLeay.
 	  affected by the runtime environment variables, HOME and
 	  RANDFILE. These variables are insted controlled by the tests
 	  with local %ENV. Problems related to RAND_file_name were
-	  discussed in Github issues GH-152, and there might still be
+	  discussed in Github issue GH-152, and there might still be
 	  cases when, for example, setuid is used because of OpenSSL's
 	  use of glibc secure_getenv() and related functions. Address
 	  RAND_file_name differences between OpenSSL versions. Note in

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -3258,7 +3258,7 @@ RAND_file_name(num)
     PREINIT:
         char *buf;
     CODE:
-        New(0, buf, num, char);
+        Newxz(buf, num, char);
         if (!RAND_file_name(buf, num)) {
             Safefree(buf);
             XSRETURN_UNDEF;

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -5423,7 +5423,9 @@ Generates a default path for the random seed file.
  my $file = Net::SSLeay::RAND_file_name($num);
  # $num - maximum size of returned file name
  #
- # returns: string with file name on success, '' (empty string) on failure
+ # returns: string with file name on success, '' (empty string) or undef on failure
+
+LibreSSL and OpenSSL 1.1.0a and later return undef when, for example, $num is not large enough to hold the filename.
 
 Check openssl doc L<http://www.openssl.org/docs/crypto/RAND_load_file.html|http://www.openssl.org/docs/crypto/RAND_load_file.html>
 

--- a/t/local/10_rand.t
+++ b/t/local/10_rand.t
@@ -54,14 +54,15 @@ sub test_rand_file_name_libressl
 # RAND_file_name return value. Note: we override environment variables
 # temporarily because some environments do not have HOME set or may
 # already have RANDFILE set. We do not try to trigger a failure which
-# happens if there's no HOME nor RANDFILE. This is because
+# happens if there's no HOME nor RANDFILE in order to keep the test
+# from becoming overly complicated.
 sub test_rand_file_name_openssl
 {
     my $file_name;
     local %ENV = %ENV;
     delete $ENV{RANDFILE};
 
-    # NOTE: If there are tests failures, are you using some type of
+    # NOTE: If there are test failures, are you using some type of
     # setuid environment? If so, this may affect usability of
     # environment variables.
 

--- a/t/local/10_rand.t
+++ b/t/local/10_rand.t
@@ -3,19 +3,19 @@
 use lib 'inc';
 
 use Net::SSLeay;
-use Test::Net::SSLeay qw( data_file_path initialise_libssl );
+use Test::Net::SSLeay qw( data_file_path initialise_libssl is_libressl );
 
-plan tests => 52;
+plan tests => 53;
 
 initialise_libssl();
 
 is(Net::SSLeay::RAND_status(), 1, 'RAND_status');
 is(Net::SSLeay::RAND_poll(), 1, 'RAND_poll');
 
-# RAND_file_name
-my $file_name = Net::SSLeay::RAND_file_name(300);
-isnt($file_name, undef, 'RAND_file_name returns defined value');
-isnt($file_name, "", "RAND_file_name returns non-empty string: $file_name");
+# RAND_file_name has significant differences between the two libraries
+is_libressl() ?
+    test_rand_file_name_libressl() :
+    test_rand_file_name_openssl();
 
 # RAND_load_file
 my $binary_file      = data_file_path('binary-test.file');
@@ -34,6 +34,59 @@ if (Net::SSLeay::constant("LIBRESSL_VERSION_NUMBER"))
 test_rand_bytes();
 
 exit(0);
+
+# With LibreSSL RAND_file_name is expected to always succeed as long
+# as the buffer size is large enough. Their manual states that it's
+# implemented for API compatibility only and its use is discouraged.
+sub test_rand_file_name_libressl
+{
+    my $file_name = Net::SSLeay::RAND_file_name(300);
+    isnt($file_name, undef, 'RAND_file_name returns defined value');
+    isnt($file_name, q{}, "RAND_file_name returns non-empty string: $file_name");
+
+    $file_name = Net::SSLeay::RAND_file_name(2);
+    is($file_name, undef, "RAND_file_name return value is undef with too short buffer");
+
+    return;
+}
+
+# With OpenSSL there are a number of options that affect
+# RAND_file_name return value. Note: we override environment variables
+# temporarily because some environments do not have HOME set or may
+# already have RANDFILE set. We do not try to trigger a failure which
+# happens if there's no HOME nor RANDFILE. This is because
+sub test_rand_file_name_openssl
+{
+    my $file_name;
+    local %ENV = %ENV;
+    delete $ENV{RANDFILE};
+
+    $ENV{HOME} = '/nosuchdir-1/home';
+    $file_name = Net::SSLeay::RAND_file_name(300);
+    if (Net::SSLeay::SSLeay() >= 0x10100006 && Net::SSLeay::SSLeay() <= 0x1010000f)
+    {
+	# This was broken starting with 1.0.0-pre6 and fixed after 1.0.0
+	is($file_name, q{}, "RAND_file_name return value is empty and doesn't include '.rnd'");
+    } else {
+	like($file_name, qr/\.rnd/s, "RAND_file_name return value '$file_name' includes '.rnd'");
+    }
+
+    my $randfile = '/nosuchdir-2/randfile';
+    $ENV{RANDFILE} = $randfile;
+    $file_name = Net::SSLeay::RAND_file_name(300);
+    is($file_name, $randfile, "RAND_file_name return value '$file_name' is RANDFILE environment value");
+
+    # RANDFILE is longer than 2 octets. OpenSSL 1.1.0a and later
+    # return undef with short buffer
+    $file_name = Net::SSLeay::RAND_file_name(2);
+    if (Net::SSLeay::SSLeay() < 0x1010001f) {
+	is($file_name, q{}, "RAND_file_name return value is empty string with too short buffer");
+    } else {
+	is($file_name, undef, "RAND_file_name return value is undef with too short buffer");
+    }
+
+    return;
+}
 
 sub test_rand_bytes
 {


### PR DESCRIPTION
Use local %ENV to set and unset environment variables that affect
RAND_file_name behaviour. Some build environments do not have, for example,
HOME set which would cause unexpected test results.

Address differences between error behaviour between OpenSSL versions.

Note in SSLeay.pod that RAND_file_name may also return undef especially with
LibreSSL and current OpenSSL versions.

Closes #152.