### PR TITLE
Make example in Net::SSLeay::Handle really work

### DIFF
--- a/lib/Net/SSLeay/Handle.pm
+++ b/lib/Net/SSLeay/Handle.pm
@@ -23,7 +23,7 @@ handled as standard file handles.
 
   tie(*SSL, "Net::SSLeay::Handle", $host, $port);
 
-  print SSL "GET / HTTP/1.0\r\n";
+  print SSL "GET / HTTP/1.0\r\n\r\n";
   shutdown(\*SSL, 1);
   print while (<SSL>);
   close SSL;                                                       
@@ -33,7 +33,7 @@ handled as standard file handles.
 Net::SSLeay::Handle allows you to request and receive HTTPS web pages
 using "old-fashion" file handles as in:
 
-    print SSL "GET / HTTP/1.0\r\n";
+    print SSL "GET / HTTP/1.0\r\n\r\n";
 
 and
 
@@ -322,7 +322,7 @@ non-SSL sockets and do the right thing.
 
   tie(*SSL, "Net::SSLeay::Handle", $host, $port);
 
-  print SSL "GET / HTTP/1.0\r\n";
+  print SSL "GET / HTTP/1.0\r\n\r\n";
   shutdown(\*SSL, 1);
   print while (<SSL>);
   close SSL; 


### PR DESCRIPTION
If you try an example from Net::SSLeay::Handle pod on real server (by replacing localhost with www.google.com for example), you will get no answer, and connection will be closed on timeout.

You should send extra empty line to get an answer.

I've added this line to an example, to save time of other developers, who will need to figure that out themselves. 

PS please refer me as NATARAJ (Nikolay Shaplov) if you ever would like to mention me anywhere...