### PR TITLE
GH-320 Reorder potential library paths for macOS Monterey compatibility.

### DIFF
--- a/Changes
+++ b/Changes
@@ -32,6 +32,16 @@ Revision history for Perl extension Net::SSLeay.
 	  RAND_file_name differences between OpenSSL versions. Note in
 	  SSLeay.pod that RAND_file_name() can return undef with
 	  LibreSSL and recent OpenSSL versions.
+	- Removed the following exportable symbols from SSLeay.pm:
+	  - SESSION, clear_error and err have never been defined.
+	  - add_session, flush_sessions and remove_session were
+	    removed in Net::SSLeay 1.04
+	  - Undocumented X509_STORE_CTX_set_flags() was removed in
+	    Net::SSLeay 1.37 when X509_VERIFY_PARAM_* functions were
+	    added. These are preferred over directly setting the flags.
+	- Clarified Changes entry for release 1.75 to state that
+	  CTX_v2_new is not removed from Net::SSLeay. SSLv2 is
+	  completely removed in OpenSSL 1.1.0.
 
 1.91_01 2021-10-24
 	- Correct X509_STORE_CTX_init() return value to integer. Previous
@@ -691,7 +701,7 @@ Revision history for Perl extension Net::SSLeay.
      - SSL_set_state removed with 1.1
      - SSL_get_state and SSL_state are now equivalent and available in all
        versions
-     - SSL_CTX_v2_new removed
+     - SSL_CTX_v2_new is not available with 1.1 and later. SSLv2 is removed in 1.1.
      - SESSION_set_master_key removed with 1.1. Code that previously used
        SESSION_set_master_key must now set $secret in the session_secret
        callback set with SSL_set_session_secret_cb

--- a/Changes
+++ b/Changes
@@ -53,6 +53,11 @@ Revision history for Perl extension Net::SSLeay.
 	  functions return double and options functions return
 	  long. This partially fixes GH-315, 32bit integer Perls need
 	  to be handled separately.
+	- Work around macOS Monterey build failure during 'perl
+	  Makefile.PL' that causes perl to exit with 'WARNING:
+	  .../perl is loading libcrypto in an unsafe way' or similar
+	  message. This fixes GH-329. Thanks to Daniel J. Luke for the
+	  report and John Napiorkowski for additional help.
 
 1.91_01 2021-10-24
 	- Correct X509_STORE_CTX_init() return value to integer. Previous

--- a/Changes
+++ b/Changes
@@ -42,6 +42,17 @@ Revision history for Perl extension Net::SSLeay.
 	- Clarified Changes entry for release 1.75 to state that
 	  CTX_v2_new is not removed from Net::SSLeay. SSLv2 is
 	  completely removed in OpenSSL 1.1.0.
+	- Beginning with OpenSSL 3.0.0-alpha17, SSL_CTX_get_options()
+	  and related functions return uint64_t instead of long. For
+	  this reason constant() in constant.c and Net::SSLeay must
+	  also be able to return 64bit constants. Add uint64_t
+	  definitions to typemap file and update constant() and
+	  options functions to use uint64_t with OpenSSL 3.0.0 and
+	  later when Perl is compiled with 64bit integers. With 32bit
+	  integers, the functions remain as they are: constant()
+	  functions return double and options functions return
+	  long. This partially fixes GH-315, 32bit integer Perls need
+	  to be handled separately.
 
 1.91_01 2021-10-24
 	- Correct X509_STORE_CTX_init() return value to integer. Previous

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -218,9 +218,25 @@ sub ssleay_get_build_opts {
         }
     }
 
-    # Note: the order matters for macOS Monterey.
-    for ("$prefix/lib64", "$prefix/lib", "$prefix/out32dll", $prefix) {
-      push @{$opts->{lib_paths}}, $_ if -d $_;
+    # Directory order matters. With macOS Monterey a poisoned dylib is
+    # returned if the directory exists without the desired
+    # library. See GH-329 for more information. With Strawberry Perl
+    # 5.26 and later the paths must be in different order or the link
+    # phase fails.
+    my @try_lib_paths = (
+	["$prefix/lib64", "$prefix/lib", "$prefix/out32dll", $prefix] => sub {$OSNAME eq 'darwin' },
+	[$prefix, "$prefix/lib64", "$prefix/lib", "$prefix/out32dll"] => sub { 1 },
+    );
+    while (
+           !defined $opts->{lib_paths}
+        && defined( my $dirs = shift @try_lib_paths )
+        && defined( my $cond = shift @try_lib_paths )
+    ) {
+        if ( $cond->() ) {
+	    foreach my $dir (@{$dirs}) {
+		push @{$opts->{lib_paths}}, $dir if -d $dir;
+	    }
+	}
     }
 
     print <<EOM;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -218,7 +218,8 @@ sub ssleay_get_build_opts {
         }
     }
 
