### PR TITLE
 Fix memory leaks problems in t/local/32_x509_get_cert_info.t reported by Assress Sanitizer

### DIFF
--- a/t/local/32_x509_get_cert_info.t
+++ b/t/local/32_x509_get_cert_info.t
@@ -42,7 +42,10 @@ for my $f (keys (%$dump)) {
   my $filename = data_file_path($f);
   ok(my $bio = Net::SSLeay::BIO_new_file($filename, 'rb'), "BIO_new_file\t$f");
   ok(my $x509 = Net::SSLeay::PEM_read_bio_X509($bio), "PEM_read_bio_X509\t$f");
-  ok(Net::SSLeay::X509_get_pubkey($x509), "X509_get_pubkey\t$f"); #only test whether the function works  
+  {
+    ok(my $pubkey = Net::SSLeay::X509_get_pubkey($x509), "X509_get_pubkey\t$f"); #only test whether the function works
+    Net::SSLeay::EVP_PKEY_free($pubkey);
+  }
 
   ok(my $subj_name = Net::SSLeay::X509_get_subject_name($x509), "X509_get_subject_name\t$f");
   is(my $subj_count = Net::SSLeay::X509_NAME_entry_count($subj_name), $dump->{$f}->{subject}->{count}, "X509_NAME_entry_count\t$f");
@@ -352,7 +355,9 @@ for my $f (keys (%$dump)) {
     skip('EVP_PKEY_id requires OpenSSL 1.0.0+', 1) unless Net::SSLeay::SSLeay >= 0x1000000f;
     is(Net::SSLeay::EVP_PKEY_id($pubkey), $dump->{$f}->{pubkey_id}, "EVP_PKEY_id");
   }
-
+  Net::SSLeay::EVP_PKEY_free($pubkey);
+  Net::SSLeay::X509_free($x509);
+  Net::SSLeay::BIO_free($bio);
 }
 
 my $ctx = Net::SSLeay::X509_STORE_CTX_new();


### PR DESCRIPTION
If you build perl (and consequently Net::SSLleay) using Address Sanitizer, `t/local/32_x509_get_cert_info.t` test will fail.

This patch properly frees all objects created in the tests, and makes Address Sanitizer happy.

You can find instruction on how to build perl in this modulet using ASan in https://github.com/radiator-software/p5-net-ssleay/issues/469

PS please refer me as NATARAJ (Nikolay Shaplov) if you ever would like to mention me anywhere..