### PR TITLE
Gh 367 fix deprecation warnings

### DIFF
--- a/Changes
+++ b/Changes
@@ -21,6 +21,18 @@ Revision history for Perl extension Net::SSLeay.
 	- Expose BN_dup(), BN_clear(), BN_clear_free() and BN_free().
 	- Use PTR2IV instead of direct cast to IV to fix compilation
 	  warning with SSLeay.xs internal function bn2sv().
+	- Expose X509_CRL_get0_lastUpdate(),
+	  X509_CRL_get0_nextUpdate(), X509_CRL_set1_lastUpdate() and
+	  X509_CRL_set1_nextUpdate() that became available with
+	  OpenSSL 1.1.0 and LibreSSL 2.7.0. These and the respective
+	  deprecated _get/set_ aliases are available with all OpenSSL
+	  and LibreSSL versions. Fixes GH-367 and part of RT#124371
+	- Note in documentation that the X509_CRL_get* functions
+	  return a pointer to time structure that should be considered
+	  read-only.
+	- Use ASN1_STRING_get0_data() instead of ASN1_STRING_data() to
+	  avoid compile time deprecation warnings. Partly fixes
+	  RT#124371.
 
 1.92 2022-01-12
 	- New stable release incorporating all changes from developer releases 1.91_01

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -3632,12 +3632,6 @@ int
 X509_CRL_set_issuer_name(X509_CRL *x, X509_NAME *name)
 
 int
-X509_CRL_set_lastUpdate(X509_CRL *x, ASN1_TIME *tm)
-
-int
-X509_CRL_set_nextUpdate(X509_CRL *x, ASN1_TIME *tm)
-
-int
 X509_CRL_sort(X509_CRL *x)
 
 #endif
@@ -3660,7 +3654,17 @@ X509_CRL_get0_nextUpdate(const X509_CRL *crl)
 	  ALIAS:
 		X509_CRL_get_nextUpdate = 1
 
-#else /* plain get_ is deprecated */
+int
+X509_CRL_set1_lastUpdate(X509_CRL *x, ASN1_TIME *tm)
+	  ALIAS:
+		X509_CRL_set_lastUpdate = 1
+
+int
+X509_CRL_set1_nextUpdate(X509_CRL *x, ASN1_TIME *tm)
+	  ALIAS:
+		X509_CRL_set_nextUpdate = 1
+
+#else /* plain get/set is deprecated */
 
 ASN1_TIME *
 X509_CRL_get_lastUpdate(X509_CRL *x)
@@ -3671,6 +3675,16 @@ ASN1_TIME *
 X509_CRL_get_nextUpdate(X509_CRL *x)
 	  ALIAS:
 		X509_CRL_get0_nextUpdate = 1
+
+int
+X509_CRL_set_lastUpdate(X509_CRL *x, ASN1_TIME *tm)
+	  ALIAS:
+		X509_CRL_set1_lastUpdate = 1
+
+int
+X509_CRL_set_nextUpdate(X509_CRL *x, ASN1_TIME *tm)
+	  ALIAS:
+		X509_CRL_set1_nextUpdate = 1
 
 #endif
 

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -7131,27 +7131,35 @@ Returns X509_NAME object corresponding to the issuer of X509_CRL $x.
 
 See other C<X509_NAME_*> functions to get more info from X509_NAME structure.
 
-=item * X509_CRL_get_lastUpdate
+=item * X509_CRL_get0_lastUpdate and X509_CRL_get_lastUpdate
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.45 and before
+B<COMPATIBILITY:> X509_CRL_get0_lastUpdate not available in Net-SSLeay-1.92 and before, X509_CRL_get_lastUpdate not available in Net-SSLeay-1.45 and before
 
 Returns 'lastUpdate' date-time value of X509_CRL object $x.
 
