### PR TITLE
RSA_generate_key: declare all variables in PREINIT

### DIFF
--- a/Changes
+++ b/Changes
@@ -21,6 +21,9 @@ Revision history for Perl extension Net::SSLeay.
 	    - LibreSSL on OpenBSD 6.9
 	    - LibreSSL on OpenBSD 7.1
 	    - Cygwin on x86_64
+	- Refactor variable declarations in RSA_generate_key to allow SSLeay.xs to
+	  compile under -Werror=declaration-after-statement. Fixes GH-407. Thanks to
+	  dharanlinux for the report.
 
 1.93_01 2022-03-20
 	- LibreSSL 3.5.0 has removed access to internal data


### PR DESCRIPTION
The default values for `perl_cb` and `perl_data` in the type signature of `RSA_generate_key` cause xsubpp to emit code that sets the default values before the `CODE` section. The declarations that follow in the `CODE` section therefore trigger compilation failures under `-Werror=declaration-after-statement`.

Move the declarations in the `CODE` section into the `PREINIT` section, which is omitted before the default parameter values are set.

Fixes #407.