### PR TITLE
Stable release 1.92

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,39 @@
 Revision history for Perl extension Net::SSLeay.
 
+1.92 2022-01-12
+	- New stable release incorporating all changes from developer releases 1.91_01
+	  to 1.91_03.
+	- Summary of major changes since version 1.90:
+	  - Net::SSLeay now supports stable releases of OpenSSL 3.0.
+	    - OpenSSL 3.0.0 introduces the concept of "providers", which contain
+	      cryptographic algorithm implementations. Many outdated, deprecated and/or
+	      insecure algorithms have been moved to the "legacy" provider, which may
+	      need to be loaded explicitly in order to use them with Net::SSLeay. See
+	      "Low level API: OSSL_LIB_CTX and OSSL_PROVIDER related functions" in the
+	      Net::SSLeay documentation for details.
+	    - Net::SSLeay's built-in PEM_get_string_PrivateKey() function depends on
+	      algorithms that have moved to the legacy provider described above; if
+	      OpenSSL has been compiled without the legacy provider, the tests
+	      t/local/33_x509_create_cert.t and t/local/63_ec_key_generate_key.t will
+	      fail when the test suite is run.
+	    - TLS 1.1 and below may only be used at security level 0 as of OpenSSL
+	      3.0.0; if a minimum required security level is imposed (e.g. in an
+	      OpenSSL configuration file managed by the operating system), the tests
+	      t/local/44_sess.t and t/local/45_exporter.t will fail when the test suite
+	      is run.
+	  - Net::SSLeay now supports stable releases of LibreSSL from the 3.2 - 3.4
+	    branches (with the exception of 3.2.2 and 3.2.3 - see "COMPATIBILITY" in
+	    the Net::SSLeay documentation for details).
+	    - The TLS 1.3 implementation in LibreSSL 3.1 - 3.3, parts of which are
+	      enabled by default, is not fully compatible with the libssl API and may
+	      not function as expected with Net::SSLeay; see "KNOWN BUGS AND CAVEATS"
+	      in the Net::SSLeay documentation for details.
+	  - A number of new libcrypto/libssl constants and functions are now exposed,
+	    including SSL_CTX_set_keylog_callback() and SSL_CTX_set_msg_callback(),
+	    which are helpful when debugging TLS handshakes. See the release notes for
+	    the 1.91 developer releases below for a full list of newly-exposed
+	    constants and functions.
+
 1.91_03 2022-01-10
 	- Avoid misclassifying Clang as GCC in Test::Net::SSLeay's can_thread()
 	  function. This fixes test failures in 61_threads-cb-crash.t and

--- a/Changes
+++ b/Changes
@@ -10,7 +10,7 @@ Revision history for Perl extension Net::SSLeay.
 	      insecure algorithms have been moved to the "legacy" provider, which may
 	      need to be loaded explicitly in order to use them with Net::SSLeay. See
 	      "Low level API: OSSL_LIB_CTX and OSSL_PROVIDER related functions" in the
-	      Net::SSLeay documentation for details.
+	      Net::SSLeay module documentation for details.
 	    - Net::SSLeay's built-in PEM_get_string_PrivateKey() function depends on
 	      algorithms that have moved to the legacy provider described above; if
 	      OpenSSL has been compiled without the legacy provider, the tests
@@ -23,11 +23,11 @@ Revision history for Perl extension Net::SSLeay.
 	      is run.
 	  - Net::SSLeay now supports stable releases of LibreSSL from the 3.2 - 3.4
 	    branches (with the exception of 3.2.2 and 3.2.3 - see "COMPATIBILITY" in
-	    the Net::SSLeay documentation for details).
+	    the Net::SSLeay module documentation for details).
 	    - The TLS 1.3 implementation in LibreSSL 3.1 - 3.3, parts of which are
 	      enabled by default, is not fully compatible with the libssl API and may
 	      not function as expected with Net::SSLeay; see "KNOWN BUGS AND CAVEATS"
-	      in the Net::SSLeay documentation for details.
+	      in the Net::SSLeay module documentation for details.
 	  - A number of new libcrypto/libssl constants and functions are now exposed,
 	    including SSL_CTX_set_keylog_callback() and SSL_CTX_set_msg_callback(),
 	    which are helpful when debugging TLS handshakes. See the release notes for

