### PR TITLE
Support running the test suite in an environment where sha1 isn't allowed by policy

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,14 @@ Revision history for Perl extension Net::SSLeay.
 	- Pass RAND_seed()'s sole argument to the underlying RAND_seed() function in
 	  libcrypto, rather than passing the value of a non-existent second argument.
 	  Fixes GH-427. Thanks to cgf1 for the report.
+	- Avoid explicit and implicit use of weak hash algorithms,
+	  such as MD5 and SHA-1, in test suite. This allows tests
+	  44_sess.t and 45_exporter.t to correctly work on systems
+	  where crypto policies prohibit their direct use and TLS
+	  versions that require them. An example of such a system is
+	  Rocky Linux 9.2. Any Red Hat Enterprise Linux 9 and derived
+	  system is likely to have similar behaviour.  Thanks to Paul
+	  Howarth for the investigation and patches.
 
 1.93_02 2023-02-22
 	- Update ppport.h to version 3.68. This eliminates thousands of

--- a/t/local/33_x509_create_cert.t
+++ b/t/local/33_x509_create_cert.t
@@ -98,8 +98,8 @@ is(Net::SSLeay::X509_NAME_cmp($ca_issuer, $ca_subject), 0, "X509_NAME_cmp");
         &Net::SSLeay::NID_crl_distribution_points => 'URI:http://pki.dom.com/crl1.pem,URI:http://pki.dom.com/crl2.pem',
     ), "P_X509_add_extensions");
 
-  ok(my $sha1_digest = Net::SSLeay::EVP_get_digestbyname("sha1"), "EVP_get_digestbyname");
-  ok(Net::SSLeay::X509_sign($x509, $ca_pk, $sha1_digest), "X509_sign");
+  ok(my $sha256_digest = Net::SSLeay::EVP_get_digestbyname("sha256"), "EVP_get_digestbyname");
+  ok(Net::SSLeay::X509_sign($x509, $ca_pk, $sha256_digest), "X509_sign");
   
   is(Net::SSLeay::X509_get_version($x509), 3, "X509_get_version");  
   is(Net::SSLeay::X509_verify($x509, Net::SSLeay::X509_get_pubkey($ca_cert)), 1, "X509_verify");
@@ -208,8 +208,8 @@ is(Net::SSLeay::X509_NAME_cmp($ca_issuer, $ca_subject), 0, "X509_NAME_cmp");
    
   ok(Net::SSLeay::X509_REQ_set_version($req, 2), "X509_REQ_set_version");
 
-  ok(my $sha1_digest = Net::SSLeay::EVP_get_digestbyname("sha1"), "EVP_get_digestbyname");
-  ok(Net::SSLeay::X509_REQ_sign($req, $pk, $sha1_digest), "X509_REQ_sign");
+  ok(my $sha256_digest = Net::SSLeay::EVP_get_digestbyname("sha256"), "EVP_get_digestbyname");
+  ok(Net::SSLeay::X509_REQ_sign($req, $pk, $sha256_digest), "X509_REQ_sign");
   
   ok(my $req_pubkey = Net::SSLeay::X509_REQ_get_pubkey($req), "X509_REQ_get_pubkey");
   is(Net::SSLeay::X509_REQ_verify($req, $req_pubkey), 1, "X509_REQ_verify");
@@ -250,7 +250,7 @@ is(Net::SSLeay::X509_NAME_cmp($ca_issuer, $ca_subject), 0, "X509_NAME_cmp");
   ok(Net::SSLeay::X509_set_pubkey($x509ss,$tmppkey), "X509_set_pubkey");
   Net::SSLeay::EVP_PKEY_free($tmppkey);
   
-  ok(Net::SSLeay::X509_sign($x509ss, $ca_pk, $sha1_digest), "X509_sign");
+  ok(Net::SSLeay::X509_sign($x509ss, $ca_pk, $sha256_digest), "X509_sign");
   like(my $crt_pem = Net::SSLeay::PEM_get_string_X509($x509ss), qr/-----BEGIN CERTIFICATE-----/, "PEM_get_string_X509");
 
   #write_file("tmp_cert2.crt.pem", $crt_pem);
@@ -318,8 +318,8 @@ is(Net::SSLeay::X509_NAME_cmp($ca_issuer, $ca_subject), 0, "X509_NAME_cmp");
     ok(Net::SSLeay::P_ASN1_TIME_set_isotime(Net::SSLeay::X509_get_notAfter($x509), "2038-01-01T00:00:00Z"), "P_ASN1_TIME_set_isotime+X509_get_notAfter");
   }
   
