### PR TITLE
GH-408 Fix Cygwin CI action.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,28 +264,28 @@ jobs:
 
     steps:
       - name: Set up Cygwin
-        uses: egor-tensin/setup-cygwin@master
+        uses: cygwin/cygwin-install-action@master
         with:
-            platform: x64
+            platform: x86_64
             packages: perl_base perl-ExtUtils-MakeMaker make gcc-g++ libcrypt-devel libssl-devel curl bash
       - uses: actions/checkout@main
         with:
             submodules: recursive
       - run: perl -V
-        shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+        shell: C:\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
       - name: Install cpanm
         run: curl https://cpanmin.us | perl - App::cpanminus
-        shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+        shell: C:\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
       - name: Install Dependencies
         run: cd $GITHUB_WORKSPACE; cpanm --verbose --notest --installdeps --with-configure .
-        shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+        shell: C:\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
       - name: perl Makefile.PL
         run: cd $GITHUB_WORKSPACE; perl Makefile.PL
-        shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+        shell: C:\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
       - name: make
         run: cd $GITHUB_WORKSPACE; make -j3 -j3
-        shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+        shell: C:\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
       - name: make test
         run: cd $GITHUB_WORKSPACE; make test
-        shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+        shell: C:\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
 

--- a/Changes
+++ b/Changes
@@ -10,6 +10,17 @@ Revision history for Perl extension Net::SSLeay.
 	  in which Perl is installed (i.e. $Config{prefix}/bin/). Thanks to Henrik
 	  Grimler for the patch.
 	- Expose EVP_PKEY_security_bits. Thanks to Felipe Gasper.
+	- Major update to Gihub Actions configuration. Thanks to Felipe Gasper.
+	  New testing targets are:
+	    - OpenSSL and LibreSSL on Alpine Linux on i386, x390x, arm32v6,
+	      ar32v7 and arm64v8 architectures.
+	    - OpenSSL and LibreSSL on Ubuntu on i386, x390x, ar32v7 and arm64v8
+	      architectures.
+	    - OpenSSL on FreeBSD 13.0, not enabled yet because of GH #272 and #394
+	    - LibreSSL on FreeBSD 13.0
+	    - LibreSSL on OpenBSD 6.9
+	    - LibreSSL on OpenBSD 7.1
+	    - Cygwin on x86_64
 
 1.93_01 2022-03-20
 	- LibreSSL 3.5.0 has removed access to internal data


### PR DESCRIPTION
Cygwin CI run is failing. The fix seems to be to switch action egor-tensin/setup-cygwin to cygwin/cygwin-install-action.

bash.exe path also needs a fix to avoid this error:
  Run perl -V
   perl -V
   Second path fragment must not be a drive or UNC name. (Parameter 'expression')

The problem is not running 'perl -V' but invoking bash.exe. Thanks to Felipe Gasper for helping with this.