### PR TITLE
Update tests to pass with OpenSSL 3.4

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,9 @@ Revision history for Perl extension Net::SSLeay.
 	- Update GitHub Actions CI workflow. A number of test jobs
 	  were broken because some GitHub runners were discontinued,
 	  changes in QEMU setup, changes in Cygwin, etc.
+	- Adjust test 32_x509_get_cert_info.t to match formatting
+	  changes in OpenSSL 3.4.0 and 3.4.1. Thanks to Sebastian
+	  Andrzej Siewior for the patches.
 
 1.94 2024-01-08
 	- New stable release incorporating all changes from developer releases 1.93_01

--- a/t/local/32_x509_get_cert_info.t
+++ b/t/local/32_x509_get_cert_info.t
@@ -188,6 +188,10 @@ for my $f (keys (%$dump)) {
                   ) {
                       $ext_data =~ s{(othername:) [^, ]+}{$1<unsupported>}g;
                   }
+                  # Starting with 3.4.0 the double colon in emailAddress has been removed.
+                  if (Net::SSLeay::SSLeay >= 0x30400000) {
+                      $ext_data =~ s{emailAddress::}{emailAddress:};
+                  }
               }
               elsif ( $nid == 89 ) {
                   # The output formatting for certificate policies has a

--- a/t/local/32_x509_get_cert_info.t
+++ b/t/local/32_x509_get_cert_info.t
@@ -218,6 +218,9 @@ for my $f (keys (%$dump)) {
                       # OpenSSL 1.0.0 to 1.1.1:
                       $ext_data =~ s{(Full Name:\n  )}{\n$1}g;
                       $ext_data .= "\n";
+                  } elsif ( Net::SSLeay::SSLeay >  0x3040000f ) {
+                      $ext_data =~ s{(\nFull Name:)}{\n$1}g;
+                      $ext_data .= "\n";
                   }
               }
               elsif ( $nid == 126 ) {


### PR DESCRIPTION
Update test 32_x509_get_cert_info.t to match changes in OpenSSL 3.4.0 and 3.4.1. The tests now pass with OpenSSL 3.5.0 too.

Closes #514, Resolves #513, Resolves #511, Resolves #494 and Resolves #493.