-    for ($prefix, "$prefix/lib64", "$prefix/lib", "$prefix/out32dll") {
+    # Note: the order matters for macOS Monterey.
+    for ("$prefix/lib64", "$prefix/lib", "$prefix/out32dll", $prefix) {
       push @{$opts->{lib_paths}}, $_ if -d $_;
     }
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -111,6 +111,18 @@ my %eumm_args = (
   ssleay(),
 );
 
+# See if integers are only 32 bits long. If they are, add a flag to
+# CCFLAGS. Since OpenSSL 1.1.0, a growing number of APIs are using 64
+# bit integers. This causes a problem if Perl is compiled without 64
+# bit integers. DEFINE is not used because Makefile.PL command line
+# DEFINE argument is used for enabling compile time PR1
+# etc. debugging.
+#
+# Note: 32bit integers are treated as the non-default case. When you
+# use this define, do it so that 64bit case is the default whenever
+# possible. This is safer for future library and Net::SSLeay releases.
+$eumm_args{CCFLAGS} = "-DNET_SSLEAY_32BIT_INT_PERL $Config{ccflags}" if !defined $Config{use64bitint} || $Config{use64bitint} ne 'define';
+
 # This can go when EU::MM older than 6.58 are gone
 $eumm_args{AUTHOR} = join(', ', @{$eumm_args{AUTHOR}}) unless eval { ExtUtils::MakeMaker->VERSION(6.58); };
 

--- a/constants.c
+++ b/constants.c
@@ -5,7 +5,11 @@
  * helper_script/update-exported-constants.
  */
 
+#ifdef NET_SSLEAY_32BIT_CONSTANTS
 static double
+#else
+static uint64_t
+#endif
 constant (const char *name, size_t len) {
   /* Initially switch on the length of the name.  */
   switch (len) {

--- a/helper_script/update-exported-constants
+++ b/helper_script/update-exported-constants
@@ -377,7 +377,16 @@ sub assignment_clause_for_type {
 }
 
 sub C_constant_return_type {
-    return 'static double';
+    my $ret = <<'END';
+#ifdef NET_SSLEAY_32BIT_CONSTANTS
+static double
+#else
+static uint64_t
+#endif
+END
+    # Newline is automatically added, remove ours.
+    chomp($ret);
+    return $ret;
 }
 
 sub return_statement_for_notfound {

--- a/lib/Net/SSLeay.pm
+++ b/lib/Net/SSLeay.pm
@@ -696,14 +696,12 @@ my @functions = qw(
     PEM_read_bio_X509_CRL
     RSA_free
     RSA_generate_key
-    SESSION
     SESSION_free
     SESSION_get_master_key
     SESSION_new
     SESSION_print
     X509_NAME_get_text_by_NID
     X509_NAME_oneline
-    X509_STORE_CTX_set_flags
     X509_STORE_add_cert
     X509_STORE_add_crl
     X509_check_email
@@ -717,9 +715,7 @@ my @functions = qw(
     X509_load_cert_file
     X509_load_crl_file
     accept
-    add_session
     clear
-    clear_error
     connect
     copy_session_id
     d2i_SSL_SESSION
@@ -727,8 +723,6 @@ my @functions = qw(
     die_now
     do_https
     dump_peer_certificate
-    err
-    flush_sessions
     free
     get_cipher
     get_cipher_list
@@ -766,7 +760,6 @@ my @functions = qw(
     post_httpx4
     print_errs
     read
-    remove_session
     rstate_string
     rstate_string_long
     set_bio

--- a/typemap
+++ b/typemap
@@ -86,7 +86,15 @@ OSSL_LIB_CTX * T_PTR
 OSSL_PROVIDER * T_PTR
 const OSSL_PROVIDER * T_PTR
 
+uint64_t T_UINT64
+
+OUTPUT
+T_UINT64
+    sv_setuv($arg, (UV)$var);
+
 INPUT
+T_UINT64
+    $var = (uint64_t)SvUV($arg)
 
 T_PERL_IO_HANDLE
 	if ($arg && SvOK($arg) && SvROK($arg)) {


### PR DESCRIPTION
Running 'perl Makefile.PL' may fail with:
   WARNING: .../perl is loading libcrypto in an unsafe way

See https://github.com/radiator-software/p5-net-ssleay/issues/329
and https://openradar.appspot.com/FB9725981 (linked by GH-329) for
more information.

To summarise why this commit helps in this case:

  The failure is triggered when the prospective library directory exists but
  does not contain the desired library file. That is, $prefix/lib64 does not
  trigger the failure because the directory pointed by OPENSSL_PREFIX does not
  contain lib64 subdirectory.