### PR TITLE
 Fix memory leaks problems in t/local/40_npn_support.t reported by Assress Sanitizer

### DIFF
--- a/t/local/40_npn_support.t
+++ b/t/local/40_npn_support.t
@@ -15,7 +15,7 @@ BEGIN {
         plan skip_all => "NPN is not enabled";
     } elsif (not can_fork()) {
         plan skip_all => "fork() not supported on this system";
-    } elsif ( !eval { new_ctx( undef, 'TLSv1.2' ); 1 } ) {
+    } elsif ( !eval { my $ctx = new_ctx( undef, 'TLSv1.2' ); Net::SSLeay::CTX_free($ctx); 1 } ) {
         # NPN isn't well-defined for TLSv1.3, so these tests can't be run if
         # that's the only available protocol version
         plan skip_all => 'TLSv1.2 or below not available in this libssl';


### PR DESCRIPTION
If you build perl (and consequently Net::SSLleay) using Address Sanitizer, `t/local/40_npn_support.t` test will fail.

This patch properly frees all objects created in the tests, and makes Address Sanitizer happy.

You can find instruction on how to build perl in this modulet using ASan in https://github.com/radiator-software/p5-net-ssleay/issues/469

PS please refer me as NATARAJ (Nikolay Shaplov) if you ever would like to mention me anywhere..