### PR TITLE
Support LibreSSL 3.5 and 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@
 #
 # - libssl: the latest patch release of every minor release between:
 #   - OpenSSL: 0.9.8 and 3.0
-#   - LibreSSL: 2.2 and 3.4
+#   - LibreSSL: 2.2 and 3.6
 
 name: CI
 
@@ -112,6 +112,8 @@ jobs:
           - '5.10'
           - '5.8'
         libressl:
+          - '3.6.1'
+          - '3.5.3'
           - '3.4.3'
           - '3.3.6'
           - '3.2.7'

--- a/Changes
+++ b/Changes
@@ -40,6 +40,7 @@ Revision history for Perl extension Net::SSLeay.
 	- Documentation fix: Correct CRL revocation reasons in
 	  P_X509_CRL_add_revoked_serial_hex(). Closes GH-397. Reported
 	  by Marc Reisner.
+	- Support stable releases of LibreSSL 3.5 and 3.6.
 
 1.93_01 2022-03-20
 	- LibreSSL 3.5.0 has removed access to internal data

--- a/README
+++ b/README
@@ -24,7 +24,7 @@ One of the following libssl implementations:
 * Any stable release of OpenSSL (https://www.openssl.org) in the
   0.9.8 - 3.0 branches, except for OpenSSL 0.9.8 - 0.9.8b.
 * Any stable release of LibreSSL (https://www.libressl.org) in the
-  2.0 - 3.4 series, except for LibreSSL 3.2.2 and 3.2.3.
+  2.0 - 3.6 series, except for LibreSSL 3.2.2 and 3.2.3.
 
 Net-SSLeay may not compile or pass its tests against releases other
 than the ones listed above due to libssl API incompatibilities, or, in

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -54,7 +54,7 @@ branches, except for OpenSSL 0.9.8 - 0.9.8b.
 
 =item *
 
-Any stable release of L<LibreSSL|https://www.libressl.org> in the 2.0 - 3.4
+Any stable release of L<LibreSSL|https://www.libressl.org> in the 2.0 - 3.6
 series, except for LibreSSL 3.2.2 and 3.2.3.
 
 =back


### PR DESCRIPTION
Add stable releases on the LibreSSL 3.5 and 3.6 branches to the support policy, and test the latest 3.5 and 3.6 stable releases in the GHA CI matrix.

Closes #420.