### PR TITLE
GH-369 Make RSA_get_key_parameters available with OpenSSL 1.1.0 and later.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,14 +1,26 @@
 Revision history for Perl extension Net::SSLeay.
 
 ????
-	- LibreSSL 3.5.0 has removed access to internal data structures. Use
-	  X509_get0_tbs_sigalg() like in OpenSSL 1.1.  Thanks to Alexander
-	  Bluhm.
+	- LibreSSL 3.5.0 has removed access to internal data
+	  structures: Use X509_get0_tbs_sigalg() and
+	  OCSP_SINGLERESP_get0_id() like in OpenSSL 1.1. Also use
+	  RSA_get0... with RSA_get_key_parameters(). Thanks to
+	  Alexander Bluhm.
+	- Expose SSL_CTX_get_min_proto_version(),
+	  SSL_CTX_get_max_proto_version(), SSL_get_min_proto_version()
+	  and SSL_get_max_proto_version() with LibresSSL 3.4.0 and
+	  later. Thanks to Alexander Bluhm.
 	- Update tests 07_sslecho.t and 44_sess.t to work around
 	  failures seen on Windows with Perls earlier than 5.20. For
 	  the details, see GH-356 and look for CloseHandle() in Perl
 	  5.20.0 changelog. Thanks to GitHub user twata1 for the
 	  report and additional help.
+	- Alexander's recent work with RSA_get_key_parameters(),
+	  allows to make it available with all OpenSSL versions. It
+	  was already available with versions earlier than 1.1.0.
+	- Expose BN_dup(), BN_clear(), BN_clear_free() and BN_free().
+	- Use PTR2IV instead of direct cast to IV to fix compilation
+	  warning with SSLeay.xs internal function bn2sv().
 
 1.92 2022-01-12
 	- New stable release incorporating all changes from developer releases 1.91_01

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -1914,10 +1914,10 @@ X509 * find_issuer(X509 *cert,X509_STORE *store, STACK_OF(X509) *chain) {
     return issuer;
 }
 
-SV* bn2sv(const BIGNUM* p_bn)
+static SV *bn2sv(const BIGNUM* p_bn)
 {
     return p_bn != NULL
-        ? sv_2mortal(newSViv((IV) BN_dup(p_bn)))
+        ? sv_2mortal(newSViv(PTR2IV(BN_dup(p_bn))))
         : &PL_sv_undef;
 }
 
@@ -6199,6 +6199,18 @@ SSL_set_tmp_rsa(ssl,rsa)
 
 #endif
 
+BIGNUM *
+BN_dup(const BIGNUM *from)
+
+void
+BN_clear(BIGNUM *bn)
+
+void
+BN_clear_free(BIGNUM *bn)
+
+void
+BN_free(BIGNUM *bn)
+
 #if OPENSSL_VERSION_NUMBER >= 0x0090800fL
 
 RSA *
@@ -6278,20 +6290,18 @@ RSA_generate_key(bits,e,perl_cb=&PL_sv_undef,perl_data=&PL_sv_undef)
 
 #endif
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
-
 void
 RSA_get_key_parameters(rsa)
 	    RSA * rsa
 PREINIT:
-#if defined(LIBRESSL_VERSION_NUMBER) && (LIBRESSL_VERSION_NUMBER >= 0x3050000fL)
+#if (!defined(LIBRESSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER >= 0x1010000fL)) || (defined(LIBRESSL_VERSION_NUMBER) && (LIBRESSL_VERSION_NUMBER >= 0x3050000fL))
     const BIGNUM *n, *e, *d;
     const BIGNUM *p, *q;
     const BIGNUM *dmp1, *dmq1, *iqmp;
 #endif
 PPCODE:
 {
-#if defined(LIBRESSL_VERSION_NUMBER) && (LIBRESSL_VERSION_NUMBER >= 0x3050000fL)
+#if (!defined(LIBRESSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER >= 0x1010000fL)) || (defined(LIBRESSL_VERSION_NUMBER) && (LIBRESSL_VERSION_NUMBER >= 0x3050000fL))
     RSA_get0_key(rsa, &n, &e, &d);
     RSA_get0_factors(rsa, &p, &q);
     RSA_get0_crt_params(rsa, &dmp1, &dmq1, &iqmp);
@@ -6316,8 +6326,6 @@ PPCODE:
     XPUSHs(bn2sv(rsa->iqmp));
 #endif
 }
