### PR TITLE
GH-316 Remove undefined exportable symbols from SSLeay.pm.

### DIFF
--- a/Changes
+++ b/Changes
@@ -32,6 +32,16 @@ Revision history for Perl extension Net::SSLeay.
 	  RAND_file_name differences between OpenSSL versions. Note in
 	  SSLeay.pod that RAND_file_name() can return undef with
 	  LibreSSL and recent OpenSSL versions.
+	- Removed the following exportable symbols from SSLeay.pm:
+	  - SESSION, clear_error and err have never been defined.
+	  - add_session, flush_sessions and remove_session were
+	    removed in Net::SSLeay 1.04
+	  - Undocumented X509_STORE_CTX_set_flags() was removed in
+	    Net::SSLeay 1.37 when X509_VERIFY_PARAM_* functions were
+	    added. These are preferred over directly setting the flags.
+	- Clarified Changes entry for release 1.75 to state that
+	  CTX_v2_new is not removed from Net::SSLeay. SSLv2 is
+	  completely removed in OpenSSL 1.1.0.
 
 1.91_01 2021-10-24
 	- Correct X509_STORE_CTX_init() return value to integer. Previous
@@ -691,7 +701,7 @@ Revision history for Perl extension Net::SSLeay.
      - SSL_set_state removed with 1.1
      - SSL_get_state and SSL_state are now equivalent and available in all
        versions
-     - SSL_CTX_v2_new removed
+     - SSL_CTX_v2_new is not available with 1.1 and later. SSLv2 is removed in 1.1.
      - SESSION_set_master_key removed with 1.1. Code that previously used
        SESSION_set_master_key must now set $secret in the session_secret
        callback set with SSL_set_session_secret_cb

--- a/lib/Net/SSLeay.pm
+++ b/lib/Net/SSLeay.pm
@@ -696,14 +696,12 @@ my @functions = qw(
     PEM_read_bio_X509_CRL
     RSA_free
     RSA_generate_key
-    SESSION
     SESSION_free
     SESSION_get_master_key
     SESSION_new
     SESSION_print
     X509_NAME_get_text_by_NID
     X509_NAME_oneline
-    X509_STORE_CTX_set_flags
     X509_STORE_add_cert
     X509_STORE_add_crl
     X509_check_email
@@ -717,9 +715,7 @@ my @functions = qw(
     X509_load_cert_file
     X509_load_crl_file
     accept
-    add_session
     clear
-    clear_error
     connect
     copy_session_id
     d2i_SSL_SESSION
@@ -727,8 +723,6 @@ my @functions = qw(
     die_now
     do_https
     dump_peer_certificate
-    err
-    flush_sessions
     free
     get_cipher
     get_cipher_list
@@ -766,7 +760,6 @@ my @functions = qw(
     post_httpx4
     print_errs
     read
-    remove_session
     rstate_string
     rstate_string_long
     set_bio


### PR DESCRIPTION
Remove undefined symbols from SSLeay.pm @EXPORT_OK:

- SESSION, clear_error and err have never been defined.
- add_session, flush_sessions and remove_session were removed in Net::SSLeay
  1.04
- Undocumented X509_STORE_CTX_set_flags() was removed in Net::SSLeay 1.37 when
  X509_VERIFY_PARAM_* functions were added. These are preferred over directly
  setting the flags.

Clarify Net::SSLeay Changes entry for release 1.75: CTX_v2_new() is not removed
from Net::SSLeay. OpenSSL 1.1.0 removed support for SSLv2 and therefore the
preprocessor directives for SSLv2 related conditional compilation had to be
updated. CTX_v2_new() remains available for OpenSSL 1.0.2 and earlier.

Closes #316.