### PR TITLE
Add missing documentation for STACK_OF() free functions

### DIFF
--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -1,3 +1,4 @@
+
 =encoding utf-8
 
 =head1 NAME
@@ -7073,6 +7074,15 @@ Returns a new, empty, STACK_OF(X509) structure.
     #
     # returns: value corresponding to openssl's STACK_OF(X509) structure
 
+=item * sk_X509_free
+
+Free an allocated STACK_OF(X509) structure.
+
+    Net::SSLeay::sk_X509_free($sk);
+    # $sk - value corresponding to openssl's STACK_OF(X509) structure
+    #
+    # returns: no return value
+
 =item * sk_X509_push
 
 Pushes an X509 structure onto a STACK_OF(X509) structure.
@@ -8335,6 +8345,15 @@ For more details about $trust identifier check L</CTX_set_trust>.
 =head3 Low Level API: X509_INFO related functions
 
 =over
+
+=item * sk_X509_INFO_free
+
+Free an allocated STACK_OF(X509_INFO) structure.
+
+    Net::SSLeay::sk_X509_INFO_free($sk);
+    # $sk - value corresponding to openssl's STACK_OF(X509_INFO) structure
+    #
+    # returns: no return value
 
 =item * sk_X509_INFO_num
 


### PR DESCRIPTION
sk_X509_free and sk_X509_INFO_free are already available in SSLeay.xs but they are not documented.