--- a/helper_script/generate-test-pki
+++ b/helper_script/generate-test-pki
@@ -14,7 +14,7 @@ use File::Temp;
 use Getopt::Long qw(GetOptionsFromArray);
 use IPC::Run qw( start finish timeout );
 
-our $VERSION = '1.91_03';
+our $VERSION = '1.92';
 
 local $SIG{__DIE__} = sub {
     my ($cause) = @_;
@@ -1254,7 +1254,7 @@ C<generate-test-pki> - Generate a PKI for the Net-SSLeay test suite
 
 =head1 VERSION
 
-This document describes version 1.91_03 of C<generate-test-pki>.
+This document describes version 1.92 of C<generate-test-pki>.
 
 =head1 USAGE
 

--- a/helper_script/update-exported-constants
+++ b/helper_script/update-exported-constants
@@ -14,7 +14,7 @@ use File::Spec::Functions qw(catfile);
 use Getopt::Long qw(GetOptionsFromArray);
 use POSIX qw(ceil);
 
-our $VERSION = '1.91_03';
+our $VERSION = '1.92';
 
 local $SIG{__DIE__} = sub {
     my ($cause) = @_;
@@ -427,7 +427,7 @@ C<update-exported-constants> - Manage constants exported by Net::SSLeay
 
 =head1 VERSION
 
-This document describes version 1.91_03 of C<update-exported-constants>.
+This document describes version 1.92 of C<update-exported-constants>.
 
 =head1 USAGE
 

--- a/inc/Test/Net/SSLeay.pm
+++ b/inc/Test/Net/SSLeay.pm
@@ -14,7 +14,7 @@ use File::Spec::Functions qw( abs2rel catfile );
 use Test::Builder;
 use Test::Net::SSLeay::Socket;
 
-our $VERSION = '1.91_03';
+our $VERSION = '1.92';
 
 our @EXPORT_OK = qw(
     can_fork can_really_fork can_thread
@@ -542,7 +542,7 @@ Test::Net::SSLeay - Helper module for the Net-SSLeay test suite
 
 =head1 VERSION
 
-This document describes version 1.91_03 of Test::Net::SSLeay.
+This document describes version 1.92 of Test::Net::SSLeay.
 
 =head1 SYNOPSIS
 

--- a/inc/Test/Net/SSLeay/Socket.pm
+++ b/inc/Test/Net/SSLeay/Socket.pm
@@ -13,7 +13,7 @@ use Socket qw(
     inet_aton inet_ntoa pack_sockaddr_in unpack_sockaddr_in
 );
 
-our $VERSION = '1.91_03';
+our $VERSION = '1.92';
 
 my %PROTOS = (
     tcp => SOCK_STREAM,
@@ -134,7 +134,7 @@ Test::Net::SSLeay::Socket - Socket class for the Net-SSLeay test suite
 
 =head1 VERSION
 
-This document describes version 1.91_03 of Test::Net::SSLeay::Socket.
+This document describes version 1.92 of Test::Net::SSLeay::Socket.
 
 =head1 SYNOPSIS
 

--- a/lib/Net/SSLeay.pm
+++ b/lib/Net/SSLeay.pm
@@ -70,7 +70,7 @@ $Net::SSLeay::how_random = 512;
 #   inc/Test/Net/SSLeay.pm
 #   inc/Test/Net/SSLeay/Socket.pm
 #   lib/Net/SSLeay/Handle.pm
-$VERSION = '1.91_03';
+$VERSION = '1.92';
 
 @ISA = qw(Exporter);
 

--- a/lib/Net/SSLeay/Handle.pm
+++ b/lib/Net/SSLeay/Handle.pm
@@ -57,7 +57,7 @@ you need to add to your program is the tie function as in:
 use vars qw(@ISA @EXPORT_OK $VERSION);
 @ISA = qw(Exporter);
 @EXPORT_OK = qw(shutdown);
-$VERSION = '1.91_03';
+$VERSION = '1.92';
 
 my $Initialized;       #-- only _initialize() once
 my $Debug = 0;         #-- pretty hokey


### PR DESCRIPTION
Bump all version numbers from 1.91_03 to 1.92, and summarise major changes since 1.90.

Closes #357.