### PR TITLE
Use X509_get0_tbs_sigalg() for LibreSSL.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for Perl extension Net::SSLeay.
 
+????
+	- LibreSSL 3.5.0 has removed access to internal data structures. Use
+	  X509_get0_tbs_sigalg() like in OpenSSL 1.1.  Thanks to Alexander
+	  Bluhm.
+
 1.92 2022-01-12
 	- New stable release incorporating all changes from developer releases 1.91_01
 	  to 1.91_03.

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -7197,7 +7197,7 @@ ASN1_OBJECT *
 P_X509_get_signature_alg(x)
         X509 * x
     CODE:
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x3050000fL)
         RETVAL = (X509_get0_tbs_sigalg(x)->algorithm);
 #else
         RETVAL = (x->cert_info->signature->algorithm);


### PR DESCRIPTION
LibreSSL 3.5.0 has removed access to internal data structures.  Use
X509_get0_tbs_sigalg() like in OpenSSL 1.1.