### PR TITLE
 Fix memory leaks problems in t/local/64_ticket_sharing.t reported by Address Sanitizer

### DIFF
--- a/t/local/64_ticket_sharing.t
+++ b/t/local/64_ticket_sharing.t
@@ -278,9 +278,16 @@ sub _handshake {
 	    Net::SSLeay::BIO_new(Net::SSLeay::BIO_s_mem()),
 	);
 	Net::SSLeay::set_bio($ssl,$bio[0],$bio[1]);
+	Net::SSLeay::free($self->{ssl}) if $self->{ssl};  # call SSL_free() on old ssl value;
 	$self->{ssl} = $ssl;
 	$self->{rbio} = $bio[0];
 	$self->{wbio} = $bio[1];
+    }
+
+    sub DESTROY {
+	my $self = shift;
+	Net::SSLeay::free($self->{ssl}) if $self->{ssl};  # call SSL_free() on old ssl value;
+	Net::SSLeay::CTX_free($self->{ctx}) if $self->{ctx};  # free old ctx value;
     }
 
     sub _error {

--- a/t/local/64_ticket_sharing.t
+++ b/t/local/64_ticket_sharing.t
@@ -63,8 +63,9 @@ if (0) {
 	    Net::SSLeay::get_session($client->_ssl));
     };
     $reuse = sub {
-	Net::SSLeay::set_session($client->_ssl,
-	    Net::SSLeay::d2i_SSL_SESSION($saved));
+	my $sess = Net::SSLeay::d2i_SSL_SESSION($saved);
+	Net::SSLeay::set_session($client->_ssl, $sess);
+	Net::SSLeay::SESSION_free($sess);
     };
 }
 


### PR DESCRIPTION
If you build perl (and consequently Net::SSLleay) using Address Sanitizer, `t/local/64_ticket_sharing.t` test will fail.

This patch properly frees all objects created in the tests, and makes Address Sanitizer happy. See commit messages for more info.

You can find instruction on how to build perl in this modulet using ASan in https://github.com/radiator-software/p5-net-ssleay/issues/469

PS please refer me as NATARAJ (Nikolay Shaplov) if you ever would like to mention me anywhere..