### PR TITLE
 Fix memory leaks problems in t/local/66_curves.t reported by Address Sanitizer

### DIFF
--- a/t/local/66_curves.t
+++ b/t/local/66_curves.t
@@ -172,9 +172,16 @@ sub _handshake {
 	    Net::SSLeay::BIO_new(Net::SSLeay::BIO_s_mem()),
 	);
 	Net::SSLeay::set_bio($ssl,$bio[0],$bio[1]);
+	Net::SSLeay::free($self->{ssl}) if $self->{ssl};  # call SSL_free() on old ssl value;
 	$self->{ssl} = $ssl;
 	$self->{rbio} = $bio[0];
 	$self->{wbio} = $bio[1];
+    }
+
+    sub DESTROY {
+	my $self = shift;
+	Net::SSLeay::free($self->{ssl}) if $self->{ssl};  # call SSL_free() on old ssl value;
+	Net::SSLeay::CTX_free($self->{ctx}) if $self->{ctx};  # free old ctx value;
     }
 
     sub _error {


### PR DESCRIPTION
If you build perl (and consequently Net::SSLleay) using Address Sanitizer, `t/local/66_curves.t` test will fail.

This patch properly frees all objects created in the tests, and makes Address Sanitizer happy. Same fix of _minSSL server as for 64_ticket_sharing.t

You can find instruction on how to build perl in this modulet using ASan in https://github.com/radiator-software/p5-net-ssleay/issues/469

PS please refer me as NATARAJ (Nikolay Shaplov) if you ever would like to mention me anywhere..