### PR TITLE
GH-356 Work around 07_sslecho.t and 44_sess.t failures with older Perls on Windows.

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,11 @@ Revision history for Perl extension Net::SSLeay.
 	- LibreSSL 3.5.0 has removed access to internal data structures. Use
 	  X509_get0_tbs_sigalg() like in OpenSSL 1.1.  Thanks to Alexander
 	  Bluhm.
+	- Update tests 07_sslecho.t and 44_sess.t to work around
+	  failures seen on Windows with Perls earlier than 5.20. For
+	  the details, see GH-356 and look for CloseHandle() in Perl
+	  5.20.0 changelog. Thanks to GitHub user twata1 for the
+	  report and additional help.
 
 1.92 2022-01-12
 	- New stable release incorporating all changes from developer releases 1.91_01

--- a/t/local/07_sslecho.t
+++ b/t/local/07_sslecho.t
@@ -131,6 +131,7 @@ my @results;
 }
 
 {
+    sleep(1);
     my $s = $server->connect();
 
     push @results, [ my $ctx = new_ctx(), 'new CTX' ];
@@ -169,6 +170,7 @@ my @results;
         Net::SSLeay::CTX_set_cert_verify_callback($ctx2, \&verify4, 1);
 
         {
+            sleep(1);
             my $s = $server->connect();
 
             my $ssl = Net::SSLeay::new($ctx);
@@ -188,8 +190,11 @@ my @results;
         }
 
         {
+            sleep(1);
             my $s1 = $server->connect();
+            sleep(1);
             my $s2 = $server->connect();
+            sleep(1);
             my $s3 = $server->connect();
 
             my $ssl1 = Net::SSLeay::new($ctx);
@@ -299,6 +304,7 @@ my @results;
 }
 
 {
+    sleep(1);
     my $s = $server->connect();
 
     my $ctx = new_ctx();

--- a/t/local/07_sslecho.t
+++ b/t/local/07_sslecho.t
@@ -5,6 +5,8 @@ use Test::Net::SSLeay qw(
     can_fork data_file_path initialise_libssl new_ctx tcp_socket
 );
 
+use English qw( $EVAL_ERROR $OSNAME $PERL_VERSION -no_match_vars );
+
 BEGIN {
     if (not can_fork()) {
         plan skip_all => "fork() not supported on this system";
@@ -31,6 +33,13 @@ my $cert_issuer  = '/C=PL/O=Net-SSLeay/OU=Test Suite/CN=Intermediate CA';
 my $cert_sha1_fp = '9C:2E:90:B9:A7:84:7A:3A:2B:BE:FD:A5:D1:46:EA:31:75:E9:03:26';
 
 $ENV{RND_SEED} = '1234567890123456789012345678901234567890';
+
+# For old Perls on Windows. See GH-356 for the details.
+sub maybe_sleep
+{
+    sleep(1) if $OSNAME eq 'MSWin32' && $PERL_VERSION < 5.020000;
+    return;
+}
 
 {
     my ( $ctx, $ctx_protocol ) = new_ctx();
@@ -131,7 +140,7 @@ my @results;
 }
 
 {
-    sleep(1);
+    maybe_sleep();
     my $s = $server->connect();
 
     push @results, [ my $ctx = new_ctx(), 'new CTX' ];
@@ -170,7 +179,7 @@ my @results;
         Net::SSLeay::CTX_set_cert_verify_callback($ctx2, \&verify4, 1);
 
         {
-            sleep(1);
+            maybe_sleep();
             my $s = $server->connect();
 
             my $ssl = Net::SSLeay::new($ctx);
@@ -190,11 +199,11 @@ my @results;
         }
 
         {
-            sleep(1);
+            maybe_sleep();
             my $s1 = $server->connect();
-            sleep(1);
+            maybe_sleep();
             my $s2 = $server->connect();
-            sleep(1);
+            maybe_sleep();
             my $s3 = $server->connect();
 
             my $ssl1 = Net::SSLeay::new($ctx);
@@ -304,7 +313,7 @@ my @results;
 }
 
 {
-    sleep(1);
+    maybe_sleep();
     my $s = $server->connect();
 
     my $ctx = new_ctx();


### PR DESCRIPTION
Tests  07_sslecho.t and 44_sess.t sometimes fail on Windows. This seems to happen with older Perls where the possible cause is this bug described, and fixed, in 5.20.0 [changes](https://perldoc.perl.org/5.20.0/perldelta):
 
> On Windows, perl no longer calls CloseHandle() on a socket handle. This makes debugging easier on Windows by removing certain irrelevant bad handle exceptions. It also fixes a race condition that made socket functions randomly fail in a Perl process with multiple OS threads, and possible test failures in dist/IO/t/cachepropagate-tcp.t. [perl #120091/118059]

Details in: https://github.com/Perl/perl5/issues/12979