### PR TITLE
Test::Net::SSLeay: work around BSD Clangs identifying as GCC

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 Revision history for Perl extension Net::SSLeay.
 
+????
+	- Avoid misclassifying Clang as GCC in Test::Net::SSLeay's can_thread()
+	  function. This fixes test failures in 61_threads-cb-crash.t and
+	  62_threads-ctx_new-deadlock.t on OpenBSD and FreeBSD (and possibly other OSes
+	  too). Fixes GH-350.
+
 1.91_02 2021-12-29
 	- On OpenVMS, detect vendor SSL111 product based on OpenSSL 1.1.x.
 	- Cast the return value of OCSP_SINGLERESP_get0_id to fix a

--- a/inc/Test/Net/SSLeay.pm
+++ b/inc/Test/Net/SSLeay.pm
@@ -168,9 +168,13 @@ sub can_thread {
     # (see GH #175)
     if (    $PERL_VERSION == 5.010000
         and $Config{ccname} eq 'gcc'
-        and $Config{gccversion} )
+        and defined $Config{gccversion}
+        # gccversion is sometimes defined for non-GCC compilers (see GH-350);
+        # compilers that are truly GCC are identified with a version number in
+        # gccversion
+        and $Config{gccversion} =~ /^\d+\.\d+/ )
     {
-        my ( $gcc_major, $gcc_minor ) = split /\./, $Config{gccversion};
+        my ( $gcc_major, $gcc_minor ) = split /[.\s]+/, $Config{gccversion};
 
         return 0
             if ( $gcc_major > 4 or ( $gcc_major == 4 and $gcc_minor >= 8 ) );


### PR DESCRIPTION
The Config module assigns a value of `gccversion` for BSD Clangs that contains more than just a version number (e.g. `OpenBSD Clang 10.0.1 `), which causes Test::Net::SSLeay to emit an "Argument isn't numeric in numeric gt" warning when it tries to parse it in `can_thread()`. Assume the compiler isn't GCC (thus skipping the parsing step) unless `gccversion` looks like a version number.

Closes #350.