### PR TITLE
GH-367 Expose X509_get0_notBefore, X509_getm_notBefore, X509_get0_notAfter and X509_getm_notAfter.

### DIFF
--- a/Changes
+++ b/Changes
@@ -24,9 +24,9 @@ Revision history for Perl extension Net::SSLeay.
 	- Expose X509_CRL_get0_lastUpdate(),
 	  X509_CRL_get0_nextUpdate(), X509_CRL_set1_lastUpdate() and
 	  X509_CRL_set1_nextUpdate() that became available with
-	  OpenSSL 1.1.0 and LibreSSL 2.7.0. These and the respective
-	  deprecated _get/set_ aliases are available with all OpenSSL
-	  and LibreSSL versions. Fixes GH-367 and part of RT#124371
+	  OpenSSL 1.1.0 and LibreSSL 2.7.0. These, and the respective
+	  deprecated _get/set_ aliases, are available with all OpenSSL
+	  and LibreSSL versions. Fixes part of RT#124371.
 	- Note in documentation that the X509_CRL_get* functions
 	  return a pointer to time structure that should be considered
 	  read-only.
@@ -71,6 +71,12 @@ Revision history for Perl extension Net::SSLeay.
 	  - X509_V_ERR_SUBJECT_KEY_IDENTIFIER_CRITICAL
 	  - X509_V_ERR_SUBJECT_NAME_EMPTY
 	  - X509_V_ERR_UNSUPPORTED_SIGNATURE_ALGORITHM
+	- Expose X509_get0_notBefore(), X509_getm_notBefore()
+	  X509_get0_nextAfter() and X509_getm_nextAfter() that became
+	  available with OpenSSL 1.1.0 and LibreSSL 2.7.0. These, and
+	  the deprecated _get functions, are available, as aliases
+	  when needed, with all OpenSSL and LibreSSL versions. Fixes
+	  GH-367.
 
 1.92 2022-01-12
 	- New stable release incorporating all changes from developer releases 1.91_01

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -4579,13 +4579,39 @@ P_ASN1_STRING_get(s,utf8_decode=0)
         if (utf8_decode) sv_utf8_decode(u8);
         XPUSHs(sv_2mortal(u8));
 
-ASN1_TIME *
-X509_get_notBefore(cert)
-     X509 *	cert
+#if (OPENSSL_VERSION_NUMBER >= 0x1010000f && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x2070000fL)
+
+const ASN1_TIME *
+X509_get0_notBefore(const X509 *cert)
+
+const ASN1_TIME *
+X509_get0_notAfter(const X509 *cert)
 
 ASN1_TIME *
-X509_get_notAfter(cert)
-     X509 *	cert
+X509_getm_notBefore(const X509 *cert)
+	ALIAS:
+		X509_get_notBefore = 1
+
+ASN1_TIME *
+X509_getm_notAfter(const X509 *cert)
+	ALIAS:
+		X509_get_notAfter = 1
+
+#else /* plain get_ is deprecated */
+
+ASN1_TIME *
+X509_get_notBefore(X509 *cert)
+	ALIAS:
+		X509_get0_notBefore = 1
+		X509_getm_notBefore = 2
+
+ASN1_TIME *
+X509_get_notAfter(X509 *cert)
+	ALIAS:
+		X509_get0_notAfter = 1
+		X509_getm_notAfter = 2
+
+#endif
 
 ASN1_TIME *
 X509_gmtime_adj(s, adj)

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -6334,33 +6334,49 @@ Return an X509_NAME object representing the issuer of the certificate $cert.
  #
  # returns: value corresponding to openssl's X509_NAME structure (0 on failure)
 
-=item * X509_get_notAfter
+=item * X509_get0_notAfter, X509_getm_notAfter and X509_get_notAfter
+
+B<COMPATIBILITY:> X509_get0_notAfter and X509_getm_notAfter are not available in Net-SSLeay-1.92 and before
 
 Return an object giving the time after which the certificate $cert is not valid.
 
- my $rv = Net::SSLeay::X509_get_notAfter($cert);
+ my $rv  = Net::SSLeay::X509_get0_notAfter($cert);
+ my $rvm = Net::SSLeay::X509_getm_notAfter($cert);
  # $cert - value corresponding to openssl's X509 structure
  #
- # returns: value corresponding to openssl's ASN1_TIME structure (0 on failure)
+ # returns: $rv  read-only value corresponding to openssl's ASN1_TIME structure
+ #          $rvm mutable   value corresponding to openssl's ASN1_TIME structure
 
 To get human readable/printable form the return value you can use:
 
  my $time = Net::SSLeay::X509_get_notAfter($cert);
  print "notAfter=", Net::SSLeay::P_ASN1_TIME_get_isotime($time), "\n";
 