- my $rv = Net::SSLeay::X509_CRL_get_lastUpdate($x);
+ my $rv = Net::SSLeay::X509_CRL_get0_lastUpdate($x);
  # $x - value corresponding to openssl's X509_CRL structure
  #
- # returns: value corresponding to openssl's ASN1_TIME structure (0 on failure)
+ # returns: read-only value corresponding to openssl's ASN1_TIME structure
 
-=item * X509_CRL_get_nextUpdate
+B<NOTE:> X509_CRL_get_lastUpdate is an alias and deprecated in OpenSSL 1.1.0 and later
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.45 and before
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/X509_CRL_get0_lastUpdate.html>
+
+=item * X509_CRL_get0_nextUpdate and X509_CRL_get_nextUpdate
+
+B<COMPATIBILITY:> X509_CRL_get0_nextUpdate not available in Net-SSLeay-1.92 and before, X509_CRL_get_nextUpdate not available in Net-SSLeay-1.45 and before
 
 Returns 'nextUpdate' date-time value of X509_CRL object $x.
 
- my $rv = Net::SSLeay::X509_CRL_get_nextUpdate($x);
+ my $rv = Net::SSLeay::X509_CRL_get0_nextUpdate($x);
  # $x - value corresponding to openssl's X509_CRL structure
  #
- # returns: value corresponding to openssl's ASN1_TIME structure (0 on failure)
+ # returns: read-only value corresponding to openssl's ASN1_TIME structure or 0 if 'nextUpdate' is not set
+
+B<NOTE:> X509_CRL_get_nextUpdate is an alias and deprecated in OpenSSL 1.1.0 and later
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/X509_CRL_get0_nextUpdate.html>
 
 =item * X509_CRL_get_version
 

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -7184,29 +7184,37 @@ Sets the issuer of X509_CRL object $x to X509_NAME object $name.
  #
  # returns: 1 on success, 0 on failure
 
-=item * X509_CRL_set_lastUpdate
+=item * X509_CRL_set1_lastUpdate and X509_CRL_set_lastUpdate
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.45 and before; requires at least openssl-0.9.7
+B<COMPATIBILITY:> X509_CRL_set1_lastUpdate not available in Net-SSLeay-1.92 and before, X509_CRL_set_lastUpdate not available in Net-SSLeay-1.45 and before
 
 Sets 'lastUpdate' value of X509_CRL object $x to $tm.
 
- my $rv = Net::SSLeay::X509_CRL_set_lastUpdate($x, $tm);
+ my $rv = Net::SSLeay::X509_CRL_set1_lastUpdate($x, $tm);
  # $x - value corresponding to openssl's X509_CRL structure
  # $tm - value corresponding to openssl's ASN1_TIME structure
  #
  # returns: 1 on success, 0 on failure
 
-=item * X509_CRL_set_nextUpdate
+B<NOTE:> X509_CRL_set_lastUpdate is an alias and deprecated in OpenSSL 1.1.0 and later
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.45 and before; requires at least openssl-0.9.7
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/X509_CRL_set1_lastUpdate.html>
+
+=item * X509_CRL_set1_nextUpdate and X509_CRL_set_nextUpdate
+
+B<COMPATIBILITY:> X509_CRL_set1_nextUpdate not available in Net-SSLeay-1.92 and before, X509_CRL_set_nextUpdate not available in Net-SSLeay-1.45 and before
 
 Sets 'nextUpdate' value of X509_CRL object $x to $tm.
 
- my $rv = Net::SSLeay::X509_CRL_set_nextUpdate($x, $tm);
+ my $rv = Net::SSLeay::X509_CRL_set1_nextUpdate($x, $tm);
  # $x - value corresponding to openssl's X509_CRL structure
  # $tm - value corresponding to openssl's ASN1_TIME structure
  #
  # returns: 1 on success, 0 on failure
+
+B<NOTE:> X509_CRL_set_nextUpdate is an alias and deprecated in OpenSSL 1.1.0 and later
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/X509_CRL_set1_nextUpdate.html>
 
 =item * X509_CRL_set_version
 

