### PR TITLE
Modern Solaris support

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -240,6 +240,7 @@ sub ssleay_get_build_opts {
     # phase fails.
     my @try_lib_paths = (
 	["$prefix/lib64", "$prefix/lib", "$prefix/out32dll", $prefix] => sub {$OSNAME eq 'darwin' },
+	["$prefix/lib/64", $prefix] => sub {$OSNAME eq 'solaris' },
 	[$prefix, "$prefix/lib64", "$prefix/lib", "$prefix/out32dll"] => sub { 1 },
 	);
 
@@ -356,6 +357,7 @@ sub find_openssl_prefix {
 	'/usr/local/opt/openssl/bin/openssl' => '/usr/local/opt/openssl', # OSX homebrew openssl
 	'/usr/local/bin/openssl'         => '/usr/local', # OSX homebrew openssl
 	'/opt/local/bin/openssl'         => '/opt/local', # Macports openssl
+	'/usr/openssl/3/bin/openssl'     => '/usr/openssl/3', # Solaris
 	'/usr/bin/openssl'               => '/usr',
 	'/usr/sbin/openssl'              => '/usr',
 	'/opt/ssl/bin/openssl'           => '/opt/ssl',


### PR DESCRIPTION
Solaris 11+ does have OpenSSL located in /usr/openssl/3 resp.
/usr/openssl/1.1 . Moreover the 64bit libraries are located in
.../lib/64 . This change makes Net::SSLeay link with OpenSSL 3. If you
want to link against 1.1 then just export

  OPENSSL_PREFIX=/usr/openssl/1.1