-=item * X509_get_notBefore
+B<NOTE:> X509_get_notAfter is an alias and deprecated in OpenSSL 1.1.0 and later
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/X509_get0_notAfter.html>
+
+=item * X509_get0_notBefore, X509_getm_notBefore and X509_get_notBefore
+
+B<COMPATIBILITY:> X509_get0_notBefore and X509_getm_notBefore are not available in Net-SSLeay-1.92 and before
 
 Return an object giving the time before which the certificate $cert is not valid
 
- my $rv = Net::SSLeay::X509_get_notBefore($cert);
+ my $rv  = Net::SSLeay::X509_get0_notBefore($cert);
+ my $rvm = Net::SSLeay::X509_getm_notBefore($cert);
  # $cert - value corresponding to openssl's X509 structure
  #
- # returns: value corresponding to openssl's ASN1_TIME structure (0 on failure)
+ # returns: $rv  read-only value corresponding to openssl's ASN1_TIME structure
+ #          $rvm mutable   value corresponding to openssl's ASN1_TIME structure
 
 To get human readable/printable form the return value you can use:
 
  my $time = Net::SSLeay::X509_get_notBefore($cert);
  print "notBefore=", Net::SSLeay::P_ASN1_TIME_get_isotime($time), "\n";
+
+B<NOTE:> X509_get_notBefore is an alias and deprecated in OpenSSL 1.1.0 and later
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/X509_get0_notBefore.html>
 
 =item * X509_get_subjectAltNames
 

--- a/t/local/32_x509_get_cert_info.t
+++ b/t/local/32_x509_get_cert_info.t
@@ -8,8 +8,8 @@ use Test::Net::SSLeay qw(
 use lib '.';
 
 my $tests =   ( is_openssl() && Net::SSLeay::SSLeay < 0x10100003 ) || is_libressl()
-            ? 723
-            : 726;
+            ? 739
+            : 742;
 
 plan tests => $tests;
 
@@ -121,8 +121,12 @@ for my $f (keys (%$dump)) {
   
   SKIP: {
     skip('P_ASN1_TIME_get_isotime requires 0.9.7e+', 2) unless Net::SSLeay::SSLeay >= 0x0090705f;
-    is(Net::SSLeay::P_ASN1_TIME_get_isotime(Net::SSLeay::X509_get_notBefore($x509)), $dump->{$f}->{not_before}, "X509_get_notBefore\t$f");
-    is(Net::SSLeay::P_ASN1_TIME_get_isotime(Net::SSLeay::X509_get_notAfter($x509)), $dump->{$f}->{not_after}, "X509_get_notAfter\t$f");
+    is(Net::SSLeay::P_ASN1_TIME_get_isotime(Net::SSLeay::X509_get0_notBefore($x509)), $dump->{$f}->{not_before}, "X509_get0_notBefore\t$f");
+    is(Net::SSLeay::P_ASN1_TIME_get_isotime(Net::SSLeay::X509_getm_notBefore($x509)), $dump->{$f}->{not_before}, "X509_getm_notBefore\t$f");
+    is(Net::SSLeay::P_ASN1_TIME_get_isotime(Net::SSLeay::X509_get_notBefore($x509)),  $dump->{$f}->{not_before}, "X509_get_notBefore\t$f");
+    is(Net::SSLeay::P_ASN1_TIME_get_isotime(Net::SSLeay::X509_get0_notAfter($x509)),  $dump->{$f}->{not_after},  "X509_get0_notAfter\t$f");
+    is(Net::SSLeay::P_ASN1_TIME_get_isotime(Net::SSLeay::X509_getm_notAfter($x509)),  $dump->{$f}->{not_after},  "X509_getm_notAfter\t$f");
+    is(Net::SSLeay::P_ASN1_TIME_get_isotime(Net::SSLeay::X509_get_notAfter($x509)),   $dump->{$f}->{not_after},  "X509_get_notAfter\t$f");
   }
   
   ok(my $ai = Net::SSLeay::X509_get_serialNumber($x509), "X509_get_serialNumber\t$f");


### PR DESCRIPTION
Expose non-deprecated versions of X509_get_notBefore and X509_get_notAfter to
close GH-367.

This was originally the purpose behind commit
fc1b054f5adc85ba9f6b8dbc3ade055c63f4b459, but misread deprecation warnings
caused work to be done on X509_CRL_ functions instead.

Closes GH-367 (again).