### PR TITLE
GH-454 Makefile.PL, XS and installation fixes

### DIFF
--- a/Changes
+++ b/Changes
@@ -155,6 +155,8 @@ Revision history for Perl extension Net::SSLeay.
 	  Net::SSLeay. This may still be a requirement on some
 	  platforms, but, for example, with Linux and macOS mixing
 	  clang and gcc appears to work.
+	- Add general installation instructions in README. Thanks to
+	  GitHub user viviparous. Update README and README.OSX.
 
 1.93_02 2023-02-22
 	- Update ppport.h to version 3.68. This eliminates thousands of

--- a/Changes
+++ b/Changes
@@ -134,6 +134,13 @@ Revision history for Perl extension Net::SSLeay.
 	  related functions.
 	- Support finding OpenSSL libraries using
 	  ExtUtils::PkgConfig. Thanks to Paul Howarth for the patch.
+	- Fix a number of cases where variables were declared after
+	  code triggering Gcc and Clang warning
+	  -Wdeclaration-after-statement. This is supported by C
+	  language version C99 and used by Perl 5.35.5 and
+	  later. SSLeay.xs is likely compiled with compilers that do
+	  not support this, therefore such constructs are avoided in
+	  SSLeay.xs. Thanks to GitHub user bulk88 for the patch.
 
 1.93_02 2023-02-22
 	- Update ppport.h to version 3.68. This eliminates thousands of

--- a/Changes
+++ b/Changes
@@ -150,6 +150,11 @@ Revision history for Perl extension Net::SSLeay.
 	  path detection may pick the wrong version. Static
 	  compilation needs seems not to work with the these
 	  versions. Thanks to bulk88 for the initial updates.
+	- Tone down Makefile.PL and README warning against mixing
+	  compilers and flags when compiling OpenSSL, Perl and
+	  Net::SSLeay. This may still be a requirement on some
+	  platforms, but, for example, with Linux and macOS mixing
+	  clang and gcc appears to work.
 
 1.93_02 2023-02-22
 	- Update ppport.h to version 3.68. This eliminates thousands of

--- a/Changes
+++ b/Changes
@@ -141,6 +141,15 @@ Revision history for Perl extension Net::SSLeay.
 	  later. SSLeay.xs is likely compiled with compilers that do
 	  not support this, therefore such constructs are avoided in
 	  SSLeay.xs. Thanks to GitHub user bulk88 for the patch.
+	- Fix _CRT_SECURE_NO_DEPRECATE warning on Windows. Fix OpenSSL
+	  library file path detection loop in Makefile.PL. Both thanks
+	  to bulk88.
+	- Update Shining Light OpenSSL detection to work with OpenSSL
+	  1.1.1w, 3.0.12, 3.1.4 and 3.2.0 installers. Caveats: when
+	  both 32bit and 64bit versions are installed, OpenSSL library
+	  path detection may pick the wrong version. Static
+	  compilation needs seems not to work with the these
+	  versions. Thanks to bulk88 for the initial updates.
 
 1.93_02 2023-02-22
 	- Update ppport.h to version 3.68. This eliminates thousands of

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -274,14 +274,14 @@ EOM
         # Library names depend on the compiler
         @pairs = (['eay32','ssl32'],['crypto.dll','ssl.dll'],['crypto','ssl']) if $Config{cc} =~ /gcc/;
         @pairs = (['libeay32','ssleay32'],['libeay32MD','ssleay32MD'],['libeay32MT','ssleay32MT'],['libcrypto','libssl'],['crypto','ssl']) if $Config{cc} =~ /cl/;
