### PR TITLE
Stable release 1.96

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,15 @@
 Revision history for Perl extension Net::SSLeay.
 
+1.96 2026-03-21
+	- New stable release incorporating all changes from developer releases
+	  1.95_01 to 1.95_03.
+	- Summary of major changes since version 1.94:
+	  - Net::SSLeay now officially supports all stable releases of OpenSSL
+	    3.3 - 3.6 and LibreSSL 3.9 - 4.2, including the vendor-supplied
+	    version of OpenSSL 3 on VMS.
+	  - Several libssl functions allowing for the control of supported
+	    signature algorithms are now exposed.
+
 1.95_03 2026-03-20
 	- In 67_sigalgs.t, load the certificates and keys before forking
 	  to avoid a failure on MSWin32.

--- a/helper_script/generate-test-pki
+++ b/helper_script/generate-test-pki
@@ -14,7 +14,7 @@ use File::Temp;
 use Getopt::Long qw(GetOptionsFromArray);
 use IPC::Run qw( start finish timeout );
 
-our $VERSION = '1.95_03';
+our $VERSION = '1.96';
 
 local $SIG{__DIE__} = sub {
     my ($cause) = @_;
@@ -1254,7 +1254,7 @@ C<generate-test-pki> - Generate a PKI for the Net-SSLeay test suite
 
 =head1 VERSION
 
-This document describes version 1.95_03 of C<generate-test-pki>.
+This document describes version 1.96 of C<generate-test-pki>.
 
 =head1 USAGE
 

--- a/helper_script/update-exported-constants
+++ b/helper_script/update-exported-constants
@@ -14,7 +14,7 @@ use File::Spec::Functions qw(catfile);
 use Getopt::Long qw(GetOptionsFromArray);
 use POSIX qw(ceil);
 
-our $VERSION = '1.95_03';
+our $VERSION = '1.96';
 
 local $SIG{__DIE__} = sub {
     my ($cause) = @_;
@@ -427,7 +427,7 @@ C<update-exported-constants> - Manage constants exported by Net::SSLeay
 
 =head1 VERSION
 
-This document describes version 1.95_03 of C<update-exported-constants>.
+This document describes version 1.96 of C<update-exported-constants>.
 
 =head1 USAGE
 

--- a/inc/Test/Net/SSLeay.pm
+++ b/inc/Test/Net/SSLeay.pm
@@ -14,7 +14,7 @@ use File::Spec::Functions qw( abs2rel catfile );
 use Test::Builder;
 use Test::Net::SSLeay::Socket;
 
-our $VERSION = '1.95_03';
+our $VERSION = '1.96';
 
 our @EXPORT_OK = qw(
     can_fork can_really_fork can_thread
@@ -542,7 +542,7 @@ Test::Net::SSLeay - Helper module for the Net-SSLeay test suite
 
 =head1 VERSION
 
-This document describes version 1.95_03 of Test::Net::SSLeay.
+This document describes version 1.96 of Test::Net::SSLeay.
 
 =head1 SYNOPSIS
 

--- a/inc/Test/Net/SSLeay/Socket.pm
+++ b/inc/Test/Net/SSLeay/Socket.pm
@@ -13,7 +13,7 @@ use Socket qw(
     inet_aton inet_ntoa pack_sockaddr_in unpack_sockaddr_in
 );
 
-our $VERSION = '1.95_03';
+our $VERSION = '1.96';
 
 my %PROTOS = (
     tcp => SOCK_STREAM,
@@ -134,7 +134,7 @@ Test::Net::SSLeay::Socket - Socket class for the Net-SSLeay test suite
 
 =head1 VERSION
 
-This document describes version 1.95_03 of Test::Net::SSLeay::Socket.
+This document describes version 1.96 of Test::Net::SSLeay::Socket.
 
 =head1 SYNOPSIS
 

--- a/lib/Net/SSLeay.pm
+++ b/lib/Net/SSLeay.pm
@@ -70,7 +70,7 @@ $Net::SSLeay::how_random = 512;
 #   inc/Test/Net/SSLeay.pm
 #   inc/Test/Net/SSLeay/Socket.pm
 #   lib/Net/SSLeay/Handle.pm
-$VERSION = '1.95_03';
+$VERSION = '1.96';
 
 @ISA = qw(Exporter);
 

--- a/lib/Net/SSLeay/Handle.pm
+++ b/lib/Net/SSLeay/Handle.pm
@@ -57,7 +57,7 @@ you need to add to your program is the tie function as in:
 use vars qw(@ISA @EXPORT_OK $VERSION);
 @ISA = qw(Exporter);
 @EXPORT_OK = qw(shutdown);
-$VERSION = '1.95_03';
+$VERSION = '1.96';
 
 my $Initialized;       #-- only _initialize() once
 my $Debug = 0;         #-- pretty hokey


### PR DESCRIPTION
Bump all version numbers from 1.95_03 to 1.96, and summarise major changes since 1.94 in Changes.

Closes #548.