### PR TITLE
Update Net::SSLeay module summary/abstract

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -36,7 +36,7 @@ my $tests = prompt(
 
 my %eumm_args = (
   NAME => 'Net::SSLeay',
-  ABSTRACT => 'Perl extension for using OpenSSL',
+  ABSTRACT => 'Perl bindings for OpenSSL and LibreSSL',
   LICENSE => 'artistic_2',
   AUTHOR => [
     'Sampo Kellomäki <sampo@iki.fi>',

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-README - Net::SSLeay Perl module for using OpenSSL
+Net-SSLeay - Perl bindings for OpenSSL and LibreSSL
 
 By popular demand...
 --------------------

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 [![GitHub Actions build status](https://github.com/radiator-software/p5-net-ssleay/workflows/CI/badge.svg?branch=master)](https://github.com/radiator-software/p5-net-ssleay/actions?query=workflow%3ACI)
 [![AppVeyor build status](https://ci.appveyor.com/api/projects/status/ss6vl40o4otdq8ii/branch/master?svg=true)](https://ci.appveyor.com/project/h-vn/p5-net-ssleay/branch/master)
 
-Net::SSLeay Perl module for using OpenSSL and LibreSSL -
-https://metacpan.org/release/Net-SSLeay
+# Net-SSLeay: Perl bindings for OpenSSL and LibreSSL
+
+Information about the latest stable release is available on
+[MetaCPAN](https://metacpan.org/release/Net-SSLeay).
 
 See [README](README) for more information about this module.

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-Net::SSLeay - Perl extension for using OpenSSL
+Net::SSLeay - Perl bindings for OpenSSL and LibreSSL
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
The new summary and abstract clarify that LibreSSL is supported as well as OpenSSL.