### PR TITLE
 Fix context leak when socket is not cloed explicitly

### DIFF
--- a/lib/Net/SSLeay/Handle.pm
+++ b/lib/Net/SSLeay/Handle.pm
@@ -97,6 +97,13 @@ sub TIEHANDLE {
     return $self;
 }
 
+sub DESTROY {
+    my $self = shift;
+    # Cleanup contextes if they have not been cleaned while CLOSEing
+    Net::SSLeay::CTX_free ($self->{ctx}) if defined $self->{ctx};
+    Net::SSLeay::free ($self->{ssl}) if defined $self->{ssl};
+}
+
 sub PRINT {
     my $self = shift;
 
@@ -156,6 +163,8 @@ sub CLOSE {
     $Debug > 10 and print "close($fileno)\n";
     Net::SSLeay::free ($self->{ssl});
     Net::SSLeay::CTX_free ($self->{ctx});
+    undef $self->{ctx};
+    undef $self->{ssl};
     close $self->{socket};
 }
 


### PR DESCRIPTION
Fix memory leak described in #469.

If this patch is applied, this module build with ASan enabled no longer fails on following sample:
```
use strict;
use Symbol qw(gensym);
use Net::SSLeay::Handle;

my @uris = ('ya.ru', 'google.com');
#my @uris = ('google.com');

for my $uri (@uris)
{
  my $ssl = gensym();
  tie(*$ssl, "Net::SSLeay::Handle", $uri, 443);
  print $ssl "GET / HTTP/1.0\r\n\r\n";

  my $response = do { local $/ = undef; <$ssl> };
}
``` 

This does not solves all ASan related problems, but reduces failed tests from 13 to 11 for me.