### PR TITLE
GH-518 CI rectification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
             make test
 
   non_x86_alpine:
-    name: "${{ matrix.platform }}/Alpine/${{ matrix.alpine_version }} (${{ matrix.package }})"
+    name: "${{ matrix.platform.name }}/Alpine/${{ matrix.alpine_version }} (${{ matrix.package }})"
 
     runs-on: ubuntu-latest
 
@@ -182,31 +182,41 @@ jobs:
           - openssl
           - libressl
         platform:
-          - i386
-          - s390x
-          - arm32v6
-          - arm32v7
-          - arm64v8
+          - name: i386
+            docker_platform: linux/386
+          - name: s390x
+            docker_platform: linux/s390x
+          - name: arm32v6
+            docker_platform: linux/arm/v6
+          - name: arm32v7
+            docker_platform: linux/arm/v7
+          - name: arm64v8
+            docker_platform: linux/arm64/v8
         alpine_version:
           - '3.18'
           - '3.17'
           - '3.16'
           - '3.15'
+        # Alpine 3.18 on s390x does not have LibreSSL
         exclude:
           - package: libressl
-            platform: s390x
+            platform:
+              name: s390x
             alpine_version: '3.18'
 
     steps:
       - uses: actions/checkout@main
         with:
             submodules: recursive
-      - name: Get the qemu container
-        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
 
       # NB: “openssl” is correct, even for LibreSSL:
-      - name: Run tests on ${{ matrix.platform }}
-        run: docker run --rm --interactive --mount type=bind,source=$(pwd),target=/host ${{ matrix.platform }}/alpine:${{ matrix.alpine_version}} sh -c "apk add perl-dev perl-app-cpanminus make gcc musl-dev zlib-dev ${{ matrix.package }}-dev openssl && perl -V && cd /host && cpanm --verbose --notest --installdeps . && perl Makefile.PL && make test"
+      - name: Run tests on ${{ matrix.platform.name }}
+        run: docker run --rm --interactive --platform ${{ matrix.platform.docker_platform }} --mount type=bind,source=$(pwd),target=/host ${{ matrix.platform.name }}/alpine:${{ matrix.alpine_version}} sh -c "apk add perl-dev perl-app-cpanminus make gcc musl-dev zlib-dev ${{ matrix.package }}-dev openssl && perl -V && cd /host && cpanm --verbose --notest --installdeps . && perl Makefile.PL && make test"
 
   non_x86_ubuntu:
     name: "${{ matrix.platform.name }}/Ubuntu"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,7 +300,7 @@ jobs:
         uses: cygwin/cygwin-install-action@master
         with:
             platform: x86_64
-            packages: perl_base perl-ExtUtils-MakeMaker make gcc-g++ libcrypt-devel libssl-devel curl bash
+            packages: perl perl_base perl-ExtUtils-MakeMaker make gcc-g++ libcrypt-devel libssl-devel curl bash
       - uses: actions/checkout@main
         with:
             submodules: recursive

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
           - name: netbsd
             pretty_name: NetBSD
             version: '9.3'
-            pkginstall: /usr/sbin/pkg_add http://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/amd64/9.3/All/p5-App-cpanminus
+            pkginstall: sudo pkgin update && sudo pkgin -y install p5-App-cpanminus
 
     steps:
       - uses: actions/checkout@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,26 +209,33 @@ jobs:
         run: docker run --rm --interactive --mount type=bind,source=$(pwd),target=/host ${{ matrix.platform }}/alpine:${{ matrix.alpine_version}} sh -c "apk add perl-dev perl-app-cpanminus make gcc musl-dev zlib-dev ${{ matrix.package }}-dev openssl && perl -V && cd /host && cpanm --verbose --notest --installdeps . && perl Makefile.PL && make test"
 
   non_x86_ubuntu:
-    name: "${{ matrix.platform }}/Ubuntu"
+    name: "${{ matrix.platform.name }}/Ubuntu"
 
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         platform:
-          - i386
-          - s390x
-          - arm32v7
-          - arm64v8
+          - name: i386
+            docker_platform: linux/386
+          - name: s390x
+            docker_platform: linux/s390x
+          - name: arm32v7
+            docker_platform: linux/arm/v7
+          - name: arm64v8
+            docker_platform: linux/arm64/v8
 
     steps:
       - uses: actions/checkout@main
         with:
             submodules: recursive
-      - name: Get the qemu container
-        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-      - name: Run tests on ${{ matrix.platform }}
-        run: docker run --rm --interactive --mount type=bind,source=$(pwd),target=/host ${{ matrix.platform }}/ubuntu bash -c "apt update && apt install -y cpanminus make gcc openssl libssl-dev zlib1g-dev && perl -V && cd /host && cpanm --notest --verbose --installdeps . || find /root/.cpanm/work/ -type f | xargs cat; perl Makefile.PL && make test"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+      - name: Run tests on ${{ matrix.platform.name }}
+        run: docker run --rm --interactive --platform ${{ matrix.platform.docker_platform }} --mount type=bind,source=$(pwd),target=/host ${{ matrix.platform.name }}/ubuntu:latest bash -c "apt update && apt install -y cpanminus make gcc openssl libssl-dev zlib1g-dev && perl -V && cd /host && cpanm --notest --verbose --installdeps . || find /root/.cpanm/work/ -type f | xargs cat; perl Makefile.PL && make test"
 
   BSDs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
         run: docker run --rm --interactive --mount type=bind,source=$(pwd),target=/host ${{ matrix.platform }}/ubuntu bash -c "apt update && apt install -y cpanminus make gcc openssl libssl-dev zlib1g-dev && perl -V && cd /host && cpanm --notest --verbose --installdeps . || find /root/.cpanm/work/ -type f | xargs cat; perl Makefile.PL && make test"
 
   BSDs:
-    runs-on: macos-12
+    runs-on: ubuntu-latest
 
     name: ${{ matrix.os.pretty_name }} ${{ matrix.os.version }}
 

--- a/Changes
+++ b/Changes
@@ -4,6 +4,9 @@ Revision history for Perl extension Net::SSLeay.
 	- Skip NPN tests when NPN is disabled in OpenSSL instead o
 	  assuming NPN is always enabled. Reported by GitHub user
 	  dilyanpalauzov Дилян Палаузов.
+	- Update GitHub Actions CI workflow. A number of test jobs
+	  were broken because some GitHub runners were discontinued,
+	  changes in QEMU setup, changes in Cygwin, etc.
 
 1.94 2024-01-08
 	- New stable release incorporating all changes from developer releases 1.93_01


### PR DESCRIPTION
GitHub CI testing had broken during the last year and many of the test jobs needed updates. GitHub runners were discontinued, QEMU setup didn't work anymore, Cygwin package list needed an update, etc. These are now fixed and the remaining test failures need to be addressed by catching up with the latest LibreSSL and ensuring the slowness seen under Arm64 with QEMU does not cause unexpected timeouts.

Closes #518.