-  ok(my $sha1_digest = Net::SSLeay::EVP_get_digestbyname("sha1"), "EVP_get_digestbyname");
-  ok(Net::SSLeay::X509_sign($x509, $ca_pk, $sha1_digest), "X509_sign");
+  ok(my $sha256_digest = Net::SSLeay::EVP_get_digestbyname("sha256"), "EVP_get_digestbyname");
+  ok(Net::SSLeay::X509_sign($x509, $ca_pk, $sha256_digest), "X509_sign");
   
   like(my $crt_pem = Net::SSLeay::PEM_get_string_X509($x509), qr/-----BEGIN CERTIFICATE-----/, "PEM_get_string_X509");
   like(my $key_pem = Net::SSLeay::PEM_get_string_PrivateKey($pk), qr/-----BEGIN (RSA )?PRIVATE KEY-----/, "PEM_get_string_PrivateKey");  
@@ -333,8 +333,8 @@ is(Net::SSLeay::X509_NAME_cmp($ca_issuer, $ca_subject), 0, "X509_NAME_cmp");
   ok(my $bio = Net::SSLeay::BIO_new_file($req_pem, 'r'), "BIO_new_file");
   ok(my $req = Net::SSLeay::PEM_read_bio_X509_REQ($bio), "PEM_read_bio_X509");
   
-  ok(my $sha1_digest = Net::SSLeay::EVP_get_digestbyname("sha1"), "EVP_get_digestbyname");
-  is(unpack("H*", Net::SSLeay::X509_REQ_digest($req, $sha1_digest)), "372c21a20a6d4e15bf8ecefb487cc604d9a10960", "X509_REQ_digest");
+  ok(my $sha256_digest = Net::SSLeay::EVP_get_digestbyname("sha256"), "EVP_get_digestbyname");
+  is(unpack("H*", Net::SSLeay::X509_REQ_digest($req, $sha256_digest)), "420e99da1e23e192409ab2a5f1a9b09ac03c52fa4b8bd0d19e561358f9880e88", "X509_REQ_digest");
   
   ok(my $req2  = Net::SSLeay::X509_REQ_new(), "X509_REQ_new");  
   ok(my $name = Net::SSLeay::X509_REQ_get_subject_name($req), "X509_REQ_get_subject_name");

--- a/t/local/34_x509_crl.t
+++ b/t/local/34_x509_crl.t
@@ -39,8 +39,8 @@ ok(my $ca_pk = Net::SSLeay::PEM_read_bio_PrivateKey($bio2), "PEM_read_bio_Privat
   is(Net::SSLeay::P_ASN1_TIME_get_isotime($time_next), '2020-07-08T00:00:00Z', "P_ASN1_TIME_get_isotime next");
   
   is(Net::SSLeay::X509_CRL_get_version($crl1), 1, "X509_CRL_get_version");
-  ok(my $sha1_digest = Net::SSLeay::EVP_get_digestbyname("sha1"), "EVP_get_digestbyname");
-  is(unpack("H*",Net::SSLeay::X509_CRL_digest($crl1, $sha1_digest)), 'f0e5c853477a206c03f7347aee09a01d91df0ac5', "X509_CRL_digest");
+  ok(my $sha256_digest = Net::SSLeay::EVP_get_digestbyname("sha256"), "EVP_get_digestbyname");
+  is(unpack("H*",Net::SSLeay::X509_CRL_digest($crl1, $sha256_digest)), '4edc18ec956e722cbcf96589a43535c2d1d557e3cec55b1e421897827c3bb8be', "X509_CRL_digest");
 }
 
 { ### X509_CRL create
@@ -81,9 +81,9 @@ ok(my $ca_pk = Net::SSLeay::PEM_read_bio_PrivateKey($bio2), "PEM_read_bio_Privat
         &Net::SSLeay::NID_authority_key_identifier => 'keyid:always,issuer:always',
     ), "P_X509_CRL_add_extensions");
 
-  ok(my $sha1_digest = Net::SSLeay::EVP_get_digestbyname("sha1"), "EVP_get_digestbyname");
+  ok(my $sha256_digest = Net::SSLeay::EVP_get_digestbyname("sha256"), "EVP_get_digestbyname");
   ok(Net::SSLeay::X509_CRL_sort($crl), "X509_CRL_sort");
-  ok(Net::SSLeay::X509_CRL_sign($crl, $ca_pk, $sha1_digest), "X509_CRL_sign");
+  ok(Net::SSLeay::X509_CRL_sign($crl, $ca_pk, $sha256_digest), "X509_CRL_sign");
   
   like(my $crl_pem = Net::SSLeay::PEM_get_string_X509_CRL($crl), qr/-----BEGIN X509 CRL-----/, "PEM_get_string_X509_CRL");
     


