### PR TITLE
Silence compound-token-split-by-macro warnings with Clang >= 12

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,8 @@ Revision history for Perl extension Net::SSLeay.
 	- Update ppport.h to version 3.68. This eliminates thousands of
 	  compound-token-split-by-macro compiler warnings when building Net-SSLeay with
 	  Clang 12 or greater. Partially fixes GH-383.
+	- Silence compound-token-split-by-macro warnings when building Net-SSLeay with
+	  Clang 12 or greater. Fixes the remainder of GH-383.
 
 1.93_01 2022-03-20
 	- LibreSSL 3.5.0 has removed access to internal data

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -134,6 +134,13 @@
 /* Prevent warnings about strncpy from Windows compilers */
 #define _CRT_SECURE_NO_DEPRECATE
 
+/* Silence compound-token-split-by-macro warnings from perl.h when building with
+ * Clang >= 12 - see GH-383
+ */
+#if defined(__clang__) && defined(__clang_major__) && __clang_major__ >= 12
+#pragma clang diagnostic ignored "-Wcompound-token-split-by-macro"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Perl's use of the GCC brace groups extension in versions prior to 5.35.2 triggers large numbers of `compound-token-split-by-macro` warnings originating from `perl.h` when `SSLeay.xs` is compiled with Clang 12 or greater. There's not much we can do about these warnings since they originate from Perl, so before including `perl.h`, suppress all such warnings if Clang >= 12 is detected.

Ideally we'd be able to limit the suppression of these warnings to versions of Perl prior to 5.35.2, but this isn't possible due to the
`PERL_VERSION_*` macros being defined in `perl.h`.

Fixes the remainder of #383.