### PR TITLE
Remove unnecessary `ppport.h` `NEED_` macros

### DIFF
--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -148,8 +148,6 @@ extern "C" {
 #include "perl.h"
 #include "XSUB.h"
 #include <stdarg.h>
-#define NEED_newRV_noinc
-#define NEED_sv_2pv_flags
 #define NEED_my_snprintf
 #include "ppport.h"
 #ifdef __cplusplus


### PR DESCRIPTION
`SSLeay.xs` asks `ppport.h` to define compatibility shims for two Perl API functions, neither of which are necessary:

* `newRV_noinc`, which was added in Perl 5.003_07 or earlier, meaning that the `ppport.h` shim is no longer needed now that we target Perl 5.8.1 at a minimum;
* `sv_2pv_flags`, which doesn't seem to have ever been used in `SSLeay.xs`.

Remove the `NEED_` macros for both of these functions before `ppport.h` is included.

Closes #388.