### PR TITLE
Mark Tuure as an inactive contributor

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -42,8 +42,8 @@ my %eumm_args = (
     'Sampo Kellomaki <sampo@iki.fi>',
     'Florian Ragwitz <rafl@debian.org>',
     'Mike McCauley <mikem@airspayce.com>',
-    'Chris Novakovic <chris@chrisn.me.uk>',
     'Tuure Vartiainen <vartiait@radiatorsoftware.com>',
+    'Chris Novakovic <chris@chrisn.me.uk>',
     'Heikki Vatiainen <hvn@radiatorsoftware.com>'
   ],
   VERSION_FROM => 'lib/Net/SSLeay.pm',

--- a/README
+++ b/README
@@ -288,8 +288,8 @@ Copyright
 Copyright (c) 1996-2003 Sampo Kellomäki <sampo@iki.fi>
 Copyright (c) 2005-2010 Florian Ragwitz <rafl@debian.org>
 Copyright (c) 2005-2018 Mike McCauley <mikem@airspayce.com>
+Copyright (c) 2018 Tuure Vartiainen <vartiait@radiatorsoftware.com>
 Copyright (c) 2018- Chris Novakovic <chris@chrisn.me.uk>
-Copyright (c) 2018- Tuure Vartiainen <vartiait@radiatorsoftware.com>
 Copyright (c) 2018- Heikki Vatiainen <hvn@radiatorsoftware.com>
 
 All rights reserved.

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -3,8 +3,8 @@
  * Copyright (c) 1996-2003 Sampo Kellomäki <sampo@iki.fi>
  * Copyright (c) 2005-2010 Florian Ragwitz <rafl@debian.org>
  * Copyright (c) 2005-2018 Mike McCauley <mikem@airspayce.com>
+ * Copyright (c) 2018 Tuure Vartiainen <vartiait@radiatorsoftware.com>
  * Copyright (c) 2018- Chris Novakovic <chris@chrisn.me.uk>
- * Copyright (c) 2018- Tuure Vartiainen <vartiait@radiatorsoftware.com>
  * Copyright (c) 2018- Heikki Vatiainen <hvn@radiatorsoftware.com>
  * 
  * All rights reserved.

--- a/helper_script/generate-test-pki
+++ b/helper_script/generate-test-pki
@@ -1995,13 +1995,11 @@ the version of OpenSSL you are using.
 
 Originally written by Chris Novakovic.
 
-Maintained by Chris Novakovic, Tuure Vartiainen and Heikki Vatiainen.
+Maintained by Chris Novakovic and Heikki Vatiainen.
 
 =head1 COPYRIGHT AND LICENSE
 
 Copyright 2020- Chris Novakovic <chris@chrisn.me.uk>.
-
-Copyright 2020- Tuure Vartiainen <vartiait@radiatorsoftware.com>.
 
 Copyright 2020- Heikki Vatiainen <hvn@radiatorsoftware.com>.
 

--- a/helper_script/update-exported-constants
+++ b/helper_script/update-exported-constants
@@ -724,13 +724,11 @@ the version of Net-SSLeay you are using.
 
 Originally written by Chris Novakovic.
 
-Maintained by Chris Novakovic, Tuure Vartiainen and Heikki Vatiainen.
+Maintained by Chris Novakovic and Heikki Vatiainen.
 
 =head1 COPYRIGHT AND LICENSE
 
 Copyright 2021- Chris Novakovic <chris@chrisn.me.uk>.
-
-Copyright 2021- Tuure Vartiainen <vartiait@radiatorsoftware.com>.
 
 Copyright 2021- Heikki Vatiainen <hvn@radiatorsoftware.com>.
 

--- a/inc/Test/Net/SSLeay.pm
+++ b/inc/Test/Net/SSLeay.pm
@@ -851,13 +851,11 @@ the version of OpenSSL or LibreSSL you are using.
 
 Originally written by Chris Novakovic.
 
-Maintained by Chris Novakovic, Tuure Vartiainen and Heikki Vatiainen.
+Maintained by Chris Novakovic and Heikki Vatiainen.
 
 =head1 COPYRIGHT AND LICENSE
 
 Copyright 2020- Chris Novakovic <chris@chrisn.me.uk>.
-
-Copyright 2020- Tuure Vartiainen <vartiait@radiatorsoftware.com>.
 
 Copyright 2020- Heikki Vatiainen <hvn@radiatorsoftware.com>.
 

