### PR TITLE
CI: add Perl 5.36 to GHA Ubuntu 20.04 matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         perl:
+          - '5.36'
           - '5.34'
           - '5.32'
           - '5.30'
@@ -95,6 +96,7 @@ jobs:
       fail-fast: false
       matrix:
         perl:
+          - '5.36'
           - '5.34'
           - '5.32'
           - '5.30'


### PR DESCRIPTION
Closes #416.