### PR TITLE
SSLeay.xs: Disable Policy Tree API for LibreSSL 3.8 and later

### DIFF
--- a/Changes
+++ b/Changes
@@ -12,6 +12,20 @@ Revision history for Perl extension Net::SSLeay.
 	  Rocky Linux 9.2. Any Red Hat Enterprise Linux 9 and derived
 	  system is likely to have similar behaviour.  Thanks to Paul
 	  Howarth for the investigation and patches.
+	- LibreSSL 3.8.0 release notes state: The POLICY_TREE and its
+	  related structures and API were removed. The affected
+	  Net::SSLeay functions are:
+	  - X509_policy_level_get0_node
+	  - X509_policy_level_node_count
+	  - X509_policy_node_get0_parent
+	  - X509_policy_node_get0_policy
+	  - X509_policy_node_get0_qualifiers
+	  - X509_policy_tree_free
+	  - X509_policy_tree_get0_level
+	  - X509_policy_tree_get0_policies
+	  - X509_policy_tree_get0_user_policies
+	  - X509_policy_tree_level_count
+	  Patch by GitHub user orbea.
 
 1.93_02 2023-02-22
 	- Update ppport.h to version 3.68. This eliminates thousands of

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -7157,6 +7157,7 @@ X509_VERIFY_PARAM_get0_peername(param)
 
 #endif /* OpenSSL 1.0.2-beta2, LibreSSL 2.7.0 */
 
+#if !defined(LIBRESSL_VERSION_NUMBER) || (LIBRESSL_VERSION_NUMBER < 0x3080000fL) /* LibreSSL < 3.8.0 */
 void
 X509_policy_tree_free(tree)
     X509_POLICY_TREE *tree
@@ -7199,6 +7200,7 @@ const X509_POLICY_NODE *
 X509_policy_node_get0_parent(node)
     const X509_POLICY_NODE *node
 
+#endif /* !(LibreSSL >= 3.7.0) */
 #endif
 
 ASN1_OBJECT *

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -7200,7 +7200,7 @@ const X509_POLICY_NODE *
 X509_policy_node_get0_parent(node)
     const X509_POLICY_NODE *node
 
-#endif /* !(LibreSSL >= 3.7.0) */
+#endif /* LibreSSL < 3.8.0 */
 #endif
 
 ASN1_OBJECT *

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -6498,6 +6498,8 @@ Loads/adds X509 CRL from $file to X509_LOOKUP structure
 
 =item * X509_policy_level_get0_node
 
+B<COMPATIBILITY:> no longer available in LibreSSL 3.8.0 and later
+
 ??? (more info needed)
 
  my $rv = Net::SSLeay::X509_policy_level_get0_node($level, $i);
@@ -6508,6 +6510,8 @@ Loads/adds X509 CRL from $file to X509_LOOKUP structure
 
 =item * X509_policy_level_node_count
 
+B<COMPATIBILITY:> no longer available in LibreSSL 3.8.0 and later
+
 ??? (more info needed)
 
  my $rv = Net::SSLeay::X509_policy_level_node_count($level);
@@ -6516,6 +6520,8 @@ Loads/adds X509 CRL from $file to X509_LOOKUP structure
  # returns: (integer) node count
 
 =item * X509_policy_node_get0_parent
+
+B<COMPATIBILITY:> no longer available in LibreSSL 3.8.0 and later
 
 ??? (more info needed)
 
@@ -6526,6 +6532,8 @@ Loads/adds X509 CRL from $file to X509_LOOKUP structure
 
 =item * X509_policy_node_get0_policy
 
+B<COMPATIBILITY:> no longer available in LibreSSL 3.8.0 and later
+
 ??? (more info needed)
 
  my $rv = Net::SSLeay::X509_policy_node_get0_policy($node);
@@ -6534,6 +6542,8 @@ Loads/adds X509 CRL from $file to X509_LOOKUP structure
  # returns: value corresponding to openssl's ASN1_OBJECT structure (0 on failure)
 
 =item * X509_policy_node_get0_qualifiers
+
+B<COMPATIBILITY:> no longer available in LibreSSL 3.8.0 and later
 
 ??? (more info needed)
 
@@ -6544,6 +6554,8 @@ Loads/adds X509 CRL from $file to X509_LOOKUP structure
 
 =item * X509_policy_tree_free
 
+B<COMPATIBILITY:> no longer available in LibreSSL 3.8.0 and later
+
 ??? (more info needed)
 
  Net::SSLeay::X509_policy_tree_free($tree);
@@ -6552,6 +6564,8 @@ Loads/adds X509 CRL from $file to X509_LOOKUP structure
  # returns: no return value
 
 =item * X509_policy_tree_get0_level
+
+B<COMPATIBILITY:> no longer available in LibreSSL 3.8.0 and later
 
 ??? (more info needed)
 
@@ -6563,23 +6577,29 @@ Loads/adds X509 CRL from $file to X509_LOOKUP structure
 
 =item * X509_policy_tree_get0_policies
 
+B<COMPATIBILITY:> no longer available in LibreSSL 3.8.0 and later
+
 ??? (more info needed)
 
  my $rv = Net::SSLeay::X509_policy_tree_get0_policies($tree);
  # $tree - value corresponding to openssl's X509_POLICY_TREE structure
  #
- # returns: value corresponding to openssl's X509_POLICY_NODE structure (0 on failure)
+ # returns: value corresponding to openssl's STACK_OF(X509_POLICY_NODE) structure (0 on failure)
 
 =item * X509_policy_tree_get0_user_policies
+
+B<COMPATIBILITY:> no longer available in LibreSSL 3.8.0 and later
 
 ??? (more info needed)
 
  my $rv = Net::SSLeay::X509_policy_tree_get0_user_policies($tree);
  # $tree - value corresponding to openssl's X509_POLICY_TREE structure
  #
- # returns: value corresponding to openssl's X509_POLICY_NODE structure (0 on failure)
+ # returns: value corresponding to openssl's STACK_OF(X509_POLICY_NODE) structure (0 on failure)
 
 =item * X509_policy_tree_level_count
+
+B<COMPATIBILITY:> no longer available in LibreSSL 3.8.0 and later
 
 ??? (more info needed)
 


### PR DESCRIPTION
LibreSSL 3.8.0 no longer supports these functions. See #434 for more information and Net::SSLeay build log showing the failure.