### PR TITLE
Fix memory leaks after calls to X509_get_ext_d2i

### DIFF
--- a/Changes
+++ b/Changes
@@ -36,6 +36,7 @@ Revision history for Perl extension Net::SSLeay.
 	- Refactor variable declarations in RSA_generate_key to allow SSLeay.xs to
 	  compile under -Werror=declaration-after-statement. Fixes GH-407. Thanks to
 	  dharanlinux for the report.
+	- Fix memory leaks after calls to X509_get_ext_d2. Thanks to Anton Borowka.
 
 1.93_01 2022-03-20
 	- LibreSSL 3.5.0 has removed access to internal data

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -4171,7 +4171,6 @@ P_X509_get_crl_distribution_points(cert)
         int i, j;
     PPCODE:
         points = X509_get_ext_d2i(cert, NID_crl_distribution_points, NULL, NULL);
-        if (points)
         for (i = 0; i < sk_DIST_POINT_num(points); i++) {
             p = sk_DIST_POINT_value(points, i);
             if (!p->distpoint)

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -4214,6 +4214,7 @@ P_X509_get_crl_distribution_points(cert)
                 */
             }
         }
+        sk_DIST_POINT_pop_free(points, DIST_POINT_free);
 
 void
 P_X509_get_ocsp_uri(cert)
@@ -4242,6 +4243,7 @@ P_X509_get_ocsp_uri(cert)
 		if (GIMME == G_SCALAR) break; /* get only first */
 	    }
 	}
+	AUTHORITY_INFO_ACCESS_free(info);
 
 
 void
@@ -4268,6 +4270,7 @@ P_X509_get_ext_key_usage(cert,format=0)
            else if(format==3 && nid>0)
                XPUSHs(sv_2mortal(newSVpv(OBJ_nid2ln(nid),0))); /* format 3: longname */
         }
+        EXTENDED_KEY_USAGE_free(extusage);
 
 #endif
 
@@ -4288,6 +4291,7 @@ P_X509_get_key_usage(cert)
             if (ASN1_BIT_STRING_get_bit(u,6)) XPUSHs(sv_2mortal(newSVpv("cRLSign",0)));
             if (ASN1_BIT_STRING_get_bit(u,7)) XPUSHs(sv_2mortal(newSVpv("encipherOnly",0)));
             if (ASN1_BIT_STRING_get_bit(u,8)) XPUSHs(sv_2mortal(newSVpv("decipherOnly",0)));
+            ASN1_BIT_STRING_free(u);
         }
 
 void
@@ -4306,6 +4310,7 @@ P_X509_get_netscape_cert_type(cert)
             if (ASN1_BIT_STRING_get_bit(u,5)) XPUSHs(sv_2mortal(newSVpv("sslCA",0)));
             if (ASN1_BIT_STRING_get_bit(u,6)) XPUSHs(sv_2mortal(newSVpv("emailCA",0)));
             if (ASN1_BIT_STRING_get_bit(u,7)) XPUSHs(sv_2mortal(newSVpv("objCA",0)));
+            ASN1_BIT_STRING_free(u);
         }
 
 int


### PR DESCRIPTION
I noticed some leaking memory in Net::SSLeay functions that use X509_get_ext_d2i(). The commit frees the respective data structures after the data is pushed onto the stack.

I verified in a perl one liner loop that P_X509_get_crl_distribution_points(), P_X509_get_ext_key_usage() and P_X509_get_key_usage() don't leak anymore with the test certificates. I had no simple test for the other functions, but the issue and fix are equivalent.