### PR TITLE
GH-335 Ignore OpenSSL config file for better provider control.

### DIFF
--- a/t/local/22_provider.t
+++ b/t/local/22_provider.t
@@ -22,6 +22,9 @@ if (defined &Net::SSLeay::OSSL_PROVIDER_load) {
     plan(skip_all => "no support for providers");
 }
 
+# Supplied OpenSSL configuration file may load unwanted providers.
+local $ENV{OPENSSL_CONF} = '';
+
 # provider loading, availability and unloading
 {
     # See top of file why things are done in this order. We don't want

--- a/t/local/22_provider_try_load.t
+++ b/t/local/22_provider_try_load.t
@@ -17,6 +17,9 @@ if (defined &Net::SSLeay::OSSL_PROVIDER_load) {
     plan(skip_all => "no support for providers");
 }
 
+# Supplied OpenSSL configuration file may load unwanted providers.
+local $ENV{OPENSSL_CONF} = '';
+
 my ($null_provider, $default_avail, $null_avail);
 
 $null_provider = Net::SSLeay::OSSL_PROVIDER_try_load(undef, 'null', 1);

--- a/t/local/22_provider_try_load_zero_retain.t
+++ b/t/local/22_provider_try_load_zero_retain.t
@@ -17,6 +17,9 @@ if (defined &Net::SSLeay::OSSL_PROVIDER_load) {
     plan(skip_all => "no support for providers");
 }
 
+# Supplied OpenSSL configuration file may load unwanted providers.
+local $ENV{OPENSSL_CONF} = '';
+
 my ($null_provider, $default_avail, $null_avail);
 
 $null_provider = Net::SSLeay::OSSL_PROVIDER_try_load(undef, 'null', 0);


### PR DESCRIPTION
Github issue GH-335 shows that some OpenSSL installations, in this example
MacPorts, ship with an OpenSSL configuration file that automatically enables
non-default providers.

To ensure provider tests have a configuration they expect, set environment
variable OPENSSL_CONF to an empty string. According to config(5) manual page,
this is how no configuration file is loaded.