### PR TITLE
Fix most memory leaks problems in t/local/36_verify.t reported by Assress Sanitize

### DIFF
--- a/t/local/36_verify.t
+++ b/t/local/36_verify.t
@@ -130,7 +130,7 @@ sub test_policy_checks
 	isnt($ret, 1, 'connect not ok: policy checks must fail') if !$ok;
 	is($verify_result, Net::SSLeay::X509_V_ERR_NO_EXPLICIT_POLICY(), 'Verify result is X509_V_ERR_NO_EXPLICIT_POLICY');
     }
-
+    Net::SSLeay::free($ssl); # call SSL_free()
     Net::SSLeay::X509_VERIFY_PARAM_free($pm);
 }
 
@@ -186,9 +186,8 @@ sub test_hostname_checks
       } else {
 	  is($peername, undef, 'X509_VERIFY_PARAM_get0_peername returns undefined');
       }
-
+      Net::SSLeay::free($ssl); # call SSL_free()
       Net::SSLeay::X509_VERIFY_PARAM_free($pm);
-      Net::SSLeay::X509_VERIFY_PARAM_free($pm2);
     }
 }
 
@@ -305,6 +304,7 @@ sub client {
 	test_hostname_checks($ctx, $cl, 1) if $task eq 'hostname_checks_ok';
 	test_hostname_checks($ctx, $cl, 0) if $task eq 'hostname_checks_fail';
 	test_wildcard_checks($ctx, $cl) if $task eq 'wildcard_checks';
+	Net::SSLeay::CTX_free($ctx);
 	last if $task eq 'finish'; # Leaves $cl alive
 
 	close($cl) || die("client close: $!");
@@ -321,6 +321,7 @@ sub client {
     ok($end eq Net::SSLeay::ssl_read_all($ssl), 'Successful termination');
     Net::SSLeay::free($ssl);
     close($cl) || die("client final close: $!");
+    Net::SSLeay::CTX_free($ctx);
     return;
 }
 
@@ -366,6 +367,7 @@ sub run_server
 	    Net::SSLeay::free($ssl);
 	    close($cl) || die("server close: $!");
 	    $server->close() || die("server listen socket close: $!");
+            Net::SSLeay::CTX_free($ctx);
 	    exit (0);
 	}
     }

--- a/t/local/36_verify.t
+++ b/t/local/36_verify.t
@@ -356,7 +356,11 @@ sub run_server
 
 	Net::SSLeay::set_fd($ssl, fileno($cl));
 	my $ret = Net::SSLeay::accept($ssl);
-	next unless $ret == 1;
+	if ($ret != 1)
+	{
+	    Net::SSLeay::free($ssl);
+            next;
+	}
 
 	# Termination request or other message from client
 	my $msg = Net::SSLeay::ssl_read_all($ssl);
@@ -370,5 +374,6 @@ sub run_server
             Net::SSLeay::CTX_free($ctx);
 	    exit (0);
 	}
+	Net::SSLeay::free($ssl);
     }
 }


### PR DESCRIPTION
If you build perl (and consequently Net::SSLleay) using Address Sanitizer, t/local/36_verify.t test will fail.

This patch properly frees objects that needs to be freed explicitly, and makes Address Sanitizer happy.

The only one remaining problem `X509_VERIFY_PARAM_set1_name` function that is  undocumented function of OpenSSL and it has memory leak by design:  it do `param->name = OPENSSL_strdup(name);` and `X509_VERIFY_PARAM_free` does not try to free it. So I would suggest to remove this function from the test case and documentation: same way they did in OpenSSL. 

You can find instruction on how to build perl in this modulet using ASan in https://github.com/radiator-software/p5-net-ssleay/issues/469

PS please refer me as NATARAJ (Nikolay Shaplov) if you ever would like to mention me anywhere.