### PR TITLE
test: 32_x509_get_cert_info allow single colon.

### DIFF
--- a/t/local/32_x509_get_cert_info.t
+++ b/t/local/32_x509_get_cert_info.t
@@ -188,6 +188,10 @@ for my $f (keys (%$dump)) {
                   ) {
                       $ext_data =~ s{(othername:) [^, ]+}{$1<unsupported>}g;
                   }
+                  # Starting with 3.4.0 the double colon in emailAddress has been removed.
+                  if (Net::SSLeay::SSLeay >= 0x30400000) {
+                      $ext_data =~ s{emailAddress::}{emailAddress:};
+                  }
               }
               elsif ( $nid == 89 ) {
                   # The output formatting for certificate policies has a


### PR DESCRIPTION
Starting with 3.4.0 the double colon in emailAddress has been removed. Adapt the test to allow a single colon in 3.4.0 and later.

The commit in question is openssl/openssl@de8861a7e3100 ("Remove duplicate colon in otherName display")