### PR TITLE
Pass through `RAND_seed()` argument to libcrypto

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for Perl extension Net::SSLeay.
 
+????
+	- Pass RAND_seed()'s sole argument to the underlying RAND_seed() function in
+	  libcrypto, rather than passing the value of a non-existent second argument.
+	  Fixes GH-427. Thanks to cgf1 for the report.
+
 1.93_02 2023-02-22
 	- Update ppport.h to version 3.68. This eliminates thousands of
 	  compound-token-split-by-macro compiler warnings when building Net-SSLeay with

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -3357,7 +3357,7 @@ RAND_seed(buf)
      PREINIT:
      STRLEN len;
      INPUT:
-     char *  buf = SvPV( ST(1), len);
+     char *buf = SvPV(ST(0), len);
      CODE:
      RAND_seed (buf, (int)len);
 


### PR DESCRIPTION
`ST()` arguments are zero-indexed. `RAND_seed()` incorrectly uses `ST(1)` to refer to the function's first argument (a buffer containing data to be mixed into the PRNG state) - refer to it correctly as `ST(0)` instead.

Fixes #427.