--- a/t/local/34_x509_crl.t
+++ b/t/local/34_x509_crl.t
@@ -3,7 +3,7 @@ use lib 'inc';
 use Net::SSLeay;
 use Test::Net::SSLeay qw( data_file_path initialise_libssl is_openssl );
 
-plan tests => 42;
+plan tests => 44;
 
 initialise_libssl();
 
@@ -30,8 +30,11 @@ ok(my $ca_pk = Net::SSLeay::PEM_read_bio_PrivateKey($bio2), "PEM_read_bio_Privat
 
   is(Net::SSLeay::X509_NAME_print_ex($name1), 'CN=Intermediate CA,OU=Test Suite,O=Net-SSLeay,C=PL', "X509_NAME_print_ex");
   
-  ok(my $time_last = Net::SSLeay::X509_CRL_get_lastUpdate($crl1), "X509_CRL_get_lastUpdate");
-  ok(my $time_next = Net::SSLeay::X509_CRL_get_nextUpdate($crl1), "X509_CRL_get_nextUpdate");
+  ok(my $time_last = Net::SSLeay::X509_CRL_get0_lastUpdate($crl1), "X509_CRL_get0_lastUpdate");
+  ok(my $time_next = Net::SSLeay::X509_CRL_get0_nextUpdate($crl1), "X509_CRL_get0_nextUpdate");
+  is($time_last, Net::SSLeay::X509_CRL_get_lastUpdate($crl1), "X509_CRL_get_lastUpdate alias for X509_CRL_get0_lastUpdate");
+  is($time_next, Net::SSLeay::X509_CRL_get_nextUpdate($crl1), "X509_CRL_get_nextUpdate alias for X509_CRL_get0_nextUpdate");
+
   is(Net::SSLeay::P_ASN1_TIME_get_isotime($time_last), '2020-07-01T00:00:00Z', "P_ASN1_TIME_get_isotime last");
   is(Net::SSLeay::P_ASN1_TIME_get_isotime($time_next), '2020-07-08T00:00:00Z', "P_ASN1_TIME_get_isotime next");
   
@@ -46,8 +49,8 @@ ok(my $ca_pk = Net::SSLeay::PEM_read_bio_PrivateKey($bio2), "PEM_read_bio_Privat
   ok(my $name = Net::SSLeay::X509_get_subject_name($ca_cert), "X509_get_subject_name");
   ok(Net::SSLeay::X509_CRL_set_issuer_name($crl, $name), "X509_CRL_set_issuer_name");
   
-  Net::SSLeay::P_ASN1_TIME_set_isotime(Net::SSLeay::X509_CRL_get_lastUpdate($crl), "2010-02-01T00:00:00Z");
-  Net::SSLeay::P_ASN1_TIME_set_isotime(Net::SSLeay::X509_CRL_get_nextUpdate($crl), "2011-02-01T00:00:00Z");
+  Net::SSLeay::P_ASN1_TIME_set_isotime(Net::SSLeay::X509_CRL_get0_lastUpdate($crl), "2010-02-01T00:00:00Z");
+  Net::SSLeay::P_ASN1_TIME_set_isotime(Net::SSLeay::X509_CRL_get0_nextUpdate($crl), "2011-02-01T00:00:00Z");
   
   ok(Net::SSLeay::X509_CRL_set_version($crl, 1), "X509_CRL_set_version");
   my $ser = Net::SSLeay::ASN1_INTEGER_new();
@@ -91,8 +94,8 @@ ok(my $ca_pk = Net::SSLeay::PEM_read_bio_PrivateKey($bio2), "PEM_read_bio_Privat
   ok(my $crl = Net::SSLeay::d2i_X509_CRL_bio($bio), "d2i_X509_CRL_bio");
   is(Net::SSLeay::X509_CRL_verify($crl, Net::SSLeay::X509_get_pubkey($ca_cert)), 1, "X509_CRL_verify");
 
-  ok(my $time_last = Net::SSLeay::X509_CRL_get_lastUpdate($crl), "X509_CRL_get_lastUpdate");
-  ok(my $time_next = Net::SSLeay::X509_CRL_get_nextUpdate($crl), "X509_CRL_get_nextUpdate");
+  ok(my $time_last = Net::SSLeay::X509_CRL_get0_lastUpdate($crl), "X509_CRL_get0_lastUpdate");
+  ok(my $time_next = Net::SSLeay::X509_CRL_get0_nextUpdate($crl), "X509_CRL_get0_nextUpdate");
   
   ok(my $sn = Net::SSLeay::P_X509_CRL_get_serial($crl), "P_X509_CRL_get_serial");
   is(Net::SSLeay::ASN1_INTEGER_get($sn), 1, "ASN1_INTEGER_get");

--- a/t/local/34_x509_crl.t
+++ b/t/local/34_x509_crl.t
@@ -32,11 +32,8 @@ ok(my $ca_pk = Net::SSLeay::PEM_read_bio_PrivateKey($bio2), "PEM_read_bio_Privat
   
   ok(my $time_last = Net::SSLeay::X509_CRL_get_lastUpdate($crl1), "X509_CRL_get_lastUpdate");
   ok(my $time_next = Net::SSLeay::X509_CRL_get_nextUpdate($crl1), "X509_CRL_get_nextUpdate");
-  SKIP: {
-    skip 'openssl-0.9.7e required', 2 unless Net::SSLeay::SSLeay >= 0x0090705f; 
-    is(Net::SSLeay::P_ASN1_TIME_get_isotime($time_last), '2020-07-01T00:00:00Z', "P_ASN1_TIME_get_isotime last");
-    is(Net::SSLeay::P_ASN1_TIME_get_isotime($time_next), '2020-07-08T00:00:00Z', "P_ASN1_TIME_get_isotime next");
-  }
+  is(Net::SSLeay::P_ASN1_TIME_get_isotime($time_last), '2020-07-01T00:00:00Z', "P_ASN1_TIME_get_isotime last");
+  is(Net::SSLeay::P_ASN1_TIME_get_isotime($time_next), '2020-07-08T00:00:00Z', "P_ASN1_TIME_get_isotime next");
   
   is(Net::SSLeay::X509_CRL_get_version($crl1), 1, "X509_CRL_get_version");
   ok(my $sha1_digest = Net::SSLeay::EVP_get_digestbyname("sha1"), "EVP_get_digestbyname");
@@ -47,29 +44,16 @@ ok(my $ca_pk = Net::SSLeay::PEM_read_bio_PrivateKey($bio2), "PEM_read_bio_Privat
   ok(my $crl = Net::SSLeay::X509_CRL_new(), "X509_CRL_new");
   
   ok(my $name = Net::SSLeay::X509_get_subject_name($ca_cert), "X509_get_subject_name");
-  SKIP: {
-    skip('requires openssl-0.9.7', 1) unless Net::SSLeay::SSLeay >= 0x0090700f;
-    ok(Net::SSLeay::X509_CRL_set_issuer_name($crl, $name), "X509_CRL_set_issuer_name");
-  }
+  ok(Net::SSLeay::X509_CRL_set_issuer_name($crl, $name), "X509_CRL_set_issuer_name");
   
-  if (Net::SSLeay::SSLeay >= 0x0090705f) {
-    Net::SSLeay::P_ASN1_TIME_set_isotime(Net::SSLeay::X509_CRL_get_lastUpdate($crl), "2010-02-01T00:00:00Z");
-    Net::SSLeay::P_ASN1_TIME_set_isotime(Net::SSLeay::X509_CRL_get_nextUpdate($crl), "2011-02-01T00:00:00Z");
-  }
-  else {
-    # P_ASN1_TIME_set_isotime not available before openssl-0.9.7e
-    Net::SSLeay::X509_gmtime_adj(Net::SSLeay::X509_CRL_get_lastUpdate($crl), 0);
-    Net::SSLeay::X509_gmtime_adj(Net::SSLeay::X509_CRL_get_lastUpdate($crl), 0);
-  }
+  Net::SSLeay::P_ASN1_TIME_set_isotime(Net::SSLeay::X509_CRL_get_lastUpdate($crl), "2010-02-01T00:00:00Z");
+  Net::SSLeay::P_ASN1_TIME_set_isotime(Net::SSLeay::X509_CRL_get_nextUpdate($crl), "2011-02-01T00:00:00Z");
   
-  SKIP: {
-    skip('requires openssl-0.9.7', 2) unless Net::SSLeay::SSLeay >= 0x0090700f;
-    ok(Net::SSLeay::X509_CRL_set_version($crl, 1), "X509_CRL_set_version");
-    my $ser = Net::SSLeay::ASN1_INTEGER_new();
-    Net::SSLeay::P_ASN1_INTEGER_set_hex($ser, "4AFED5654654BCEDED4AFED5654654BCEDED");
-    ok(Net::SSLeay::P_X509_CRL_set_serial($crl, $ser), "P_X509_CRL_set_serial");
-    Net::SSLeay::ASN1_INTEGER_free($ser);
-  }
+  ok(Net::SSLeay::X509_CRL_set_version($crl, 1), "X509_CRL_set_version");
+  my $ser = Net::SSLeay::ASN1_INTEGER_new();
+  Net::SSLeay::P_ASN1_INTEGER_set_hex($ser, "4AFED5654654BCEDED4AFED5654654BCEDED");
+  ok(Net::SSLeay::P_X509_CRL_set_serial($crl, $ser), "P_X509_CRL_set_serial");
+  Net::SSLeay::ASN1_INTEGER_free($ser);
   
   my @rev_table = (
     { serial_hex=>'1A2B3D', rev_datetime=>"2011-02-01T00:00:00Z", comp_datetime=>"2911-11-11T00:00:00Z", reason=>2 }, # 2 = cACompromise
@@ -79,19 +63,9 @@ ok(my $ca_pk = Net::SSLeay::PEM_read_bio_PrivateKey($bio2), "PEM_read_bio_Privat
   my $rev_datetime = Net::SSLeay::ASN1_TIME_new();
   my $comp_datetime = Net::SSLeay::ASN1_TIME_new();
   for my $item (@rev_table) {  
-    if (Net::SSLeay::SSLeay >= 0x0090705f) { 
       Net::SSLeay::P_ASN1_TIME_set_isotime($rev_datetime, $item->{rev_datetime});
       Net::SSLeay::P_ASN1_TIME_set_isotime($comp_datetime, $item->{comp_datetime});
-    }
-    else {
-      # P_ASN1_TIME_set_isotime not available before openssl-0.9.7e
-      Net::SSLeay::X509_gmtime_adj($rev_datetime, 0);
-      Net::SSLeay::X509_gmtime_adj($comp_datetime, 0);
-    }
-    SKIP: {
-      skip('requires openssl-0.9.7', 1) unless Net::SSLeay::SSLeay >= 0x0090700f;
       ok(Net::SSLeay::P_X509_CRL_add_revoked_serial_hex($crl, $item->{serial_hex}, $rev_datetime, $item->{reason}, $comp_datetime), "P_X509_CRL_add_revoked_serial_hex");        
-    }
   }
   Net::SSLeay::ASN1_TIME_free($rev_datetime);
   Net::SSLeay::ASN1_TIME_free($comp_datetime);
@@ -101,10 +75,7 @@ ok(my $ca_pk = Net::SSLeay::PEM_read_bio_PrivateKey($bio2), "PEM_read_bio_Privat
     ), "P_X509_CRL_add_extensions");
 
   ok(my $sha1_digest = Net::SSLeay::EVP_get_digestbyname("sha1"), "EVP_get_digestbyname");
-  SKIP: {
-    skip('requires openssl-0.9.7', 1) unless Net::SSLeay::SSLeay >= 0x0090700f;
-    ok(Net::SSLeay::X509_CRL_sort($crl), "X509_CRL_sort");
-  }
+  ok(Net::SSLeay::X509_CRL_sort($crl), "X509_CRL_sort");
   ok(Net::SSLeay::X509_CRL_sign($crl, $ca_pk, $sha1_digest), "X509_CRL_sign");
   
   like(my $crl_pem = Net::SSLeay::PEM_get_string_X509_CRL($crl), qr/-----BEGIN X509 CRL-----/, "PEM_get_string_X509_CRL");
@@ -123,17 +94,11 @@ ok(my $ca_pk = Net::SSLeay::PEM_read_bio_PrivateKey($bio2), "PEM_read_bio_Privat
   ok(my $time_last = Net::SSLeay::X509_CRL_get_lastUpdate($crl), "X509_CRL_get_lastUpdate");
   ok(my $time_next = Net::SSLeay::X509_CRL_get_nextUpdate($crl), "X509_CRL_get_nextUpdate");
   
-  SKIP: {
-    skip('requires openssl-0.9.7', 2) unless Net::SSLeay::SSLeay >= 0x0090700f;
-    ok(my $sn = Net::SSLeay::P_X509_CRL_get_serial($crl), "P_X509_CRL_get_serial");
-    is(Net::SSLeay::ASN1_INTEGER_get($sn), 1, "ASN1_INTEGER_get");
-  }
+  ok(my $sn = Net::SSLeay::P_X509_CRL_get_serial($crl), "P_X509_CRL_get_serial");
+  is(Net::SSLeay::ASN1_INTEGER_get($sn), 1, "ASN1_INTEGER_get");
   
-  SKIP: {
-    skip('requires openssl-0.9.7', 3) unless Net::SSLeay::SSLeay >= 0x0090700f;
-    ok(my $crl2 = Net::SSLeay::X509_CRL_new(), "X509_CRL_new");
-    ok(Net::SSLeay::X509_CRL_set_lastUpdate($crl2, $time_last), "X509_CRL_set_lastUpdate");
-    ok(Net::SSLeay::X509_CRL_set_nextUpdate($crl2, $time_next), "X509_CRL_set_nextUpdate");
-    Net::SSLeay::X509_CRL_free($crl2);
-  }
+  ok(my $crl2 = Net::SSLeay::X509_CRL_new(), "X509_CRL_new");
+  ok(Net::SSLeay::X509_CRL_set_lastUpdate($crl2, $time_last), "X509_CRL_set_lastUpdate");
+  ok(Net::SSLeay::X509_CRL_set_nextUpdate($crl2, $time_next), "X509_CRL_set_nextUpdate");
+  Net::SSLeay::X509_CRL_free($crl2);
 }

--- a/typemap
+++ b/typemap
@@ -39,6 +39,7 @@ LHASH *         T_PTR
 struct lhash_st_SSL_SESSION *	T_PTR
 struct cert_st * T_PTR
 X509_STORE_CTX * T_PTR
+const ASN1_TIME *      T_PTR
 ASN1_TIME *      T_PTR
 ASN1_OCTET_STRING *   T_PTR
 const ASN1_INTEGER *   T_PTR


### PR DESCRIPTION
Expose X509_CRL_get0_lastUpdate(), X509_CRL_get0_nextUpdate(), X509_CRL_set1_lastUpdate() and X509_CRL_set1_nextUpdate() that became available with OpenSSL 1.1.0 and LibreSSL 2.7.0. Use XS ALIAS to the hide deprecation warnings while making them and their current counterparts available.

