### PR TITLE
Make libssl support for TLSv1 - TLSv1.2 optional

### DIFF
--- a/Changes
+++ b/Changes
@@ -77,6 +77,10 @@ Revision history for Perl extension Net::SSLeay.
 	  the deprecated _get functions, are available, as aliases
 	  when needed, with all OpenSSL and LibreSSL versions. Fixes
 	  GH-367.
+	- Only export the TLSv1*_method() functions when support for the respective TLS
+	  version is available in the underlying libssl library. This allows
+	  Net::SSLeay to be built against libssl libraries that were built without
+	  support for old TLS versions, e.g. for security reasons.
 
 1.92 2022-01-12
 	- New stable release incorporating all changes from developer releases 1.91_01

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -2082,6 +2082,8 @@ SSL_CTX_v23_new()
      OUTPUT:
      RETVAL
 
+#ifndef OPENSSL_NO_TLS1_METHOD
+
 SSL_CTX *
 SSL_CTX_tlsv1_new()
      CODE:
@@ -2089,7 +2091,9 @@ SSL_CTX_tlsv1_new()
      OUTPUT:
      RETVAL
 
-#ifdef SSL_TXT_TLSV1_1
+#endif
+
+#ifndef OPENSSL_NO_TLS1_1_METHOD
 
 SSL_CTX *
 SSL_CTX_tlsv1_1_new()
@@ -2100,7 +2104,7 @@ SSL_CTX_tlsv1_1_new()
 
 #endif
 
-#ifdef SSL_TXT_TLSV1_2
+#ifndef OPENSSL_NO_TLS1_2_METHOD
 
 SSL_CTX *
 SSL_CTX_tlsv1_2_new()
@@ -5107,6 +5111,8 @@ SSLv23_server_method()
 const SSL_METHOD *
 SSLv23_client_method()
 
+#ifndef OPENSSL_NO_TLS1_METHOD
+
 const SSL_METHOD *
 TLSv1_method()
 
@@ -5116,7 +5122,9 @@ TLSv1_server_method()
 const SSL_METHOD *
 TLSv1_client_method()
 
-#ifdef SSL_TXT_TLSV1_1
+#endif
+
+#ifndef OPENSSL_NO_TLS1_1_METHOD
 
 const SSL_METHOD *
 TLSv1_1_method()
@@ -5129,7 +5137,7 @@ TLSv1_1_client_method()
 
 #endif
 
-#ifdef SSL_TXT_TLSV1_2
+#ifndef OPENSSL_NO_TLS1_2_METHOD
 
 const SSL_METHOD *
 TLSv1_2_method()

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -2082,7 +2082,7 @@ SSL_CTX_v23_new()
      OUTPUT:
      RETVAL
 
-#ifndef OPENSSL_NO_TLS1_METHOD
+#if !defined(OPENSSL_NO_TLS1_METHOD)
 
 SSL_CTX *
 SSL_CTX_tlsv1_new()
@@ -2093,7 +2093,7 @@ SSL_CTX_tlsv1_new()
 
 #endif
 
-#ifndef OPENSSL_NO_TLS1_1_METHOD
+#if (OPENSSL_VERSION_NUMBER >= 0x10001001L && !defined(OPENSSL_NO_TLS1_1_METHOD)) /* OpenSSL 1.0.1-beta1 */
 
 SSL_CTX *
 SSL_CTX_tlsv1_1_new()
@@ -2104,7 +2104,7 @@ SSL_CTX_tlsv1_1_new()
 
 #endif
 
-#ifndef OPENSSL_NO_TLS1_2_METHOD
+#if (OPENSSL_VERSION_NUMBER >= 0x10001001L && !defined(OPENSSL_NO_TLS1_2_METHOD)) /* OpenSSL 1.0.1-beta1 */
 
 SSL_CTX *
 SSL_CTX_tlsv1_2_new()

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -5111,7 +5111,7 @@ SSLv23_server_method()
 const SSL_METHOD *
 SSLv23_client_method()
 
-#ifndef OPENSSL_NO_TLS1_METHOD
+#if !defined(OPENSSL_NO_TLS1_METHOD)
 
 const SSL_METHOD *
 TLSv1_method()
@@ -5124,7 +5124,7 @@ TLSv1_client_method()
 
 #endif
 
-#ifndef OPENSSL_NO_TLS1_1_METHOD
+#if (OPENSSL_VERSION_NUMBER >= 0x10001001L && !defined(OPENSSL_NO_TLS1_1_METHOD)) /* OpenSSL 1.0.1-beta1 */
 
 const SSL_METHOD *
 TLSv1_1_method()
@@ -5137,7 +5137,7 @@ TLSv1_1_client_method()
 
 #endif
 
