### PR TITLE
Stable release 1.94

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,27 @@
 Revision history for Perl extension Net::SSLeay.
 
+1.94 2024-01-08
+	- New stable release incorporating all changes from developer releases 1.93_01
+	  to 1.93_05.
+	- Summary of major changes since version 1.92:
+	  - Net::SSLeay now officially supports all stable releases of OpenSSL 3.1 and
+	    3.2, and LibreSSL 3.5 - 3.8.
+	  - Many noisy compiler warnings have been silenced - if SSLeay.xs fails to
+	    compile, it should now be much easier to identify the cause.
+	  - libcrypto's OPENSSL_init_crypto() function and libssl's OPENSSL_init_ssl()
+	    function are now exposed, enabling fine-grained control over the
+	    initialisation and configuration of both libraries.
+	  - libssl functions implementing TLS 1.3 PSK authentication are now exposed,
+	    in particular SSL_CTX_set_psk_find_session_callback() (on the server side)
+	    and SSL_CTX_set_psk_use_session_callback() (on the client side).
+	  - libssl functions implementing server-side TLS 1.2 PSK authentication are
+	    now exposed, in particular SSL_CTX_set_psk_server_callback().
+	  - libssl's SSL_CTX_set_client_hello_cb() function is now exposed, allowing a
+	    TLS server to set a callback function that is executed when the server
+	    processes a ClientHello message.
+	  - Many more libcrypto/libssl constants and functions are now exposed; see the
+	    release notes for the 1.93 developer releases for a full list.
+
 1.93_05 2024-01-06
 	- Remove support for automatic detection of libssl/libcrypto via pkg-config
 	  with ExtUtils::PkgConfig if it is installed, due to the compiler and linker

--- a/helper_script/generate-test-pki
+++ b/helper_script/generate-test-pki
@@ -14,7 +14,7 @@ use File::Temp;
 use Getopt::Long qw(GetOptionsFromArray);
 use IPC::Run qw( start finish timeout );
 
-our $VERSION = '1.93_05';
+our $VERSION = '1.94';
 
 local $SIG{__DIE__} = sub {
     my ($cause) = @_;
@@ -1254,7 +1254,7 @@ C<generate-test-pki> - Generate a PKI for the Net-SSLeay test suite
 
 =head1 VERSION
 
-This document describes version 1.93_05 of C<generate-test-pki>.
+This document describes version 1.94 of C<generate-test-pki>.
 
 =head1 USAGE
 

--- a/helper_script/update-exported-constants
+++ b/helper_script/update-exported-constants
@@ -14,7 +14,7 @@ use File::Spec::Functions qw(catfile);
 use Getopt::Long qw(GetOptionsFromArray);
 use POSIX qw(ceil);
 
-our $VERSION = '1.93_05';
+our $VERSION = '1.94';
 
 local $SIG{__DIE__} = sub {
     my ($cause) = @_;
@@ -427,7 +427,7 @@ C<update-exported-constants> - Manage constants exported by Net::SSLeay
 
 =head1 VERSION
 
-This document describes version 1.93_05 of C<update-exported-constants>.
+This document describes version 1.94 of C<update-exported-constants>.
 
 =head1 USAGE
 

--- a/inc/Test/Net/SSLeay.pm
+++ b/inc/Test/Net/SSLeay.pm
@@ -14,7 +14,7 @@ use File::Spec::Functions qw( abs2rel catfile );
 use Test::Builder;
 use Test::Net::SSLeay::Socket;
 
-our $VERSION = '1.93_05';
+our $VERSION = '1.94';
 
 our @EXPORT_OK = qw(
     can_fork can_really_fork can_thread
@@ -542,7 +542,7 @@ Test::Net::SSLeay - Helper module for the Net-SSLeay test suite
 
 =head1 VERSION
 
-This document describes version 1.93_05 of Test::Net::SSLeay.
+This document describes version 1.94 of Test::Net::SSLeay.
 
 =head1 SYNOPSIS
 

--- a/inc/Test/Net/SSLeay/Socket.pm
+++ b/inc/Test/Net/SSLeay/Socket.pm
@@ -13,7 +13,7 @@ use Socket qw(
     inet_aton inet_ntoa pack_sockaddr_in unpack_sockaddr_in
 );
 
-our $VERSION = '1.93_05';
+our $VERSION = '1.94';
 
 my %PROTOS = (
     tcp => SOCK_STREAM,
@@ -134,7 +134,7 @@ Test::Net::SSLeay::Socket - Socket class for the Net-SSLeay test suite
 
 =head1 VERSION
 
-This document describes version 1.93_05 of Test::Net::SSLeay::Socket.
+This document describes version 1.94 of Test::Net::SSLeay::Socket.
 
 =head1 SYNOPSIS
 

--- a/lib/Net/SSLeay.pm
+++ b/lib/Net/SSLeay.pm
@@ -70,7 +70,7 @@ $Net::SSLeay::how_random = 512;
 #   inc/Test/Net/SSLeay.pm
 #   inc/Test/Net/SSLeay/Socket.pm
 #   lib/Net/SSLeay/Handle.pm
-$VERSION = '1.93_05';
+$VERSION = '1.94';
 
 @ISA = qw(Exporter);
 

--- a/lib/Net/SSLeay/Handle.pm
+++ b/lib/Net/SSLeay/Handle.pm
@@ -57,7 +57,7 @@ you need to add to your program is the tie function as in:
 use vars qw(@ISA @EXPORT_OK $VERSION);
 @ISA = qw(Exporter);
 @EXPORT_OK = qw(shutdown);
-$VERSION = '1.93_05';
+$VERSION = '1.94';
 
 my $Initialized;       #-- only _initialize() once
 my $Debug = 0;         #-- pretty hokey


### PR DESCRIPTION
Bump all version numbers from 1.93_05 to 1.94, and summarise major changes since 1.92.

Closes #460.