### PR TITLE
GH-458 Use OPENSSL_API_COMPAT with Makefile.PL and expose more LibreSSL functions

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,17 @@
 Revision history for Perl extension Net::SSLeay.
 
+????
+	- Use -DOPENSSL_API_COMPAT=908 when compiling SSLeay.xs to
+	  suppress OpenSSL deprecation warnings.
+	- Expose a number of functions that were added in recent
+	  LibreSSL releases or were not otherwise exposed before:
+	  - SSL(_CTX)_get/set_security_level in LibreSSL 3.6.0
+	  - SSL(_CTX)_get/set_num_tickets in LibreSSL 3.5.0
+	  - SSL(_CTX)_set_ciphersuites in LibreSSL 3.4.0
+	  - EVP_PKEY_security_bits in LibreSSL 3.6.0
+	  - SSL_CTX_set_keylog_callback in LibreSSL 3.5.0
+	  - SSL_is_dtls in LibreSSL 3.3.2
+
 1.93_03 2024-01-02
 	- Pass RAND_seed()'s sole argument to the underlying RAND_seed() function in
 	  libcrypto, rather than passing the value of a non-existent second argument.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -120,6 +120,10 @@ $eumm_args{CCFLAGS} = $Config{ccflags};
 # macros are available).
 add_ccflag( $eumm_args{CCFLAGS}, "-DNET_SSLEAY_PERL_VERSION=" . $] * 1e6 );
 
+# Suppress deprecation warnings during compilation.
+# https://www.openssl.org/docs/manmaster/man7/openssl_user_macros.html
+add_ccflag( $eumm_args{CCFLAGS}, '-DOPENSSL_API_COMPAT=908' );
+
 # See if integers are only 32 bits long. If they are, add a flag to
 # CCFLAGS. Since OpenSSL 1.1.0, a growing number of APIs are using 64
 # bit integers. This causes a problem if Perl is compiled without 64

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -2080,7 +2080,7 @@ int ossl_provider_do_all_cb_invoke(OSSL_PROVIDER *provider, void *cbdata) {
 }
 #endif
 
-#if OPENSSL_VERSION_NUMBER >= 0x10101001 && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10101001 && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x3050000fL)
 void ssl_ctx_keylog_cb_func_invoke(const SSL *ssl, const char *line)
 {
     dSP;
@@ -2538,7 +2538,7 @@ SSL_CTX_set_verify(ctx,mode,callback=&PL_sv_undef)
         SSL_CTX_set_verify(ctx, mode, &ssleay_verify_callback_invoke);
     }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100001L && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100001L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x3060000fL)
 
 void
 SSL_CTX_set_security_level(SSL_CTX * ctx, int level)
@@ -2548,7 +2548,7 @@ SSL_CTX_get_security_level(SSL_CTX * ctx)
 
 #endif
 
-#if OPENSSL_VERSION_NUMBER >= 0x10101007L && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10101007L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x3050000fL)
 
 int
 SSL_CTX_set_num_tickets(SSL_CTX *ctx, size_t num_tickets)
@@ -2558,7 +2558,7 @@ SSL_CTX_get_num_tickets(SSL_CTX *ctx)
 
 #endif
 
-#if OPENSSL_VERSION_NUMBER >= 0x10101003L && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10101003L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x3040000fL)
 
 int
 SSL_CTX_set_ciphersuites(SSL_CTX *ctx, const char *str)
@@ -3557,7 +3557,7 @@ SSL_set_default_passwd_cb_userdata(ssl,data=&PL_sv_undef)
 #endif /* !LibreSSL */
 #endif /* >= 1.1.0f */
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100001L && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100001L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x3060000fL)
 
 void
 SSL_set_security_level(SSL * ssl, int level)
@@ -3567,7 +3567,7 @@ SSL_get_security_level(SSL * ssl)
 
 #endif
 
-#if OPENSSL_VERSION_NUMBER >= 0x10101007L && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10101007L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x3050000fL)
 
 int
 SSL_set_num_tickets(SSL *ssl, size_t num_tickets)
@@ -3577,7 +3577,7 @@ SSL_get_num_tickets(SSL *ssl)
 
 #endif
 
-#if OPENSSL_VERSION_NUMBER >= 0x10101003L && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10101003L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x3040000fL)
 
 int
 SSL_set_ciphersuites(SSL *ssl, const char *str)
