### PR TITLE
Adapt the testuite for Openssl 3.4.1

### DIFF
--- a/t/local/32_x509_get_cert_info.t
+++ b/t/local/32_x509_get_cert_info.t
@@ -188,6 +188,10 @@ for my $f (keys (%$dump)) {
                   ) {
                       $ext_data =~ s{(othername:) [^, ]+}{$1<unsupported>}g;
                   }
+                  # Starting with 3.4.0 the double colon in emailAddress has been removed.
+                  if (Net::SSLeay::SSLeay >= 0x30400000) {
+                      $ext_data =~ s{emailAddress::}{emailAddress:};
+                  }
               }
               elsif ( $nid == 89 ) {
                   # The output formatting for certificate policies has a

--- a/t/local/32_x509_get_cert_info.t
+++ b/t/local/32_x509_get_cert_info.t
@@ -218,6 +218,9 @@ for my $f (keys (%$dump)) {
                       # OpenSSL 1.0.0 to 1.1.1:
                       $ext_data =~ s{(Full Name:\n  )}{\n$1}g;
                       $ext_data .= "\n";
+                  } elsif ( Net::SSLeay::SSLeay >  0x3040000f ) {
+                      $ext_data =~ s{(\nFull Name:)}{\n$1}g;
+                      $ext_data .= "\n";
                   }
               }
               elsif ( $nid == 126 ) {


### PR DESCRIPTION
Since OpenSSL 3.4.1, commit 8a28bca8ee08 ("x509: add a newline after
printing Full Name") to be exact, there is another new line change.
    
Adapt the testsuite.