### PR TITLE
 Fix memory leaks problems in t/local/42_info_callback.t reported by Assress Sanitizer

### DIFF
--- a/t/local/42_info_callback.t
+++ b/t/local/42_info_callback.t
@@ -36,6 +36,8 @@ my $server = tcp_socket();
 	    for(1,2) {
 		last if Net::SSLeay::shutdown($ssl)>0;
 	    }
+	    Net::SSLeay::free($ssl); # Call SSL_free()
+	    Net::SSLeay::CTX_free($ctx);
 	    close($cl) || die("server close: $!");
 	}
 	$server->close() || die("server listen socket close: $!");


### PR DESCRIPTION
If you build perl (and consequently Net::SSLleay) using Address Sanitizer, `t/local/42_info_callback.t` test will fail.

This patch properly frees all objects created in the tests, and makes Address Sanitizer happy.

You can find instruction on how to build perl in this modulet using ASan in https://github.com/radiator-software/p5-net-ssleay/issues/469

PS please refer me as NATARAJ (Nikolay Shaplov) if you ever would like to mention me anywhere..