### PR TITLE
Add functions for CTX sigalgs

### DIFF
--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -2565,6 +2565,16 @@ SSL_CTX_set_ciphersuites(SSL_CTX *ctx, const char *str)
 
 #endif
 
+#if (OPENSSL_VERSION_NUMBER >= 0x10100001L && !defined(LIBRESSL_VERSION_NUMBER)) || (LIBRESSL_VERSION_NUMBER >= 0x3060000fL)
+
+long
+SSL_CTX_set1_sigalgs_list(SSL_CTX *ctx, const char *str)
+
+long
+SSL_CTX_set1_client_sigalgs_list(SSL_CTX *ctx, const char *str)
+
+#endif
+
 #if OPENSSL_VERSION_NUMBER >= 0x1010100fL && !defined(LIBRESSL_VERSION_NUMBER) /* OpenSSL 1.1.1 */
 
 void

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -3274,6 +3274,38 @@ Applies X509 verification parameters $vpm on $ctx
 
 Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/SSL_CTX_get0_param.html>
 
+=item * CTX_set1_sigalgs_list
+
+B<COMPATIBILITY:> requires at least OpenSSL 1.1.0
+
+Set the supported signature algorithms for $ctx. $str is a string consisting of
+a colon separated list of elements, where each element is either a combination
+of a public key algorithm and a digest separated by +, or a TLS 1.3-style named
+SignatureScheme such as rsa_pss_pss_sha256.
+
+    my $rv = Net::SSLeay::CTX_set1_sigalgs_list($str)
+    # $str - (string) signature algo list, e.g. "ECDSA+SHA256:RSA+SHA256" 
+    #
+    # returns: 1 on success, 0 on failure
+
+Check openssl doc L<https://docs.openssl.org/master/man/SSL_CTX_set1_sigalgs/>
+
+=item * CTX_set1_client_sigalgs_list
+
+B<COMPATIBILITY:> requires at least OpenSSL 1.1.0
+
+Set the supported client authentication signature algorithms for $ctx. $str is
+a string consisting of a colon separated list of elements, where each element
+is either a combination of a public key algorithm and a digest separated by +,
+or a TLS 1.3-style named SignatureScheme such as rsa_pss_pss_sha256.
+
+    my $rv = Net::SSLeay::CTX_set1_client_sigalgs_list($str)
+    # $str - (string) signature algo list, e.g. "ECDSA+SHA256:RSA+SHA256" 
+    #
+    # returns: 1 on success, 0 on failure
+
+Check openssl doc L<https://docs.openssl.org/master/man/SSL_CTX_set1_sigalgs/>
+
 =item * CTX_set_cert_store
 
 Sets/replaces the certificate verification storage of $ctx to/with $store.


### PR DESCRIPTION
I found myself needing to control the signature algorithms for my client auth `CertificateRequest` to maintain compatibility with a legacy client. Luckily the string form of the function is very easy to pass though. 

Added wrappers: 
* `SSL_CTX_set1_sigalgs_list`
* `SSL_CTX_set1_client_sigalgs_list`