### PR TITLE
GH-521 latest libressl and thread test62

### DIFF
--- a/Changes
+++ b/Changes
@@ -10,6 +10,10 @@ Revision history for Perl extension Net::SSLeay.
 	- Adjust test 32_x509_get_cert_info.t to match formatting
 	  changes in OpenSSL 3.4.0 and 3.4.1. Thanks to Sebastian
 	  Andrzej Siewior for the patches.
+	- OpenSSL 3.9.0 and later remove EVP_add_digest(). Thanks to
+	  Derrik Pates for the report and patch.
+	- Increase timeout in 62_threads-ctx_new-deadlock.t to allow
+	  the test to pass on very slow platforms.
 
 1.94 2024-01-08
 	- New stable release incorporating all changes from developer releases 1.93_01

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -7493,7 +7493,11 @@ SSL_CTX_set_tlsext_ticket_getkey_cb(ctx,callback=&PL_sv_undef,data=&PL_sv_undef)
 
 #endif
 
+#if !defined(LIBRESSL_VERSION_NUMBER) || (LIBRESSL_VERSION_NUMBER < 0x3090000fL) /* LibreSSL < 3.9.0 */
+
 int EVP_add_digest(const EVP_MD *digest)
+
+#endif
 
 #ifndef OPENSSL_NO_SHA
 

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -9019,6 +9019,8 @@ B<COMPATIBILITY:> not available in Net-SSLeay-1.42 and before; requires at least
     #
     # returns: value corresponding to openssl's EVP_MD structure
 
+B<COMPATIBILITY:> no longer available in LibreSSL 3.9.0 and later
+
 =item * EVP_add_digest
 
     my $rv = Net::SSLeay::EVP_add_digest($digest);

--- a/t/local/32_x509_get_cert_info.t
+++ b/t/local/32_x509_get_cert_info.t
@@ -189,6 +189,7 @@ for my $f (keys (%$dump)) {
                       $ext_data =~ s{(othername:) [^, ]+}{$1<unsupported>}g;
                   }
                   # Starting with 3.4.0 the double colon in emailAddress has been removed.
+                  # See https://github.com/openssl/openssl/commit/de8861a7e3100
                   if (Net::SSLeay::SSLeay >= 0x30400000) {
                       $ext_data =~ s{emailAddress::}{emailAddress:};
                   }

--- a/t/local/62_threads-ctx_new-deadlock.t
+++ b/t/local/62_threads-ctx_new-deadlock.t
@@ -33,7 +33,7 @@ eval { Net::SSLeay::OPENSSL_INIT_NO_ATEXIT(); return 1; } ?
 my $start_time = time;
 
 #exit the whole program if it runs too long
-threads->new( sub { sleep 20; warn "FATAL: TIMEOUT!"; exit } )->detach;
+threads->new( sub { sleep 30; warn "FATAL: TIMEOUT!"; exit } )->detach;
 
 #print STDERR "Gonna start multi-threading part\n";
 threads->new(\&do_check) for (1..100);


### PR DESCRIPTION
Support latest LibreSSL versions and ensure 62_threads-ctx_new-deadlock.t is given enough time to finish on slow platforms.

Closes #484, closes #485, closes #521