-        for my $dir (@{$opts->{lib_paths}}) {
+        FOUND: for my $dir (@{$opts->{lib_paths}}) {
           for my $p (@pairs) {
             $found = 1 if ($Config{cc} =~ /gcc/ && -f "$dir/lib$p->[0].a" && -f "$dir/lib$p->[1].a");
             $found = 1 if ($Config{cc} =~ /cl/ && -f "$dir/$p->[0].lib" && -f "$dir/$p->[1].lib");
             if ($found) {
               $opts->{lib_links} = [$p->[0], $p->[1], 'crypt32']; # Some systems need this system lib crypt32 too
               $opts->{lib_paths} = [$dir];
-              last;
+              last FOUND;
             }
           }
         }

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -264,9 +264,13 @@ EOM
         if ($win_link_statically) {
             # Link to static libs
             push @{ $opts->{lib_paths} }, "$prefix/lib/VC/static" if -d "$prefix/lib/VC/static";
+            push @{ $opts->{lib_paths} }, "$prefix/lib/VC/x86/MT" if -d "$prefix/lib/VC/x86/MT"; # Shining Light 32bit OpenSSL 3.2.0
+            push @{ $opts->{lib_paths} }, "$prefix/lib/VC/x64/MT" if -d "$prefix/lib/VC/x64/MT"; # Shining Light 64bit OpenSSL 3.2.0
         }
         else {
             push @{ $opts->{lib_paths} }, "$prefix/lib/VC" if -d "$prefix/lib/VC";
+            push @{ $opts->{lib_paths} }, "$prefix/lib/VC/x86/MD" if -d "$prefix/lib/VC/x86/MD"; # Shining Light 32bit OpenSSL 3.2.0
+            push @{ $opts->{lib_paths} }, "$prefix/lib/VC/x64/MD" if -d "$prefix/lib/VC/x64/MD"; # Shining Light 64bit OpenSSL 3.2.0
         }
 
         my $found = 0;
@@ -371,6 +375,8 @@ sub find_openssl_prefix {
 	'/usr/sfw/bin/openssl'           => '/usr/sfw', # Open Solaris
 	'C:\OpenSSL\bin\openssl.exe'     => 'C:\OpenSSL',
 	'C:\OpenSSL-Win32\bin\openssl.exe'        => 'C:\OpenSSL-Win32',
+	'C:\Program Files (x86)\OpenSSL-Win32\bin\openssl.exe' => 'C:\Program Files (x86)\OpenSSL-Win32', # Shining Light 32bit OpenSSL 1.1.1w, 3.0.12, 3.1.4 and 3.2.0
+	'C:\Program Files\OpenSSL-Win64\bin\openssl.exe'       => 'C:\Program Files\OpenSSL-Win64',       # Shining Light 64bit OpenSSL 1.1.1w, 3.0.12, 3.1.4 and 3.2.0
 	$Config{prefix} . '\bin\openssl.exe'      => $Config{prefix},           # strawberry perl
 	$Config{prefix} . '\..\c\bin\openssl.exe' => $Config{prefix} . '\..\c', # strawberry perl
 	'/sslexe/openssl.exe'            => '/sslroot',  # VMS, openssl.org

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -256,8 +256,9 @@ sub ssleay_get_build_opts {
     }
 
     print <<EOM;
-*** Be sure to use the same compiler and options to compile your OpenSSL, perl,
-    and Net::SSLeay. Mixing and matching compilers is not supported.
+*** If there are build errors, test failures or run-time malfunctions,
+    try to use the same compiler and options to compile your OpenSSL,
+    Perl, and Net::SSLeay.
 EOM
 
     if ($^O eq 'MSWin32') {

--- a/README
+++ b/README
@@ -48,10 +48,13 @@ Linux distribution's package manager, e.g.:
 A future version of Net-SSLeay will remove this requirement when
 building against a libssl without support for TLS compression.
 
-The same C compiler and options should be used to compile all of Perl,
-OpenSSL/LibreSSL, and Net-SSLeay. Mixing compilers and options often
-leads to build errors or run-time malfunctions that are difficult to
-debug.
+If there are build errors, test failures or run-time malfunctions, try
+to use the same compiler and options to compile your OpenSSL, Perl,
+and Net::SSLeay. Mixing compilers and options may lead to build
+errors, test failures or run-time malfunctions, that are difficult to
+debug. The situation in 2024 is that, for example, compiling Perl with
+gcc and Net::SSLeay with clang works on Linux and macOS. With Windows
+it may be easier to use the same compiler and compiler options.
 
 
 Installing

--- a/README
+++ b/README
@@ -10,7 +10,6 @@ for the released versions:
    https://metacpan.org/release/Net-SSLeay
 
 for the latest and possibly unstable version from git:
-
    https://github.com/radiator-software/p5-net-ssleay
 
 
@@ -61,29 +60,35 @@ Installing
 ----------
 
 General:
-If your OpenSSL is installed in an unusual place, you can tell
-	Net-SSLeay where to find it with by setting the OPENSSL_PREFIX environment
-	variable. Example:
+	Makefile.PL tries to find OpenSSL installation location from a
+	number of pre-defined paths. It will print the version and
+	location of OpenSSL or LibreSSL it finds, or warn if it doesn't
+	find anything usable.
 
-  export OPENSSL_PREFIX=/my/non-standard/path/usr
+	If your OpenSSL is installed in an unusual place, you can tell
+	Makefile.PL from where to find it with by setting the
+	OPENSSL_PREFIX environment variable.
 
-The logic in Makefile.PL appends include/openssl to the environment 
-variable OPENSSL_PREFIX.
+	On Linux, macOS and other Unix type systems:
+	OPENSSL_PREFIX=/home/mikem/playpen/openssl-1.0.2c perl Makefile.PL
+
+	On Windows:
+	set OPENSSL_PREFIX=C:\playpen\openssl-1.0.2.c
+	perl Makefile.PL
+
+	The logic in Makefile.PL tries to resolve the required
+	libraries and include directories based on the environment
+	variable OPENSSL_PREFIX.
 
 Unix:
-	# build or install OpenSSL as per instructions in that package
+	Build or install OpenSSL as per instructions in that
+	package. Review section 'General:' above before continuing.
 
 	gunzip <Net-SSLeay.pm-1.35.tar.gz | tar xvf -
 	cd Net-SSLeay.pm-1.35
-	perl Makefile.PL     # builds and tests it
+	perl Makefile.PL     # Build it. Use OPENSSL_PREFIX, if needed.
 	make test            # Run the test suite
 	make install         # You probably have to su to root to do this
-
-	If your OpenSSL is installed in an unusual place, you can tell
-	Net-SSLeay where to find it with the OPENSSL_PREFIX environment
-	variable:
-	OPENSSL_PREFIX=/home/mikem/playpen/openssl-1.0.2c perl Makefile.PL
-	....
 
 HPUX:
 	In principle the Unix build should work (Makefile.PL contains
@@ -94,12 +99,12 @@ HPUX:
 
 	Configuring OpenSSL:
 
-		./Configure no-asm --prefix=/openssl/path hpux-parisc2-cc
+	./Configure no-asm --prefix=/openssl/path hpux-parisc2-cc
 
 	Configuring Net::SSLeay:
-	
-		OPENSSL_PREFIX=/openssl/path perl Makefile.PL CCFLAGS='-D_HPUX_SOURCE \
-		 -Aa -I/usr/local/include +e'
+
+	OPENSSL_PREFIX=/openssl/path perl Makefile.PL CCFLAGS='-D_HPUX_SOURCE \
+	 -Aa -I/usr/local/include +e'
 
 	The magic bit seemed to be the `+e' flag. Since version 1.14
 	Makefile.PL tries to figure this out.
@@ -110,9 +115,9 @@ Windows:
 	Supported on 32 and 64 bit platforms
 	See README.Win32 for details
 
-OS X:
+macOS, also known as OS X:
 	See README.OSX
----------------------------------	
+---------------------------------
 You should also be able to use CPAN.pm to install this module if you like.
 
 Problems (read this before filing a bug)

--- a/README
+++ b/README
@@ -60,6 +60,16 @@ it may be easier to use the same compiler and compiler options.
 Installing
 ----------
 
+General:
+If your OpenSSL is installed in an unusual place, you can tell
+	Net-SSLeay where to find it with by setting the OPENSSL_PREFIX environment
+	variable. Example:
+
+  export OPENSSL_PREFIX=/my/non-standard/path/usr
+
+The logic in Makefile.PL appends include/openssl to the environment 
+variable OPENSSL_PREFIX.
+
 Unix:
 	# build or install OpenSSL as per instructions in that package
 

--- a/README.OSX
+++ b/README.OSX
@@ -1,8 +1,9 @@
-As of 15 Jun 2015, Apply no longer ships OpenSSL with OS X:
+As of 15 Jun 2015, Apple no longer ships OpenSSL with OS X:
 (http://lists.apple.com/archives/macnetworkprog/2015/Jun/msg00025.html)
 
-Some OS X packages and bundles install OpenSSL, typically in /opt/local
-if that is the case it is sufficient for you to unpack and build
+Some OS X packages and bundles install OpenSSL to locations known by
+Makefile.PL, for example, /opt/homebrew, /usr/local or /opt/local.
+If that is the case it is sufficient for you to unpack and build
 Net-SSLeay in the usual way:
 
 #cd to a working directory
@@ -11,6 +12,7 @@ cd /Users/mikem/tmp/
 tar zxvf /Volumes/projects/net-ssleay/trunk/Net-SSLeay-1.72.tar.gz
 cd Net-SSLeay-1.72
 # Build it for 64 bits (default)
+# Use OPENSSL_PREFIX, see README, if needed
 perl Makefile.PL
 make
 make test
@@ -20,6 +22,13 @@ make install
 If a working openssl is not installed already the above will fail, 
 but you can still build your own OpenSSL to link against:
 (https://wiki.openssl.org/index.php/Compilation_and_Installation), and build Net-SSLeay against it:
+
+
+
+Here are some older instructions. The current, year 2024, OpenSSL and
+LibreSSL versions come with installation instructions that you should
+primarily follow. Then install Net::SSLeay as shown above.
+
 Test compilation etc in a private directory eg:
 
 #cd to a working directory

--- a/README.Win32
+++ b/README.Win32
@@ -40,6 +40,34 @@ perl Makefile.PL
 make
 .....
 
+0. Windows 11 version 23H2
+   Visual Studio Community 2022
+   64bit and 32bit Perl 5.38.2 compiled with Visual Studio Community 2022
+   Shining Light 64bit and 32bit OpenSSL 1.1.1w, 3.0.12, 3.1.4 and 3.2.0
+
+Compile 64bit or 32bit Perl.
+Install 64bit or 32bit Shining LightOpenSSL package.
+Change to Net-SSLeay directory and do the following:
+ perl Makefile.PL
+ nmake
+ nmake test
+ nmake install
+
+Caution: Static linking seem to require updating library names to use
+_static suffix with the aforementioned Shining Light OpenSSL
+versions. Run the following command after nmake to see which
+libraries and symbols are required to be dynamically loaded:
+  dumpbin /imports blib\arch\auto\Net\SSLeay\SSLeay.dll
+
+Library names and locations for static linking seem to vary between
+installation methods (local compilation, Shinging Light, other OpenSSL
+installers). Therefore Makefile.PL may not be able to keep up with all
+the possibilities.
+
+Caution: When both 32bit and 64bit Shining Light (and possibly other)
+OpenSSL package versions are installed, Makefile.PL may pick a wrong
+location. Use OPENSSL_PREFIX environment variable in case of problems.
+
 1. Windows Server 2003
    ActivePerl 5.8.8.820
    VC++ 6.0

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -132,7 +132,10 @@
  */
 
 /* Prevent warnings about strncpy from Windows compilers */
-#define _CRT_SECURE_NO_DEPRECATE
+
+#ifndef _CRT_SECURE_NO_DEPRECATE
+#  define _CRT_SECURE_NO_DEPRECATE
+#endif
 
 /* Silence compound-token-split-by-macro warnings from perl.h when building for
  * Perl < 5.35.2 with Clang >= 12 - see GH-383

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -3209,9 +3209,10 @@ SSL_verify_client_post_handshake(SSL *ssl)
 void
 i2d_SSL_SESSION(sess)
 	SSL_SESSION * sess
-    PPCODE:
+    PREINIT:
 	STRLEN len;
 	unsigned char *pc,*pi;
+    PPCODE:
 	if (!(len = i2d_SSL_SESSION(sess,NULL))) croak("invalid SSL_SESSION");
 	Newx(pc,len,unsigned char);
 	if (!pc) croak("out of memory");
@@ -4479,12 +4480,13 @@ X509_get_fingerprint(cert,type)
 void
 X509_get_subjectAltNames(cert)
 	X509 *      cert
-	PPCODE:
+	PREINIT:
 	int                    i, j, count = 0;
 	X509_EXTENSION         *subjAltNameExt = NULL;
 	STACK_OF(GENERAL_NAME) *subjAltNameDNs = NULL;
 	GENERAL_NAME           *subjAltNameDN  = NULL;
 	int                    num_gnames;
+	PPCODE:
 	if (  (i = X509_get_ext_by_NID(cert, NID_subject_alt_name, -1)) >= 0
 		&& (subjAltNameExt = X509_get_ext(cert, i))
 		&& (subjAltNameDNs = (STACK_OF(GENERAL_NAME) *)X509V3_EXT_d2i(subjAltNameExt)))
@@ -4615,9 +4617,10 @@ P_X509_get_crl_distribution_points(cert)
 void
 P_X509_get_ocsp_uri(cert)
 	X509 * cert
-    PPCODE:
+	PREINIT:
 	AUTHORITY_INFO_ACCESS *info;
 	int i;
+    PPCODE:
 	info = (AUTHORITY_INFO_ACCESS *)X509_get_ext_d2i(cert, NID_info_access, NULL, NULL);
 	if (!info) XSRETURN_UNDEF;
 
@@ -6620,11 +6623,11 @@ EVP_PKEY_assign_EC_KEY(pkey,key)
 EC_KEY *
 EC_KEY_generate_key(curve)
 	SV *curve;
-    CODE:
+	PREINIT:
 	EC_GROUP *group = NULL;
 	EC_KEY *eckey = NULL;
 	int nid;
-
+    CODE:
 	RETVAL = 0;
 	if (SvIOK(curve)) {
 	    nid = SvIV(curve);
@@ -7237,13 +7240,16 @@ SSL_get_server_random(s)
 int
 SSL_get_keyblock_size(s)
      SSL *   s
-     CODE:
+     PREINIT:
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x2070000fL)
         const SSL_CIPHER *ssl_cipher;
 	int cipher = NID_undef, digest = NID_undef, mac_secret_size = 0;
 	const EVP_CIPHER *c = NULL;
 	const EVP_MD *h = NULL;
+#endif
 
+     CODE:
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x2070000fL)
 	ssl_cipher = SSL_get_current_cipher(s);
 	if (ssl_cipher)
 	    cipher = SSL_CIPHER_get_cipher_nid(ssl_cipher);
@@ -7984,10 +7990,11 @@ P_X509_get_pubkey_alg(x)
 void
 X509_get_X509_PUBKEY(x)
    const X509 *x
-   PPCODE:
+   PREINIT:
    X509_PUBKEY *pkey;
    STRLEN len;
    unsigned char *pc, *pi;
+   PPCODE:
    if (!(pkey = X509_get_X509_PUBKEY(x))) croak("invalid certificate");
    if (!(len = i2d_X509_PUBKEY(pkey, NULL))) croak("invalid certificate public key");
    Newx(pc,len,unsigned char);
@@ -8187,9 +8194,10 @@ d2i_OCSP_RESPONSE(pv)
 void
 i2d_OCSP_RESPONSE(r)
 	OCSP_RESPONSE * r
-    PPCODE:
+	PREINIT:
 	STRLEN len;
 	unsigned char *pc,*pi;
+    PPCODE:
 	if (!(len = i2d_OCSP_RESPONSE(r,NULL))) croak("invalid OCSP response");
 	Newx(pc,len,unsigned char);
 	if (!pc) croak("out of memory");
@@ -8220,9 +8228,10 @@ d2i_OCSP_REQUEST(pv)
 void
 i2d_OCSP_REQUEST(r)
 	OCSP_REQUEST * r
-    PPCODE:
+	PREINIT:
 	STRLEN len;
 	unsigned char *pc,*pi;
+    PPCODE:
 	if (!(len = i2d_OCSP_REQUEST(r,NULL))) croak("invalid OCSP request");
 	Newx(pc,len,unsigned char);
 	if (!pc) croak("out of memory");
@@ -8246,7 +8255,7 @@ OCSP_response_status(OCSP_RESPONSE *r)
 void
 SSL_OCSP_cert2ids(ssl,...)
 	SSL *ssl
-    PPCODE:
+PREINIT:
 	SSL_CTX *ctx;
 	X509_STORE *store;
 	STACK_OF(X509) *chain;
@@ -8255,6 +8264,7 @@ SSL_OCSP_cert2ids(ssl,...)
 	int i;
 	STRLEN len;
 	unsigned char *pi;
+    PPCODE:
 
 	if (!ssl) croak("not a SSL object");
 	ctx = SSL_get_SSL_CTX(ssl);
@@ -8285,10 +8295,11 @@ SSL_OCSP_cert2ids(ssl,...)
 
 OCSP_REQUEST *
 OCSP_ids2req(...)
-    CODE:
+	PREINIT:
 	OCSP_REQUEST *req;
 	OCSP_CERTID *id;
 	int i;
+    CODE:
 
 	req = OCSP_REQUEST_new();
 	if (!req) croak("out of memory");
@@ -8380,12 +8391,13 @@ SSL_OCSP_response_verify(ssl,rsp,svreq=NULL,flags=0)
 void
 OCSP_response_results(rsp,...)
 	OCSP_RESPONSE *rsp
-    PPCODE:
+    PREINIT:
 	OCSP_BASICRESP *bsr;
 	int i,want_array;
 	time_t nextupd = 0;
 	time_t gmtoff = -1;
 	int getall,sksn;
+    PPCODE:
 
 	bsr = OCSP_response_get1_basic(rsp);
 	if (!bsr) croak("invalid OCSP response");

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -2997,8 +2997,9 @@ SSL_has_pending(s)
 #ifdef NET_SSLEAY_32BIT_INT_PERL
 int
 OPENSSL_init_ssl(double opts, SV *sv_settings = &PL_sv_undef)
-    CODE:
+    PREINIT:
 	const OPENSSL_INIT_SETTINGS *settings = NULL;
+    CODE:
 	if (sv_settings != &PL_sv_undef)
 	    settings = INT2PTR(OPENSSL_INIT_SETTINGS *, SvIV(sv_settings));
 	RETVAL = OPENSSL_init_ssl(opts, settings);
@@ -3007,8 +3008,9 @@ OPENSSL_init_ssl(double opts, SV *sv_settings = &PL_sv_undef)
 
 int
 OPENSSL_init_crypto(double opts, SV *sv_settings = &PL_sv_undef)
-    CODE:
+    PREINIT:
 	const OPENSSL_INIT_SETTINGS *settings = NULL;
+    CODE:
 	if (sv_settings != &PL_sv_undef)
 	    settings = INT2PTR(OPENSSL_INIT_SETTINGS *, SvIV(sv_settings));
 	RETVAL = OPENSSL_init_crypto(opts, settings);
@@ -3018,8 +3020,9 @@ OPENSSL_init_crypto(double opts, SV *sv_settings = &PL_sv_undef)
 #else
 int
 OPENSSL_init_ssl(uint64_t opts, SV *sv_settings = &PL_sv_undef)
-    CODE:
+    PREINIT:
 	const OPENSSL_INIT_SETTINGS *settings = NULL;
+    CODE:
 	if (sv_settings != &PL_sv_undef)
 	    settings = INT2PTR(OPENSSL_INIT_SETTINGS *, SvIV(sv_settings));
 	RETVAL = OPENSSL_init_ssl(opts, settings);
@@ -3028,8 +3031,9 @@ OPENSSL_init_ssl(uint64_t opts, SV *sv_settings = &PL_sv_undef)
 
 int
 OPENSSL_init_crypto(uint64_t opts, SV *sv_settings = &PL_sv_undef)
-    CODE:
+    PREINIT:
 	const OPENSSL_INIT_SETTINGS *settings = NULL;
+    CODE:
 	if (sv_settings != &PL_sv_undef)
 	    settings = INT2PTR(OPENSSL_INIT_SETTINGS *, SvIV(sv_settings));
 	RETVAL = OPENSSL_init_crypto(opts, settings);
@@ -8656,8 +8660,9 @@ OSSL_LIB_CTX_get0_global_default()
 
 OSSL_PROVIDER *
 OSSL_PROVIDER_load(SV *libctx, const char *name)
-    CODE:
+    PREINIT:
         OSSL_LIB_CTX *ctx = NULL;
+    CODE:
         if (libctx != &PL_sv_undef)
 	    ctx = INT2PTR(OSSL_LIB_CTX *, SvIV(libctx));
         RETVAL = OSSL_PROVIDER_load(ctx, name);
@@ -8668,8 +8673,9 @@ OSSL_PROVIDER_load(SV *libctx, const char *name)
 
 OSSL_PROVIDER *
 OSSL_PROVIDER_try_load(SV *libctx, const char *name, int retain_fallbacks)
-    CODE:
+    PREINIT:
         OSSL_LIB_CTX *ctx = NULL;
+    CODE:
         if (libctx != &PL_sv_undef)
 	    ctx = INT2PTR(OSSL_LIB_CTX *, SvIV(libctx));
         RETVAL = OSSL_PROVIDER_try_load(ctx, name, retain_fallbacks);
@@ -8683,8 +8689,9 @@ OSSL_PROVIDER_unload(OSSL_PROVIDER *prov)
 
 int
 OSSL_PROVIDER_available(SV *libctx, const char *name)
-    CODE:
+    PREINIT:
         OSSL_LIB_CTX *ctx = NULL;
+    CODE:
         if (libctx != &PL_sv_undef)
 	    ctx = INT2PTR(OSSL_LIB_CTX *, SvIV(libctx));
         RETVAL = OSSL_PROVIDER_available(ctx, name);
@@ -8695,8 +8702,8 @@ int
 OSSL_PROVIDER_do_all(SV *libctx, SV *perl_cb, SV *perl_cbdata = &PL_sv_undef)
     PREINIT:
         simple_cb_data_t* cbdata = NULL;
-    CODE:
         OSSL_LIB_CTX *ctx = NULL;
+    CODE:
         if (libctx != &PL_sv_undef)
 	    ctx = INT2PTR(OSSL_LIB_CTX *, SvIV(libctx));
 


### PR DESCRIPTION
Cherry-pick and update commits from pull request #188 by [bulk88](https://github.com/bulk88). All changes in #188 should now be addressed. Also cherry-pick installation instruction fixes to README in pull request #444 by [viviparous](https://github.com/viviparous). Fix and model some of the code in `SSLeay.xs` added after PR #188 to match corrections in the pull request.

Net::SSLeay now compiles against Shining Light OpenSSL 1.1.1w, 3.0.12, 3.1.4 and 3.2.0 packages. `Makefile.PL` now includes the OpenSSL installation paths these  packages use.

Closes #188, closes #444 and closes #454