### PR TITLE
GH-394 Tests no longer depend on the legacy provider.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,10 +222,10 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          #- name: freebsd
-          #  pretty_name: FreeBSD (OpenSSL)
-          #  version: '13.0'
-          #  pkginstall: pkg install -y p5-ExtUtils-MakeMaker p5-App-cpanminus openssl openssl-devel
+          - name: freebsd
+            pretty_name: FreeBSD (OpenSSL)
+            version: '13.0'
+            pkginstall: pkg install -y p5-ExtUtils-MakeMaker p5-App-cpanminus openssl openssl-devel
           - name: freebsd
             pretty_name: FreeBSD (LibreSSL)
             version: '13.0'

--- a/Changes
+++ b/Changes
@@ -49,10 +49,18 @@ Revision history for Perl extension Net::SSLeay.
 	  originally added to OpenSSL and Net::SSLeay for
 	  EAP-FAST. These changes allow EAP-FAST to work with AEAD
 	  ciphers and with OpenSSL versions 1.1.1 and later.
-	- Remove code guraded by obsolete
+	- Remove code guarded by obsolete
 	  SSL_F_SSL_SET_HELLO_EXTENSION #ifdef. This was used by the
 	  initial EAP-FAST related OpenSSL patch which was never part
 	  of the OpenSSL distribution.
+	- PEM_get_string_PrivateKey() currently uses DES-CBC as its
+	  default encryption algorithm. Test 33_x509_create_cert.t now
+	  skips testing the default algorithm on systems that support
+	  providers but don't have the legacy provider available. One
+	  such system is FreeBSD 13.0 with OpenSSL which was added as
+	  disabled in GitHub actions by PR GH-402 but can now be
+	  enabled. Long term fix is to replace DES-CBC with a modern
+	  cipher. Allows closing GH-394.
 
 1.93_01 2022-03-20
 	- LibreSSL 3.5.0 has removed access to internal data

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -1836,7 +1836,7 @@ Converts/exports X509 certificate to string (PEM format).
 
 =item * PEM_get_string_PrivateKey
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.45 and before. Requires legacy provider with OpenSSL 3.0 and later as long as DES-CBC is the default encryption algorithm.
+B<COMPATIBILITY:> not available in Net-SSLeay-1.45 and before. Requires legacy provider with OpenSSL 3.0 and later if the default value of C<$enc_alg> (C<DES_CBC>) is used.
 
 Converts public key $pk into PEM formatted string (optionally protected with password).
 

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -1836,7 +1836,7 @@ Converts/exports X509 certificate to string (PEM format).
 
 =item * PEM_get_string_PrivateKey
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.45 and before
+B<COMPATIBILITY:> not available in Net-SSLeay-1.45 and before. Requires legacy provider with OpenSSL 3.0 and later as long as DES-CBC is the default encryption algorithm.
 
 Converts public key $pk into PEM formatted string (optionally protected with password).
 

--- a/t/local/33_x509_create_cert.t
+++ b/t/local/33_x509_create_cert.t
@@ -108,16 +108,18 @@ is(Net::SSLeay::X509_NAME_cmp($ca_issuer, $ca_subject), 0, "X509_NAME_cmp");
   
   like(my $key_pem1 = Net::SSLeay::PEM_get_string_PrivateKey($pk), qr/-----BEGIN (RSA )?PRIVATE KEY-----/, "PEM_get_string_PrivateKey+nopasswd");        
   SKIP: {
-      # Upcoming Net::SSLeay version 2.00 is likely to remove obsolete
-      # functionality. This includes updating PEM_get_stringPrivateKey
-      # default algorithm from EVP_des_cbc() to, for example,
-      # EVP_aes_128_cbc(). When this is done, this SKIP block and
-      # everything in it, besides the test itself, can be removed.
+      # PEM_get_string_PrivateKey uses DES in CBC mode as the default
+      # key encryption algorithm. Upcoming Net::SSLeay version 2.00 is
+      # likely to remove obsolete functionality. This includes
+      # updating PEM_get_stringPrivateKey default algorithm from
+      # EVP_des_cbc() to, for example, EVP_aes_128_cbc(). When this is
+      # done, this SKIP block and everything in it, besides the test
+      # itself, can be removed.
       fail("Legacy provider still used with Net::SSLeay version $Net::SSLeay::VERSION") if $Net::SSLeay::VERSION =~ m/^2/s;
       if (defined &Net::SSLeay::OSSL_PROVIDER_load &&
 	  !Net::SSLeay::OSSL_PROVIDER_load(undef, 'legacy'))
       {
-	  my $des_warning = 'Warning: No legacy provider. DES in CBC mode used by PEM_get_string_PrivateKey by default is not available';
+	  my $des_warning = 'No legacy provider for PEM_get_string_PrivateKey';
 	  diag($des_warning);
 	  skip($des_warning, 1);
       }


### PR DESCRIPTION
`Net::SSLeay::PEM_get_string_PrivateKey()` uses DES-CBC as its default encryption algorithm. Providers introduced in OpenSSL 3.0 implement DES-CBC in the legacy provider which may not be available on all systems. This commit changes `33_x509_create_cert.t `PEM_get_string_PrivateKey() default encryption testing to skip the test on systems that support providers but do not have the default provider available.

This change does not change the fact that `PEM_get_string_PrivateKey(`) remains broken on systems without the default provider when the default encryption algorithm is used.

When obsolete encryption algorithms are updated, for example by changing DES-CBC to AES-128-CBC, the special handling can be removed and the test can be re-enabled on all systems.

As a reminder for this, test `fail()` is called when `Net::SSLeay::VERSION` reaches 2.x.

Closes GH-394. Relates to GH-402.