@@ -5176,7 +5176,7 @@ EVP_PKEY_assign_RSA(EVP_PKEY *pkey, RSA *key)
 int
 EVP_PKEY_bits(EVP_PKEY *pkey)
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x3060000fL)
 
 int
 EVP_PKEY_security_bits(EVP_PKEY *pkey)
@@ -5960,7 +5960,7 @@ SSL_CTX_use_certificate_chain_file(ctx,file)
      const char * file
 
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x3030200fL) /* OpenSSL 1.1.0-pre1 or LibreSSL 3.3.2 */
 
 int
 SSL_use_certificate_chain_file(ssl,file)
@@ -6207,7 +6207,7 @@ SSL_CTX_set_msg_callback(ctx,callback,data=&PL_sv_undef)
         }
 
 
-#if OPENSSL_VERSION_NUMBER >= 0x10101001 && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10101001 && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x3050000fL)
 
 void
 SSL_CTX_set_keylog_callback(SSL_CTX *ctx, SV *callback)
@@ -6405,6 +6405,9 @@ SSL_version(ssl)
 int
 SSL_client_version(ssl)
      const SSL * ssl
+
+#endif
+#if (OPENSSL_VERSION_NUMBER >= 0x10100006L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x3030200fL)  /* 1.1.0-pre6 or LibreSSL 3.3.2 */
 
 int
 SSL_is_dtls(ssl)

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -1782,7 +1782,7 @@ Returns the size of the key $pkey in bits.
 
 =item * EVP_PKEY_security_bits
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.92 and before
+B<COMPATIBILITY:> not available in Net-SSLeay-1.92 and before; requires at least OpenSSL 1.1.0 or at least LibreSSL 3.6.0 and Net-SSLeay-1.94
 
 Returns the size of the key $pkey in bits.
 
@@ -3316,7 +3316,7 @@ Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_ciph
 
 =item * CTX_set_ciphersuites
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.1, not in LibreSSL
+B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.1 or at least LibreSSL 3.4.0 and Net-SSLeay-1.94
 
 Configure the available TLSv1.3 ciphersuites.
 
@@ -3663,7 +3663,7 @@ Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_CTX_use_cert
 
 =item * CTX_get_security_level
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.0, not in LibreSSL
+B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.0 or at least LibreSSL 3.6.0 and Net-SSLeay-1.94
 
 Returns the security level associated with $ctx.
 
@@ -3676,7 +3676,7 @@ Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_CTX_get_secu
 
 =item * CTX_set_security_level
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.0, not in LibreSSL
+B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.0 or at least LibreSSL 3.6.0 and Net-SSLeay-1.94
 
 Sets the security level associated with $ctx to $level.
 
@@ -3690,7 +3690,7 @@ Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_secu
 
 =item * CTX_set_num_tickets
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.1, not in LibreSSL
+B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.1 or at least LibreSSL 3.5.0 and Net-SSLeay-1.94
 
 Set number of TLSv1.3 session tickets that will be sent to a client.
 
@@ -3706,7 +3706,7 @@ Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_num_
 
 =item * CTX_get_num_tickets
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.1, not in LibreSSL
+B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.1 or at least LibreSSL 3.5.0 and Net-SSLeay-1.94
 
 Get number of TLSv1.3 session tickets that will be sent to a client.
 
@@ -3719,7 +3719,7 @@ Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_CTX_get_num_
 
 =item * CTX_set_keylog_callback
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.90 and before; requires at least OpenSSL 1.1.1pre1, not in LibreSSL
+B<COMPATIBILITY:> not available in Net-SSLeay-1.90 and before; requires at least OpenSSL 1.1.1pre1 or at least LibreSSL 3.5.0 and Net-SSLeay-1.94
 
 Set the TLS key logging callback.
 
@@ -3739,7 +3739,7 @@ Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_keyl
 
 =item * CTX_get_keylog_callback
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.90 and before; requires at least OpenSSL 1.1.1pre1, not in LibreSSL
+B<COMPATIBILITY:> not available in Net-SSLeay-1.90 and before; requires at least OpenSSL 1.1.1pre1 or at least LibreSSL 3.5.0 and Net-SSLeay-1.94
 
 Retrieve the previously set TLS key logging callback.
 
@@ -4330,7 +4330,7 @@ Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_get_rbio.htm
 
 =item * get_security_level
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.0, not in LibreSSL
+B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.0 or at least LibreSSL 3.6.0 and Net-SSLeay-1.94
 
 Returns the security level associated with $ssl.
 
