### PR TITLE
Don't automatically detect libssl/libcrypto with ExtUtils::PkgConfig

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,17 @@
 Revision history for Perl extension Net::SSLeay.
 
-1.94_04 2024-01-05
+????
+	- Remove support for automatic detection of libssl/libcrypto via pkg-config
+	  with ExtUtils::PkgConfig if it is installed, due to the compiler and linker
+	  options provided by pkg-config being used unconditionally (which is
+	  incompatible with the OPENSSL_PREFIX detection method). The implementation of
+	  this was merged in time for developer release 1.93_03 and therefore hasn't
+	  been included in a stable release yet, so this doesn't represent a breaking
+	  change to the way in which libssl/libcrypto are detected by Makefile.PL. This
+	  is, however, a very useful feature, and we intend to bring it back in time
+	  for Net-SSLeay 1.96 after ironing out the remaining bugs.
+
+1.93_04 2024-01-05
 	- Use -DOPENSSL_API_COMPAT=908 when compiling SSLeay.xs to
 	  suppress OpenSSL deprecation warnings.
 	- Expose a number of functions that were added in recent

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -319,12 +319,7 @@ EOM
         @{ $opts->{lib_links} } = map { $_ =~ s/32\b//g } @{ $opts->{lib_links} } if $Config{use64bitall};
     }
     else {
-        if ( eval { require ExtUtils::PkgConfig; ExtUtils::PkgConfig->VERSION('1.16') } && ExtUtils::PkgConfig->exists('openssl') ) {
-            push @{ $opts->{lib_links} }, map { s/^-l//; $_ } split(' ', ExtUtils::PkgConfig->libs_only_l('openssl'));
-        }
-        else {
-             push @{ $opts->{lib_links} }, qw( ssl crypto z );
-        }
+        push @{ $opts->{lib_links} }, qw( ssl crypto z );
 
         if (($Config{cc} =~ /aCC/i) && $^O eq 'hpux') {
             print "*** Enabling HPUX aCC options (+e)\n";


### PR DESCRIPTION
This reverts da6292e138644aa1cdd234114c6198675611693c.

The automatic detection of libssl/libcrypto with pkg-config conflicts with the `OPENSSL_PREFIX` method of specifying where `Makefile.PL` should look for libssl/libcrypto. The one known failure case at the moment is when `OPENSSL_PREFIX` points to a copy of OpenSSL that has compression enabled, but pkg-config points to a copy of OpenSSL that doesn't have compression enabled - this causes `-lz` to be omitted from the list of options passed to the linker, causing a compilation failure. There may be other failure cases.

The automatic detection of libssl/libcrypto is a very useful feature, so we'll find and fix all the edge cases and bring it back in time for Net-SSLeay 1.96.

Fixes #465.