### PR TITLE
Fix memory leaks problems in t/local/11_read.t reported by Assress Sanitizer

### DIFF
--- a/t/local/11_read.t
+++ b/t/local/11_read.t
@@ -61,6 +61,7 @@ sub server
 	    Net::SSLeay::write($ssl, $msg);
 	    Net::SSLeay::shutdown($ssl);
 	    Net::SSLeay::free($ssl);
+	    Net::SSLeay::CTX_free($ctx);
 	    close($cl) || die("client close: $!");
 	}
 	$server->close() || die("server listen socket close: $!");
@@ -93,6 +94,7 @@ sub client
 
 	Net::SSLeay::shutdown($ssl);
 	Net::SSLeay::free($ssl);
+	Net::SSLeay::CTX_free($ctx);
 	close($cl) || die("client close: $!");
     }
     $server->close() || die("client listen socket close: $!");


### PR DESCRIPTION
If you build perl (and consequently  Net::SSLleay) using Address Sanitizer, `t/local/11_read.t` test will fail.

This is because SSL_CTX are not properly freed when no longer in use. If you directly call SSL method of creating something, you should also directly free it, as you would do if you write pure C code.

This patch fixes the problem with the test. I guess that the necessity of calling Net::SSLeay::CTX_free should also be mentioned in docs. But I did not find proper place for putting it without bit rewriting.

You can find instruction on how to build perl in this modulet using ASan in  #469

PS please refer me as NATARAJ (Nikolay Shaplov) if you ever would like to mention me anywhere...   