### PR TITLE
 Fix memory leaks problems in t/local/45_exporter.t reported by Assress Sanitizer #505 Fix t local sess#506

### DIFF
--- a/t/local/45_exporter.t
+++ b/t/local/45_exporter.t
@@ -69,6 +69,7 @@ sub server
 
 	    Net::SSLeay::shutdown($ssl);
 	    Net::SSLeay::free($ssl);
+            Net::SSLeay::CTX_free($ctx);
 	    close($cl) || die("server close: $!");
 	}
 	$server->close() || die("server listen socket close: $!");
@@ -110,6 +111,7 @@ sub client {
 
             Net::SSLeay::shutdown($ssl);
             Net::SSLeay::free($ssl);
+            Net::SSLeay::CTX_free($ctx);
             close($cl) || die("client close: $!");
             $proto_count += 1;
         }


### PR DESCRIPTION
If you build perl (and consequently Net::SSLleay) using Address Sanitizer, `t/local/45_exporter.t` test will fail.

This patch properly frees all objects created in the tests, and makes Address Sanitizer happy.

You can find instruction on how to build perl in this modulet using ASan in https://github.com/radiator-software/p5-net-ssleay/issues/469

PS please refer me as NATARAJ (Nikolay Shaplov) if you ever would like to mention me anywhere..