### PR TITLE
GH-329 Reorder potential library paths for macOS Monterey compatibility.

### DIFF
--- a/Changes
+++ b/Changes
@@ -53,6 +53,11 @@ Revision history for Perl extension Net::SSLeay.
 	  functions return double and options functions return
 	  long. This partially fixes GH-315, 32bit integer Perls need
 	  to be handled separately.
+	- Work around macOS Monterey build failure during 'perl
+	  Makefile.PL' that causes perl to exit with 'WARNING:
+	  .../perl is loading libcrypto in an unsafe way' or similar
+	  message. This fixes GH-329. Thanks to Daniel J. Luke for the
+	  report and John Napiorkowski for additional help.
 
 1.91_01 2021-10-24
 	- Correct X509_STORE_CTX_init() return value to integer. Previous

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -218,8 +218,26 @@ sub ssleay_get_build_opts {
         }
     }
 
-    for ($prefix, "$prefix/lib64", "$prefix/lib", "$prefix/out32dll") {
-      push @{$opts->{lib_paths}}, $_ if -d $_;
+    # Directory order matters. With macOS Monterey a poisoned dylib is
+    # returned if the directory exists without the desired
+    # library. See GH-329 for more information. With Strawberry Perl
+    # 5.26 and later the paths must be in different order or the link
+    # phase fails.
+    my @try_lib_paths = (
+	["$prefix/lib64", "$prefix/lib", "$prefix/out32dll", $prefix] => sub {$OSNAME eq 'darwin' },
+	[$prefix, "$prefix/lib64", "$prefix/lib", "$prefix/out32dll"] => sub { 1 },
+	);
+
+    while (
+	!defined $opts->{lib_paths}
+	&& defined( my $dirs = shift @try_lib_paths )
+	&& defined( my $cond = shift @try_lib_paths )
+    ) {
+	if ( $cond->() ) {
+	    foreach my $dir (@{$dirs}) {
+		push @{$opts->{lib_paths}}, $dir if -d $dir;
+	    }
+	}
     }
 
     print <<EOM;


### PR DESCRIPTION
Running 'perl Makefile.PL' may fail with:
   WARNING: .../perl is loading libcrypto in an unsafe way

See https://github.com/radiator-software/p5-net-ssleay/issues/329
and https://openradar.appspot.com/FB9725981 (linked by GH-329) for
more information.

To summarise why this commit helps in this case:

  The failure is triggered when the prospective library directory exists but
  does not contain the desired library file. That is, $prefix/lib64 does not
  trigger the failure because the directory pointed by OPENSSL_PREFIX does not
  contain lib64 subdirectory.

Closes GH-329.