### PR TITLE
Support OpenSSL 3.3-3.6 and LibreSSL 3.9-4.2

### DIFF
--- a/README
+++ b/README
@@ -21,9 +21,9 @@ Perl 5.8.1 or higher.
 One of the following libssl implementations:
 
 * Any stable release of OpenSSL (https://www.openssl.org) in the
-  0.9.8 - 3.2 branches, except for OpenSSL 0.9.8 - 0.9.8b.
+  0.9.8 - 3.6 branches, except for OpenSSL 0.9.8 - 0.9.8b.
 * Any stable release of LibreSSL (https://www.libressl.org) in the
-  2.0 - 3.8 series, except for LibreSSL 3.2.2 and 3.2.3.
+  2.0 - 4.2 series, except for LibreSSL 3.2.2 and 3.2.3.
 
 Net-SSLeay may not compile or pass its tests against releases other
 than the ones listed above due to libssl API incompatibilities, or, in

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -49,12 +49,12 @@ Net::SSLeay supports the following libssl implementations:
 
 =item *
 
-Any stable release of L<OpenSSL|https://www.openssl.org> in the 0.9.8 - 3.2
+Any stable release of L<OpenSSL|https://www.openssl.org> in the 0.9.8 - 3.6
 branches, except for OpenSSL 0.9.8 - 0.9.8b.
 
 =item *
 
-Any stable release of L<LibreSSL|https://www.libressl.org> in the 2.0 - 3.8
+Any stable release of L<LibreSSL|https://www.libressl.org> in the 2.0 - 4.2
 series, except for LibreSSL 3.2.2 and 3.2.3.
 
 =back


### PR DESCRIPTION
Add the OpenSSL 3.3, 3.4, 3.5 and 3.6 branches and all stable releases in the LibreSSL 3.9, 4.0, 4.1 and 4.2 series to the support policy.

Closes #538.