--- a/inc/Test/Net/SSLeay/Socket.pm
+++ b/inc/Test/Net/SSLeay/Socket.pm
@@ -310,13 +310,11 @@ the version of OpenSSL or LibreSSL you are using.
 
 Originally written by Chris Novakovic.
 
-Maintained by Chris Novakovic, Tuure Vartiainen and Heikki Vatiainen.
+Maintained by Chris Novakovic and Heikki Vatiainen.
 
 =head1 COPYRIGHT AND LICENSE
 
 Copyright 2020- Chris Novakovic <chris@chrisn.me.uk>.
-
-Copyright 2020- Tuure Vartiainen <vartiait@radiatorsoftware.com>.
 
 Copyright 2020- Heikki Vatiainen <hvn@radiatorsoftware.com>.
 

--- a/lib/Net/SSLeay.pm
+++ b/lib/Net/SSLeay.pm
@@ -3,8 +3,8 @@
 # Copyright (c) 1996-2003 Sampo Kellomäki <sampo@iki.fi>
 # Copyright (c) 2005-2010 Florian Ragwitz <rafl@debian.org>
 # Copyright (c) 2005-2018 Mike McCauley <mikem@airspayce.com>
+# Copyright (c) 2018 Tuure Vartiainen <vartiait@radiatorsoftware.com>
 # Copyright (c) 2018- Chris Novakovic <chris@chrisn.me.uk>
-# Copyright (c) 2018- Tuure Vartiainen <vartiait@radiatorsoftware.com>
 # Copyright (c) 2018- Heikki Vatiainen <hvn@radiatorsoftware.com>
 #
 # All rights reserved.

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -11240,7 +11240,9 @@ Maintained by Florian Ragwitz between November 2005 and January 2010.
 
 Maintained by Mike McCauley between November 2005 and June 2018.
 
-Maintained by Chris Novakovic, Tuure Vartiainen and Heikki Vatiainen since June 2018.
+Maintained by Tuure Vartiainen between June 2018 and July 2018.
+
+Maintained by Chris Novakovic and Heikki Vatiainen since June 2018.
 
 =head1 COPYRIGHT
 
@@ -11250,9 +11252,9 @@ Copyright (c) 2005-2010 Florian Ragwitz <rafl@debian.org>
 
 Copyright (c) 2005-2018 Mike McCauley <mikem@airspayce.com>
 
-Copyright (c) 2018- Chris Novakovic <chris@chrisn.me.uk>
+Copyright (c) 2018 Tuure Vartiainen <vartiait@radiatorsoftware.com>
 
-Copyright (c) 2018- Tuure Vartiainen <vartiait@radiatorsoftware.com>
+Copyright (c) 2018- Chris Novakovic <chris@chrisn.me.uk>
 
 Copyright (c) 2018- Heikki Vatiainen <hvn@radiatorsoftware.com>
 

--- a/lib/Net/SSLeay/Handle.pm
+++ b/lib/Net/SSLeay/Handle.pm
@@ -377,7 +377,9 @@ Maintained by Florian Ragwitz between November 2005 and January 2010.
 
 Maintained by Mike McCauley between November 2005 and June 2018.
 
-Maintained by Chris Novakovic, Tuure Vartiainen and Heikki Vatiainen since June 2018.
+Maintained by Tuure Vartiainen between June 2018 and July 2018.
+
+Maintained by Chris Novakovic and Heikki Vatiainen since June 2018.
 
 =head1 COPYRIGHT
 
@@ -389,9 +391,9 @@ Copyright (c) 2005-2010 Florian Ragwitz <rafl@debian.org>
 
 Copyright (c) 2005-2018 Mike McCauley <mikem@airspayce.com>
 
-Copyright (c) 2018- Chris Novakovic <chris@chrisn.me.uk>
+Copyright (c) 2018 Tuure Vartiainen <vartiait@radiatorsoftware.com>
 
-Copyright (c) 2018- Tuure Vartiainen <vartiait@radiatorsoftware.com>
+Copyright (c) 2018- Chris Novakovic <chris@chrisn.me.uk>
 
 Copyright (c) 2018- Heikki Vatiainen <hvn@radiatorsoftware.com>
 


### PR DESCRIPTION
Tuure's last contribution was the configuration for Travis and AppVeyor, in 2018. Update the maintainership notices and copyright dates in each module/script to reflect this.