### PR TITLE
SSLeay.xs: Disable Policy Tree API for LibreSSL 3.8 and later

### DIFF
--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -7157,6 +7157,7 @@ X509_VERIFY_PARAM_get0_peername(param)
 
 #endif /* OpenSSL 1.0.2-beta2, LibreSSL 2.7.0 */
 
+#if !defined(LIBRESSL_VERSION_NUMBER) || (LIBRESSL_VERSION_NUMBER < 0x3080000fL) /* LibreSSL < 3.8.0 */
 void
 X509_policy_tree_free(tree)
     X509_POLICY_TREE *tree
@@ -7199,6 +7200,7 @@ const X509_POLICY_NODE *
 X509_policy_node_get0_parent(node)
     const X509_POLICY_NODE *node
 
+#endif /* !(LibreSSL >= 3.7.0) */
 #endif
 
 ASN1_OBJECT *


### PR DESCRIPTION
This is taken from the OpenBSD ports tree.

https://github.com/openbsd/ports/commit/f6567f938c9bd51bfd99f8426eba6a1590cc6384

Here is a full [build log](https://github.com/radiator-software/p5-net-ssleay/files/11593811/build.log) showing the failure with LibreSSL 3.8.0.

