### PR TITLE
GH-471 Check that OpenSSL has NPN enabled when testing NPN.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for Perl extension Net::SSLeay.
 
+1.95_01 yyyy-mm-dd
+	- Skip NPN tests when NPN is disabled in OpenSSL instead o
+	  assuming NPN is always enabled. Reported by GitHub user
+	  dilyanpalauzov Дилян Палаузов.
+
 1.94 2024-01-08
 	- New stable release incorporating all changes from developer releases 1.93_01
 	  to 1.93_05.

--- a/t/local/40_npn_support.t
+++ b/t/local/40_npn_support.t
@@ -10,6 +10,9 @@ BEGIN {
         plan skip_all => "OpenSSL 1.0.1 or above required";
     } elsif (Net::SSLeay::constant("LIBRESSL_VERSION_NUMBER")) {
         plan skip_all => "LibreSSL removed support for NPN";
+    } elsif (!defined &Net::SSLeay::CTX_set_next_protos_advertised_cb) {
+        # OpenSSL can optionally be compiled without NPN support
+        plan skip_all => "NPN is not enabled";
     } elsif (not can_fork()) {
         plan skip_all => "fork() not supported on this system";
     } elsif ( !eval { new_ctx( undef, 'TLSv1.2' ); 1 } ) {


### PR DESCRIPTION
OpenSSL can be configured without NPN support. The NPN tests assumed that NPN is always available instead of checking for the presence of NPN functionality.

Closes #471