@@ -4343,7 +4343,7 @@ Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_get_security
 
 =item * set_security_level
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.0, not in LibreSSL
+B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.0 or at least LibreSSL 3.6.0 and Net-SSLeay-1.94
 
 Sets the security level associated with $ssl to $level.
 
@@ -4357,7 +4357,7 @@ Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_set_security
 
 =item * set_num_tickets
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.1, not in LibreSSL
+B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.1 or at least LibreSSL 3.5.0 and Net-SSLeay-1.94
 
 Set number of TLSv1.3 session tickets that will be sent to a client.
 
@@ -4373,7 +4373,7 @@ Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_set_num_tick
 
 =item * get_num_tickets
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.1, not in LibreSSL
+B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.1 or at least LibreSSL 3.5.0 and Net-SSLeay-1.94
 
 Get number of TLSv1.3 session tickets that will be sent to a client.
 
@@ -4902,7 +4902,7 @@ Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_ciph
 
 =item * set_ciphersuites
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.1, not in LibreSSL
+B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.1 or at least LibreSSL 3.4.0 and Net-SSLeay-1.94
 
 Configure the available TLSv1.3 ciphersuites.
 
@@ -5513,7 +5513,7 @@ Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_CTX_use_cert
 
 =item * use_certificate_chain_file
 
-B<COMPATIBILITY>: not available in Net-SSLeay-1.82 and before; requires at least OpenSSL 1.1.0
+B<COMPATIBILITY>: not available in Net-SSLeay-1.82 and before; requires at least OpenSSL 1.1.0 or at least LibreSSL 3.6.0 and Net-SSLeay-1.94
 
 Loads a certificate chain from $file into $ssl. The certificates must be in PEM format and must be sorted
 starting with the subject's certificate (actual client or server certificate), followed by intermediate
@@ -5583,7 +5583,7 @@ Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_client_versi
 
 =item * is_dtls
 
-B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.0, not in LibreSSL
+B<COMPATIBILITY:> not available in Net-SSLeay-1.85 and before; requires at least OpenSSL 1.1.0 or at least LibreSSL 3.3.1 and Net-SSLeay-1.94
 
     my $rv = Net::SSLeay::is_dtls($ssl);
     # $ssl - value corresponding to openssl's SSL structure

--- a/t/local/43_misc_functions.t
+++ b/t/local/43_misc_functions.t
@@ -245,11 +245,18 @@ sub client_test_version_funcs
 	} else {
 	    is(Net::SSLeay::client_version($ssl), $version, 'Net::SSLeay::client_version equals to Net::SSLeay::version');
 	}
-	is(Net::SSLeay::is_dtls($ssl), 0, 'Net::SSLeay::is_dtls returns 0');
     } else
     {
       SKIP: {
-	  skip('Do not have Net::SSLeay::client_version nor Net::SSLeay::is_dtls', 2);
+	  skip('Do not have Net::SSLeay::client_version', 1);
+	};
+    }
+
+    if (defined &Net::SSLeay::is_dtls) {
+	is(Net::SSLeay::is_dtls($ssl), 0, 'Net::SSLeay::is_dtls returns 0');
+    } else {
+      SKIP: {
+	  skip('Do not have Net::SSLeay::is_dtls', 1);
 	};
     }
 

--- a/t/local/65_security_level.t
+++ b/t/local/65_security_level.t
@@ -3,12 +3,10 @@ use lib 'inc';
 use Net::SSLeay;
 use Test::Net::SSLeay qw(initialise_libssl);
 
-if (Net::SSLeay::SSLeay < 0x10100001) {
-    plan skip_all => 'OpenSSL 1.1.0 required';
-} elsif (Net::SSLeay::constant("LIBRESSL_VERSION_NUMBER")) {
-    plan skip_all => 'get/set_security_level not available with LibreSSL';
-} else {
+if (defined &Net::SSLeay::CTX_get_security_level) {
     plan tests => 20;
+} else {
+    plan skip_all => 'OpenSSL 1.1.0 or LibreSSL 3.6.0 required for get/set_security_level';
 }
 
 initialise_libssl();


### PR DESCRIPTION
See GH-458 for the related issue. WIth [OPENSSL_API_COMPAT](https://www.openssl.org/docs/manmaster/man7/openssl_user_macros.html) defined during the compile, it's now easier to see real warnings and less confusing for those who compile `Net::SSLeay` themselves.
 
Closes #458 