### PR TITLE
CI: replace `openssl30` package with `openssl32` in FreeBSD tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,13 +244,13 @@ jobs:
             version: '13.2'
             pkginstall: pkg install -y p5-ExtUtils-MakeMaker p5-App-cpanminus
           - name: freebsd
-            pretty_name: FreeBSD (OpenSSL 3.0)
-            version: '13.2'
-            pkginstall: pkg install -y p5-ExtUtils-MakeMaker p5-App-cpanminus openssl30
-          - name: freebsd
             pretty_name: FreeBSD (OpenSSL 3.1)
             version: '13.2'
             pkginstall: pkg install -y p5-ExtUtils-MakeMaker p5-App-cpanminus openssl31
+          - name: freebsd
+            pretty_name: FreeBSD (OpenSSL 3.2)
+            version: '13.2'
+            pkginstall: pkg install -y p5-ExtUtils-MakeMaker p5-App-cpanminus openssl32
           - name: freebsd
             pretty_name: FreeBSD (LibreSSL)
             version: '13.2'


### PR DESCRIPTION
The `openssl30` package has been removed from FreeBSD Ports, but `openssl32` is now available as well as `openssl31` - run the test suite against those two versions of OpenSSL.

Fixes #477.