### PR TITLE
CI: test against OpenSSL 3.6, LibreSSL 4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@
 # - OS: Ubuntu 24.04
 # - Perl: the latest patch release of every minor release since 5.8
 # - libssl: the latest patch release of every minor release between:
-#   - OpenSSL: 0.9.8 and 3.2
-#   - LibreSSL: 2.2 and 3.8
+#   - OpenSSL: 0.9.8 and 3.6
+#   - LibreSSL: 2.2 and 4.2
 #
 # - Non-x86 architectures on Alpine Linux and Ubuntu
 #
@@ -53,11 +53,13 @@ jobs:
           - '5.10'
           - '5.8'
         openssl:
-          - '3.5.0'
-          - '3.4.1'
-          - '3.3.3'
+          - '3.6.1'
+          - '3.5.5'
+          - '3.4.4'
+          - '3.3.6'
+          - '3.2.6'
           - '3.1.8'
-          - '3.0.16'
+          - '3.0.19'
           - '1.1.1w'
           - '1.1.0l'
           - '1.0.2u'
@@ -268,7 +270,8 @@ jobs:
           - '5.10'
           - '5.8'
         libressl:
-          - '4.1.0'
+          - '4.2.1'
+          - '4.1.2'
           - '4.0.0'
     steps:
       - name: Check out


### PR DESCRIPTION
Add OpenSSL 3.6.1 and LibreSSL 4.2.1 to the CI test matrices, and bump the patch releases for the older minor releases to their latest available versions.

Closes #533.