### PR TITLE
GH-397 SSLeay.pod: Correct CRL revocation reasons P_X509_CRL_add_revoked_serial_hex.

### DIFF
--- a/Changes
+++ b/Changes
@@ -36,7 +36,10 @@ Revision history for Perl extension Net::SSLeay.
 	- Refactor variable declarations in RSA_generate_key to allow SSLeay.xs to
 	  compile under -Werror=declaration-after-statement. Fixes GH-407. Thanks to
 	  dharanlinux for the report.
-	- Fix memory leaks after calls to X509_get_ext_d2. Thanks to Anton Borowka.
+	- Fix memory leaks after calls to X509_get_ext_d2i. Thanks to Anton Borowka.
+	- Documentation fix: Correct CRL revocation reasons in
+	  P_X509_CRL_add_revoked_serial_hex(). Closes GH-397. Reported
+	  by Marc Reisner.
 
 1.93_01 2022-03-20
 	- LibreSSL 3.5.0 has removed access to internal data

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -7337,7 +7337,10 @@ Adds given serial number $serial_hex to X509_CRL object $crl.
  4 - superseded
  5 - cessationOfOperation
  6 - certificateHold
- 7 - removeFromCRL
+ 7 - (value 7 is not used)
+ 8 - removeFromCRL
+ 9 - privilegeWithdrawn
+ 10 - aACompromise
 
 =item * P_X509_CRL_get_serial
 


### PR DESCRIPTION
SSLeay.pod incorrectly listed CRL DistributionPoint ReasonFlags as values for certificate revocation reason.

Closes #397.