### PR DESCRIPTION
I tried building Net-SSLeay 1.92 on Rocky Linux 9 (a clone of Red Hat Enterprise Linux 9) and there were some test failures. I tried 1.93_02 and it didn't help - the tests results were the same:
```
$ unset RELEASE_TESTING
$ make test
"/usr/bin/perl" -MExtUtils::Command::MM -e 'cp_nonempty' -- SSLeay.bs blib/arch/auto/Net/SSLeay/SSLeay.bs 644
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/local/*.t t/handle/local/*.t
t/handle/local/05_use.t ..................... ok
t/local/01_pod.t ............................ ok
t/local/02_pod_coverage.t ................... skipped: These tests are for only for release candidate testing. Enable with RELEASE_TESTING=1
# 
# Testing Net::SSLeay 1.93_02
# 
# Perl information:
#   Version:         '5.032001'
#   Executable path: '/usr/bin/perl'
# 
# Library version with OpenSSL_version_num():
#   OPENSSL_VERSION_NUMBER: '0x30000010'
# 
# Library information with SSLeay_version() and OpenSSL_version():
#   SSLEAY_VERSION:              'OpenSSL 3.0.1 14 Dec 2021'
#   SSLEAY_CFLAGS:               'compiler: gcc -fPIC -pthread -m64 -Wa,--noexecstack -Wall -O3 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=x86-64-v2 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -Wa,--noexecstack -Wa,--generate-missing-build-notes=yes -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -DOPENSSL_USE_NODELETE -DL_ENDIAN -DOPENSSL_PIC -DOPENSSL_BUILDING_OPENSSL -DZLIB -DNDEBUG -DPURIFY -DDEVRANDOM="\"/dev/urandom\"" -DREDHAT_FIPS_VERSION="\"3.0.1-0f88da31fc0876c9\"" -DSYSTEM_CIPHERS_FILE="/etc/crypto-policies/back-ends/openssl.config"'
#   SSLEAY_BUILT_ON:             'built on: Wed Feb  8 00:00:00 2023 UTC'
#   SSLEAY_PLATFORM:             'platform: linux-x86_64'
#   SSLEAY_DIR:                  'OPENSSLDIR: "/etc/pki/tls"'
#   OPENSSL_ENGINES_DIR:         'ENGINESDIR: "/usr/lib64/engines-3"'
#   OPENSSL_MODULES_DIR:         'MODULESDIR: "/usr/lib64/ossl-modules"'
#   OPENSSL_CPU_INFO:            'CPUINFO: OPENSSL_ia32cap=0x7ffaf3ffffebffff:0x40000000029c6fbf'
#   OPENSSL_VERSION_STRING:      '3.0.1'
#   OPENSSL_FULL_VERSION_STRING: '3.0.1'
# 
# Library version information with OPENSSL_version_*():
#   OPENSSL_version_major():          '3'
#   OPENSSL_version_minor():          '0'
#   OPENSSL_version_patch():          '1'
#   OPENSSL_version_pre_release():    ''
#   OPENSSL_version_build_metadata(): ''
# 
# Library information with OPENSSL_info():
#   OPENSSL_INFO_CONFIG_DIR:             '/etc/pki/tls'
#   OPENSSL_INFO_ENGINES_DIR:            '/usr/lib64/engines-3'
#   OPENSSL_INFO_MODULES_DIR:            '/usr/lib64/ossl-modules'
#   OPENSSL_INFO_DSO_EXTENSION:          '.so'
#   OPENSSL_INFO_DIR_FILENAME_SEPARATOR: '/'
#   OPENSSL_INFO_LIST_SEPARATOR:         ':'
#   OPENSSL_INFO_SEED_SOURCE:            'os-specific'
#   OPENSSL_INFO_CPU_SETTINGS:           'OPENSSL_ia32cap=0x7ffaf3ffffebffff:0x40000000029c6fbf'
t/local/03_use.t ............................ ok
t/local/04_basic.t .......................... ok
t/local/05_passwd_cb.t ...................... ok
t/local/06_tcpecho.t ........................ ok
t/local/07_sslecho.t ........................ ok
t/local/08_pipe.t ........................... ok
t/local/09_ctx_new.t ........................ ok
t/local/10_rand.t ........................... ok
t/local/11_read.t ........................... ok
t/local/15_bio.t ............................ ok
t/local/20_functions.t ...................... ok
t/local/21_constants.t ...................... ok
t/local/22_provider.t ....................... ok
t/local/22_provider_try_load.t .............. ok
t/local/22_provider_try_load_zero_retain.t .. ok
t/local/30_error.t .......................... ok
t/local/31_rsa_generate_key.t ............... ok
t/local/32_x509_get_cert_info.t ............. ok
#   Failed test 'X509_sign'
#   at t/local/33_x509_create_cert.t line 102.
#   Failed test 'X509_verify'
#   at t/local/33_x509_create_cert.t line 105.
#          got: '-1'
#     expected: '1'
#   Failed test 'PEM_get_string_X509'
#   at t/local/33_x509_create_cert.t line 107.
#                   undef
#     doesn't match '(?^:-----BEGIN CERTIFICATE-----)'
#   Failed test 'X509_REQ_sign'
#   at t/local/33_x509_create_cert.t line 212.
#   Failed test 'X509_REQ_verify'
#   at t/local/33_x509_create_cert.t line 215.
#          got: '-1'
#     expected: '1'
#   Failed test 'PEM_get_string_X509_REQ'
#   at t/local/33_x509_create_cert.t line 231.
#                   undef
#     doesn't match '(?^:-----BEGIN CERTIFICATE REQUEST-----)'
#   Failed test 'X509_sign'
#   at t/local/33_x509_create_cert.t line 253.
#   Failed test 'PEM_get_string_X509'
#   at t/local/33_x509_create_cert.t line 254.
#                   undef
#     doesn't match '(?^:-----BEGIN CERTIFICATE-----)'
#   Failed test 'X509_sign'
#   at t/local/33_x509_create_cert.t line 322.
#   Failed test 'PEM_get_string_X509'
#   at t/local/33_x509_create_cert.t line 324.
#                   undef
#     doesn't match '(?^:-----BEGIN CERTIFICATE-----)'
# Looks like you failed 10 tests of 141.
t/local/33_x509_create_cert.t ............... 
Dubious, test returned 10 (wstat 2560, 0xa00)
Failed 10/141 subtests 
	(less 2 skipped subtests: 129 okay)
#   Failed test 'X509_CRL_sign'
#   at t/local/34_x509_crl.t line 86.
#   Failed test 'PEM_get_string_X509_CRL'
#   at t/local/34_x509_crl.t line 88.
#                   undef
#     doesn't match '(?^:-----BEGIN X509 CRL-----)'
# Looks like you failed 2 tests of 53.
t/local/34_x509_crl.t ....................... 
Dubious, test returned 2 (wstat 512, 0x200)
Failed 2/53 subtests 
t/local/35_ephemeral.t ...................... skipped: LibreSSL and OpenSSL 1.1.0 removed support for ephemeral/temporary RSA private keys
t/local/36_verify.t ......................... ok
t/local/37_asn1_time.t ...................... ok
t/local/38_priv-key.t ....................... ok
t/local/39_pkcs12.t ......................... ok
t/local/40_npn_support.t .................... ok
t/local/41_alpn_support.t ................... ok
t/local/42_info_callback.t .................. ok
t/local/43_misc_functions.t ................. ok
# Protocol TLSv1, connect() returns -1, Error: error:0A000438:SSL routines::tlsv1 alert internal error
# Protocol TLSv1.1, connect() returns -1, Error: error:0A000438:SSL routines::tlsv1 alert internal error
#   Failed test 'Server TLSv1 new_cb call count'
#   at t/local/44_sess.t line 327.
#          got: undef
#     expected: '1'
#   Failed test 'Server TLSv1 new_cb params were correct'
#   at t/local/44_sess.t line 328.
#          got: undef
#     expected: '1'
#   Failed test 'Server TLSv1 remove_cb call count'
#   at t/local/44_sess.t line 329.
#          got: '2'
#     expected: '1'
#   Failed test 'Client TLSv1 new_cb call count'
#   at t/local/44_sess.t line 332.
#          got: undef
#     expected: '1'
#   Failed test 'Client TLSv1 new_cb params were correct'
#   at t/local/44_sess.t line 333.
#          got: undef
#     expected: '1'
#   Failed test 'Client TLSv1 remove_cb call count'
#   at t/local/44_sess.t line 334.
#          got: '2'
#     expected: '1'
#   Failed test 'Server TLSv1 session is resumable'
#   at t/local/44_sess.t line 341.
#          got: undef
#     expected: '1'
#   Failed test 'Client TLSv1 session is resumable'
#   at t/local/44_sess.t line 344.
#          got: undef
#     expected: '1'
#   Failed test 'Server TLSv1.1 new_cb call count'
#   at t/local/44_sess.t line 327.
#          got: undef
#     expected: '1'
#   Failed test 'Server TLSv1.1 new_cb params were correct'
#   at t/local/44_sess.t line 328.
#          got: undef
#     expected: '1'
#   Failed test 'Server TLSv1.1 remove_cb call count'
#   at t/local/44_sess.t line 329.
#          got: '2'
#     expected: '1'
#   Failed test 'Client TLSv1.1 new_cb call count'
#   at t/local/44_sess.t line 332.
#          got: undef
#     expected: '1'
#   Failed test 'Client TLSv1.1 new_cb params were correct'
#   at t/local/44_sess.t line 333.
#          got: undef
#     expected: '1'
#   Failed test 'Client TLSv1.1 remove_cb call count'
#   at t/local/44_sess.t line 334.
#          got: '2'
#     expected: '1'
#   Failed test 'Server TLSv1.1 session is resumable'
#   at t/local/44_sess.t line 341.
#          got: undef
#     expected: '1'
#   Failed test 'Client TLSv1.1 session is resumable'
#   at t/local/44_sess.t line 344.
#          got: undef
#     expected: '1'
# Looks like you failed 16 tests of 58.
t/local/44_sess.t ........................... 
Dubious, test returned 16 (wstat 4096, 0x1000)
Failed 16/58 subtests 
# Protocol TLSv1, connect() returns -1, Error: error:0A000438:SSL routines::tlsv1 alert internal error
# Protocol TLSv1.1, connect() returns -1, Error: error:0A000438:SSL routines::tlsv1 alert internal error
t/local/45_exporter.t ....................... ok
t/local/46_msg_callback.t ................... ok
t/local/47_keylog.t ......................... ok
t/local/50_digest.t ......................... ok
t/local/61_threads-cb-crash.t ............... ok
t/local/62_threads-ctx_new-deadlock.t ....... ok
t/local/63_ec_key_generate_key.t ............ ok
t/local/64_ticket_sharing.t ................. ok
t/local/65_security_level.t ................. ok
t/local/65_ticket_sharing_2.t ............... ok
t/local/66_curves.t ......................... ok
t/local/kwalitee.t .......................... skipped: These tests are for only for release candidate testing. Enable with RELEASE_TESTING=1
Test Summary Report
-------------------
t/local/33_x509_create_cert.t             (Wstat: 2560 (exited 10) Tests: 141 Failed: 10)
  Failed tests:  34, 36-37, 60, 62, 72, 83-84, 127-128
  Non-zero exit status: 10
t/local/34_x509_crl.t                     (Wstat: 512 (exited 2) Tests: 53 Failed: 2)
  Failed tests:  34-35
  Non-zero exit status: 2
t/local/44_sess.t                         (Wstat: 4096 (exited 16) Tests: 58 Failed: 16)
  Failed tests:  2-4, 6-8, 10, 12, 14-16, 18-20, 22, 24
  Non-zero exit status: 16
Files=45, Tests=2598,  5 wallclock secs ( 0.13 usr  0.02 sys +  3.81 cusr  0.39 csys =  4.35 CPU)
Result: FAIL
```
After some experimentation I found that I could enable support for the SHA1 algorithm:
```
$ sudo update-crypto-policies --set DEFAULT:SHA1
```
After doing that, the tests all passed, which pointed me towards the solution for the default case. The tests `t/local/33_x509_create_cert.t` and `t/local/34_x509_crl.t` explicitly use sha1 and by changing them to use sha256 (as used for the signatures in the test PKI), the tests passed without changing the crypto policy.

The `t/local/44_sess.t ` failures were less obvious, though I did read somewhere that sha1 was hard-coded into the key exchange algorithm for TLSv1 and TLSv1.1, which were the failing cases. The protocols were marked "usable" by `Test::Net::SSLeay::is_protocol_usable()` but evidently they were not *actually* usable. This turned out to be because the `is_protocol_usable` check doesn't go as far as doing a key exchange (I think). I toyed with the idea of enhancing the check to fork off a server and make a real connection to it but that turned out to be quite complicated, made the test  suite more dependent on having a working `fork()`, and I still had some `SIGPIPE` issues. Instead, I tweaked the `t/local/44_sess.t` test to check for `SSL_ERROR_SSL` on `connect()` and if it shows up, assume that the current protocol is not actually usable.

I also made a similar change in `t/local/45_exporter.t`, which has the same protocol issues but doesn't actually result in a failing test.

After making these changes, the test suite passes using the default policy on Rocky Linux 9.