-#ifndef OPENSSL_NO_TLS1_2_METHOD
+#if (OPENSSL_VERSION_NUMBER >= 0x10001001L && !defined(OPENSSL_NO_TLS1_2_METHOD)) /* OpenSSL 1.0.1-beta1 */
 
 const SSL_METHOD *
 TLSv1_2_method()

--- a/lib/Net/SSLeay.pm
+++ b/lib/Net/SSLeay.pm
@@ -1436,45 +1436,59 @@ sub randomize (;$$$) {
 }
 
 sub new_x_ctx {
-    if ($ssl_version == 2)  {
-	unless (exists &Net::SSLeay::CTX_v2_new) {
-	    warn "ssl_version has been set to 2, but this version of OpenSSL has been compiled without SSLv2 support";
-	    return undef;
-	}
-	$ctx = CTX_v2_new();
+    if ( $ssl_version == 2 ) {
+        unless ( exists &Net::SSLeay::CTX_v2_new ) {
+            warn "ssl_version has been set to 2, but this version of libssl has been compiled without SSLv2 support";
+            return undef;
+        }
+        $ctx = CTX_v2_new();
     }
-    elsif ($ssl_version == 3)  { $ctx = CTX_v3_new(); }
-    elsif ($ssl_version == 10) { $ctx = CTX_tlsv1_new(); }
-    elsif ($ssl_version == 11) {
-	unless (exists &Net::SSLeay::CTX_tlsv1_1_new) {
-	    warn "ssl_version has been set to 11, but this version of OpenSSL has been compiled without TLSv1.1 support";
-	    return undef;
-	}
-        $ctx = CTX_tlsv1_1_new;
+    elsif ( $ssl_version == 3 ) {
+        unless ( exists &Net::SSLeay::CTX_v3_new ) {
+            warn 'ssl_version has been set to 3, but this version of libssl has been compiled without SSLv3 support';
+            return undef;
+        }
+        $ctx = CTX_v3_new();
     }
-    elsif ($ssl_version == 12) {
-	unless (exists &Net::SSLeay::CTX_tlsv1_2_new) {
-	    warn "ssl_version has been set to 12, but this version of OpenSSL has been compiled without TLSv1.2 support";
-	    return undef;
-	}
-        $ctx = CTX_tlsv1_2_new;
+    elsif ( $ssl_version == 10 ) {
+        unless ( exists &Net::SSLeay::CTX_tlsv1_new ) {
+            warn 'ssl_version has been set to 10, but this version of libssl has been compiled without TLSv1 support';
+            return undef;
+        }
+        $ctx = CTX_tlsv1_new();
     }
-    elsif ($ssl_version == 13) {
-	unless (eval { Net::SSLeay::TLS1_3_VERSION(); } ) {
-	    warn "ssl_version has been set to 13, but this version of OpenSSL has been compiled without TLSv1.3 support";
-	    return undef;
-	}
+    elsif ( $ssl_version == 11 ) {
+        unless ( exists &Net::SSLeay::CTX_tlsv1_1_new ) {
+            warn 'ssl_version has been set to 11, but this version of libssl has been compiled without TLSv1.1 support';
+            return undef;
+        }
+        $ctx = CTX_tlsv1_1_new();
+    }
+    elsif ( $ssl_version == 12 ) {
+        unless ( exists &Net::SSLeay::CTX_tlsv1_2_new ) {
+            warn 'ssl_version has been set to 12, but this version of libssl has been compiled without TLSv1.2 support';
+            return undef;
+        }
+        $ctx = CTX_tlsv1_2_new();
+    }
+    elsif ( $ssl_version == 13 ) {
+        unless ( eval { Net::SSLeay::TLS1_3_VERSION() } ) {
+            warn 'ssl_version has been set to 13, but this version of libssl has been compiled without TLSv1.3 support';
+            return undef;
+        }
         $ctx = CTX_new();
-        unless(Net::SSLeay::CTX_set_min_proto_version($ctx, Net::SSLeay::TLS1_3_VERSION())) {
-            warn "CTX_set_min_proto failed for TLSv1.3";
+        unless ( Net::SSLeay::CTX_set_min_proto_version( $ctx, Net::SSLeay::TLS1_3_VERSION() ) ) {
+            warn 'CTX_set_min_proto failed for TLSv1.3';
             return undef;
         }
-        unless(Net::SSLeay::CTX_set_max_proto_version($ctx, Net::SSLeay::TLS1_3_VERSION())) {
-            warn "CTX_set_max_proto failed for TLSv1.3";
+        unless ( Net::SSLeay::CTX_set_max_proto_version( $ctx, Net::SSLeay::TLS1_3_VERSION() ) ) {
+            warn 'CTX_set_max_proto failed for TLSv1.3';
             return undef;
         }
     }
-    else                       { $ctx = CTX_new(); }
+    else {
+        $ctx = CTX_new();
+    }
     return $ctx;
 }
 

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -1464,7 +1464,7 @@ Check openssl doc L<http://www.openssl.org/docs/ssl/SSL_CTX_new.html|http://www.
 
 =item * TLSv1_method, TLSv1_server_method and TLSv1_client_method
 
-B<COMPATIBILITY:> Server and client methods not available in Net-SSLeay-1.82 and before.
+B<COMPATIBILITY:> Requires OpenSSL or LibreSSL built with support for TLSv1. Server and client methods not available in Net-SSLeay-1.82 and before.
 
 Returns SSL_METHOD structure corresponding to TLSv1 method, the return value can be later used as a param of L</CTX_new_with_method>.
 
@@ -1476,9 +1476,9 @@ Check openssl doc L<http://www.openssl.org/docs/ssl/SSL_CTX_new.html|http://www.
 
 =item * TLSv1_1_method, TLSv1_1_server_method and TLSv1_1_client_method
 
-B<COMPATIBILITY:> Server and client methods not available in Net-SSLeay-1.82 and before.
+B<COMPATIBILITY:> Requires OpenSSL >= 1.0.1 or LibreSSL built with support for TLSv1.1. Server and client methods not available in Net-SSLeay-1.82 and before.
 
-Returns SSL_METHOD structure corresponding to TLSv1_1 method, the return value can be later used as a param of L</CTX_new_with_method>. Only available where supported by the underlying openssl.
+Returns SSL_METHOD structure corresponding to TLSv1_1 method, the return value can be later used as a param of L</CTX_new_with_method>.
 
  my $rv = Net::SSLeay::TLSv1_1_method();
  #
@@ -1488,9 +1488,9 @@ Check openssl doc L<http://www.openssl.org/docs/ssl/SSL_CTX_new.html|http://www.
 
 =item * TLSv1_2_method, TLSv1_2_server_method and TLSv1_2_client_method
 
-B<COMPATIBILITY:> Server and client methods not available in Net-SSLeay-1.82 and before.
+B<COMPATIBILITY:> Requires OpenSSL >= 1.0.1 or LibreSSL built with support for TLSv1.2. Server and client methods not available in Net-SSLeay-1.82 and before.
 
-Returns SSL_METHOD structure corresponding to TLSv1_2 method, the return value can be later used as a param of L</CTX_new_with_method>. Only available where supported by the underlying openssl.
+Returns SSL_METHOD structure corresponding to TLSv1_2 method, the return value can be later used as a param of L</CTX_new_with_method>.
 
  my $rv = Net::SSLeay::TLSv1_2_method();
  #
@@ -2808,7 +2808,7 @@ Creates a new SSL_CTX object - based on SSLv3_method() - as framework to establi
 
 =item * CTX_tlsv1_new
 
-B<COMPATIBILITY:> requires a libssl compiled with support for TLSv1
+B<COMPATIBILITY:> Requires OpenSSL or LibreSSL built with support for TLSv1.
 
 Creates a new SSL_CTX object - based on C<TLSv1_method()> - as a framework for establishing connections using TLSv1.
 
@@ -2818,7 +2818,7 @@ Creates a new SSL_CTX object - based on C<TLSv1_method()> - as a framework for e
 
 =item * CTX_tlsv1_1_new
 
-B<COMPATIBILITY:> requires a libssl compiled with support for TLSv1.1
+B<COMPATIBILITY:> Requires OpenSSL >= 1.0.1 or LibreSSL built with support for TLSv1.1.
 
 Creates a new SSL_CTX object - based on C<TLSv1_1_method()> - as a framework for establishing connections using TLSv1.1.
 
@@ -2828,7 +2828,7 @@ Creates a new SSL_CTX object - based on C<TLSv1_1_method()> - as a framework for
 
 =item * CTX_tlsv1_2_new
 
-B<COMPATIBILITY:> requires a libssl compiled with support for TLSv1.2
+B<COMPATIBILITY:> Requires OpenSSL >= 1.0.1 or LibreSSL built with support for TLSv1.2.
 
 Creates a new SSL_CTX object - based on C<TLSv1_2_method()> - as a framework for establishing connections using TLSv1.2.
 

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -2808,7 +2808,9 @@ Creates a new SSL_CTX object - based on SSLv3_method() - as framework to establi
 
 =item * CTX_tlsv1_new
 
-Creates a new SSL_CTX object - based on TLSv1_method() - as framework to establish TLS/SSL enabled connections.
+B<COMPATIBILITY:> requires a libssl compiled with support for TLSv1
+
+Creates a new SSL_CTX object - based on C<TLSv1_method()> - as a framework for establishing connections using TLSv1.
 
  my $rv = Net::SSLeay::CTX_tlsv1_new();
  #
@@ -2816,8 +2818,9 @@ Creates a new SSL_CTX object - based on TLSv1_method() - as framework to establi
 
 =item * CTX_tlsv1_1_new
 
-Creates a new SSL_CTX object - based on TLSv1_1_method() - as framework to establish TLS/SSL 
-enabled connections. Only available where supported by the underlying openssl.
+B<COMPATIBILITY:> requires a libssl compiled with support for TLSv1.1
+
+Creates a new SSL_CTX object - based on C<TLSv1_1_method()> - as a framework for establishing connections using TLSv1.1.
 
  my $rv = Net::SSLeay::CTX_tlsv1_1_new();
  #
@@ -2825,8 +2828,9 @@ enabled connections. Only available where supported by the underlying openssl.
 
 =item * CTX_tlsv1_2_new
 
-Creates a new SSL_CTX object - based on TLSv1_2_method() - as framework to establish TLS/SSL 
-enabled connections. Only available where supported by the underlying openssl.
+B<COMPATIBILITY:> requires a libssl compiled with support for TLSv1.2
+
+Creates a new SSL_CTX object - based on C<TLSv1_2_method()> - as a framework for establishing connections using TLSv1.2.
 
  my $rv = Net::SSLeay::CTX_tlsv1_2_new();
  #

--- a/t/local/09_ctx_new.t
+++ b/t/local/09_ctx_new.t
@@ -27,8 +27,16 @@ my $ctx = Net::SSLeay::CTX_new();
 ok($ctx, 'CTX_new');
 $ctx =  Net::SSLeay::CTX_v23_new();
 ok($ctx, 'CTX_v23_new');
-$ctx =  Net::SSLeay::CTX_tlsv1_new();
-ok($ctx, 'CTX_tlsv1_new');
+
+if ( defined &Net::SSLeay::CTX_tlsv1_new ) {
+    $ctx = Net::SSLeay::CTX_tlsv1_new();
+    ok( $ctx, 'CTX_tlsv1_new' );
+}
+else {
+    SKIP: {
+        skip( 'Do not have Net::SSLeay::CTX_tlsv1_new', 1 );
+    }
+}
 
 my $ctx_23 = Net::SSLeay::CTX_new_with_method(Net::SSLeay::SSLv23_method());
 ok($ctx_23, 'CTX_new with SSLv23_method');
@@ -39,8 +47,15 @@ ok($ctx_23_client, 'CTX_new with SSLv23_client_method');
 my $ctx_23_server = Net::SSLeay::CTX_new_with_method(Net::SSLeay::SSLv23_server_method());
 ok($ctx_23_server, 'CTX_new with SSLv23_server_method');
 
-my $ctx_tls1 = Net::SSLeay::CTX_new_with_method(Net::SSLeay::TLSv1_method());
-ok($ctx_tls1, 'CTX_new with TLSv1_method');
+if ( defined &Net::SSLeay::TLSv1_method ) {
+    my $ctx_tls1 = Net::SSLeay::CTX_new_with_method( Net::SSLeay::TLSv1_method() );
+    ok( $ctx_tls1, 'CTX_new with TLSv1_method' );
+}
+else {
+    SKIP: {
+        skip( 'Do not have Net::SSLeay::TLSv1_method', 1 );
+    }
+}
 
 # Retrieve information about the handshake state machine
 is(Net::SSLeay::in_connect_init(Net::SSLeay::new($ctx_23_client)), 1, 'in_connect_init() is 1 for client');


### PR DESCRIPTION
Gate the exposure of the `TLSv1*_method()` functions behind the appropriate `OPENSSL_NO_TLS1*_METHOD` macros (which indicate whether libssl was built with support for those TLS methods) rather than the `SSL_TXT_TLSV1*` macros (which merely indicate whether libssl implements those TLS versions). If a `TLSv1*_method()` function is not available in libssl, do not export the equivalent `CTX_tlsv1*_new()` function in Net::SSLeay and do not attempt to use that TLS version in Net::SSLeay's high-level API.

This allows Net::SSLeay to be built against libssls that were compiled without support for previous versions of TLS, e.g. for security reasons.

Closes #280.

----

None of the libssls in our CI environments are built with `OPENSSL_NO_TLS1_METHOD`, `OPENSSL_NO_TLS1_1_METHOD` or `OPENSSL_NO_TLS1_2_METHOD` enabled so they probably won't reveal any problems with this PR, but I've built OpenSSL 3.0.0 locally with `OPENSSL_NO_TLS1_METHOD` and `OPENSSL_NO_TLS1_1_METHOD` enabled and the test suite passes. It'd probably be a good idea to do a developer release after this is merged, since the smoke testers have an exotic range of libssls that tend to pick up faults that our CI doesn't.