-
-#endif /* OpenSSL < 1.1 or LibreSSL */
 
 void
 RSA_free(r)

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -8677,6 +8677,56 @@ Check openssl doc L<https://www.openssl.org/docs/ssl/SSL_CIPHER_get_version.html
 
 =back
 
+=head3 Low level API: BN_* related functions
+
+=over
+
+=item * BN_dup
+
+Creates and returns a new BIGNUM from an existing BIGNUM.
+
+ my $bn = Net::SSLeay::BN_dup($from)
+ # $from - value corresponding to BIGNUM structure
+ #
+ # returns: a new BIGNUM containing the value $from
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/BN_dup.html>
+
+=item * BN_clear
+
+Clears BIGNUM data when it is no longer needed.
+
+ Net::SSLeay::BN_clear($bn)
+ # $bn - value corresponding to BIGNUM structure
+ #
+ # returns: nothing. $bn is set to 0.
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/BN_clear.html>
+
+=item * BN_clear_free
+
+Clears and frees a previously allocated BIGNUM.
+
+ Net::SSLeay::BN_clear_free($bn)
+ # $bn - value corresponding to BIGNUM structure
+ #
+ # returns: nothing. $bn is no longer usable.
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/BN_clear_free.html>
+
+=item * BN_free
+
+Frees previously a allocated BIGNUM.
+
+ Net::SSLeay::BN_free($bn)
+ # $bn - value corresponding to BIGNUM structure
+ #
+ # returns: nothing. $bn is no longer usable.
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/BN_free.html>
+
+=back
+
 =head3 Low level API: RSA_* related functions
 
 =over
@@ -8709,13 +8759,28 @@ Check openssl doc L<http://www.openssl.org/docs/crypto/RSA_new.html|http://www.o
 
 =item * RSA_get_key_parameters
 
-Returns a list of pointers to BIGNUMs representing the parameters of the key in
-this order:
-(n, e, d, p, q, dmp1, dmq1, iqmp)
+B<COMPATIBILITY>: not available when OpenSSL is 1.1.0 or later and Net-SSLeay is 1.92 or earlier
 
-Caution: returned list consists of SV pointers to BIGNUMs, which would need to be blessed as Crypt::OpenSSL::Bignum for further use
+Returns a list of pointers to BIGNUMs representing the parameters of
+the key in this order: C<(n, e, d, p, q, dmp1, dmq1, iqmp)>
+
+B<Caution>: returned list consists of direct pointers to BIGNUMs. These must
+not be freed by the caller. These pointers can be used to duplicate a
+BIGNUM, which would need to be blessed as Crypt::OpenSSL::Bignum for further
+use. See L<Crypt::OpenSSL::Bignum> and OpenSSL manual for more about
+C<bless_pointer> to why C<BN_dup()> is used.
 
  my (@params) = RSA_get_key_parameters($r);
+
+ my $dup = Net::SSLeay::BN_dup($params[1]);
+ my $e = Crypt::OpenSSL::Bignum->bless_pointer($dup);
+ print "exponent: ", $e->to_decimal(), "\n";
+
+This function has no equivalent in OpenSSL or LibreSSL but combines
+functions C<RSA_get0_key>, C<RSA_get0_factors> and C<RSA_get0_crt_params> for
+an easier interface.
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/RSA_get0_key.html>
 
 =back
 

--- a/typemap
+++ b/typemap
@@ -24,6 +24,7 @@ X509_NAME_ENTRY *   T_PTR
 X509_EXTENSION *	T_PTR
 X509_REQ *      T_PTR
 X509_PUBKEY *   T_PTR
+const BIGNUM *        T_PTR
 BIGNUM *        T_PTR
 BIO *           T_PTR
 const BIO_METHOD *    T_PTR


### PR DESCRIPTION
Use work done by Alexander Bluhm to make RSA_get_key_parameters() also
available with OpenSSL 1.1.0 and later.

Expose BN_dup(), BN_clear(), BN_clear_free() and BN_free() which are useful for
working with RSA_get_key_parameters() return values and other BIGNUM pointers.

Fix a pointer cast warning in SSLeay.xs internal function bn2sv.

Update Changes with the recent LibreSSL related work.

Enhance RSA_get_key_parameters() documentation to clarify what its return
values are and how they should be used.