### PR TITLE
Partial fix of t/local/31_rsa_generate_key.t memory leaks

### DIFF
--- a/t/local/31_rsa_generate_key.t
+++ b/t/local/31_rsa_generate_key.t
@@ -8,7 +8,8 @@ plan tests => 14;
 initialise_libssl();
 
 lives_ok(sub {
-        Net::SSLeay::RSA_generate_key(2048, 0x10001);
+        my $rsa = Net::SSLeay::RSA_generate_key(2048, 0x10001);
+        Net::SSLeay::RSA_free($rsa);
 }, 'RSA_generate_key with valid callback');
 
 dies_like(sub {
@@ -19,7 +20,8 @@ dies_like(sub {
     my $called = 0;
 
     lives_ok(sub {
-            Net::SSLeay::RSA_generate_key(2048, 0x10001, \&cb);
+            my $rsa = Net::SSLeay::RSA_generate_key(2048, 0x10001, \&cb);
+            Net::SSLeay::RSA_free($rsa);
     }, 'RSA_generate_key with valid callback');
 
     cmp_ok( $called, '>', 0, 'callback has been called' );
@@ -44,7 +46,8 @@ dies_like(sub {
     my $userdata = 'foo';
 
     lives_ok(sub {
-            Net::SSLeay::RSA_generate_key(2048, 0x10001, \&cb_data, $userdata);
+            my $rsa = Net::SSLeay::RSA_generate_key(2048, 0x10001, \&cb_data, $userdata);
+            Net::SSLeay::RSA_free($rsa);
     }, 'RSA_generate_key with valid callback and userdata');
 
     cmp_ok( $called, '>', 0, 'callback has been called' );


### PR DESCRIPTION
If you build perl and Net::SSLleay with Address Sanitizer and run tests, `t/local/31_rsa_generate_key.t` will fail with some Memory Leak error messages. There are two parts of this problem.

**Second part:**  You should explicitly free RSA structure created with `RSA_generate_key`, when it is no longer in use this will prevent unnecessary memory leaks. This patch solves this problem.

**First part:** Test that checks failure with not-proper callback scalar value
```
dies_like(sub {
        Net::SSLeay::RSA_generate_key(2048, 0x10001, 1);
}, qr/Undefined subroutine &main::1 called/, 'RSA_generate_key with invalid callback');
```
also causes memory leak.

As far as I can get this happens because `RSA_generate_key` from `SSLeay.xs` allocate something, then calls `RSA_generate_key_ex` with `ssleay_RSA_generate_key_cb_invoke` as a callback. And `ssleay_RSA_generate_key_cb_invoke` calls `count = call_sv( cb->func, G_VOID|G_DISCARD );` that throws an exeption if `cb->func` is not a function. Thus we do not free what have been allocated in `RSA_generate_key` and go straight to `dies_like` exception catcher. 

I guess best solution would be to catch that exception in `RSA_generate_key`, free the staff, and then rethorow it. Because there can be any exception in a call back, even user generated. But such trick is beyond my power for now. 

So this patch will fix only `RSA_free` related things.

PS You can find instruction on how to build perl in this modulet using ASan in https://github.com/radiator-software/p5-net-ssleay/issues/469

PPS please refer me as NATARAJ (Nikolay Shaplov) if you ever would like to mention me anywhere...