### PR TITLE
Remove UTF-8 characters from generated Makefile

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -39,7 +39,7 @@ my %eumm_args = (
   ABSTRACT => 'Perl bindings for OpenSSL and LibreSSL',
   LICENSE => 'artistic_2',
   AUTHOR => [
-    'Sampo Kellomäki <sampo@iki.fi>',
+    'Sampo Kellomaki <sampo@iki.fi>',
     'Florian Ragwitz <rafl@debian.org>',
     'Mike McCauley <mikem@airspayce.com>',
     'Chris Novakovic <chris@chrisn.me.uk>',


### PR DESCRIPTION
Replace the ä in Sampo's surname with an a, allowing Net-SSLeay to be built using versions of make that can only handle ASCII characters.

Closes #378.