### PR TITLE
Add functions for SSL groups

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -233,5 +233,6 @@ t/local/65_security_level.t
 t/local/65_ticket_sharing_2.t
 t/local/66_curves.t
 t/local/67_sigalgs.t
+t/local/68_groups.t
 t/local/kwalitee.t
 typemap

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -6820,6 +6820,66 @@ SSL_set1_groups_list(ssl,list)
 
 #endif
 
+#if SSL_CTRL_GET_GROUPS
+
+void
+SSL_get1_groups(SSL *s)
+    PREINIT:
+	int ret, *out = NULL, i;
+	AV *av;
+    PPCODE:
+	/* First call to get the count */
+	ret = SSL_get1_groups(s, NULL);
+	if (ret <= 0) XSRETURN_UNDEF;
+
+	/* Allocate memory for groups */
+	Newx(out, ret, int);
+
+	/* Second call to get the actual groups */
+	SSL_get1_groups(s, out);
+
+	av = newAV();
+	mXPUSHs(newRV_noinc((SV*)av));
+	for (i=0; i < ret; i++) {
+	    av_push(av, newSViv(out[i]));
+	}
+	Safefree(out);
+
+#endif
+
+#if SSL_CTRL_GET_SHARED_GROUP
+
+int
+SSL_get_shared_group(ssl,n)
+     SSL * ssl
+     int   n
+
+#endif
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+
+int
+SSL_get_negotiated_group(ssl)
+     SSL * ssl
+     CODE:
+     /* Workaround for OpenSSL 3.0.x-3.4.x bug where SSL_get_negotiated_group
+      * crashes if called before handshake when session is NULL.
+      * Fixed in OpenSSL 3.5.x, but we need to support older versions. */
+     if (SSL_get_session(ssl) == NULL) {
+         RETVAL = NID_undef;
+     } else {
+         RETVAL = SSL_get_negotiated_group(ssl);
+     }
+     OUTPUT:
+     RETVAL
+
+const char *
+SSL_group_to_name(ssl, id)
+     SSL * ssl
+     int   id
+
+#endif
+
 
 
 #endif

--- a/lib/Net/SSLeay.pm
+++ b/lib/Net/SSLeay.pm
@@ -922,6 +922,7 @@ my @functions = qw(
     get_time
     get_timeout
     get_wbio
+    group_to_name
     i2d_SSL_SESSION
     load_error_strings
     make_form

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -10100,6 +10100,85 @@ These functions are only available since OpenSSL 1.1.1.
     Net::SSLeay::CTX_set1_groups_list($ctx,"P-521:P-384:P-256");
     Net::SSLeay::set1_groups_list($ssl,"P-521:P-384:P-256");
 
+=item * get1_groups
+
+This function returns the list of supported groups for the SSL connection.
+It calls SSL_get1_groups and returns an array reference containing the group IDs,
+or undef if no groups are set or the function is not supported.
+
+    my $groups = Net::SSLeay::get1_groups($ssl);
+    # returns: array reference of group IDs (e.g., [29, 23, 24]) or undef
+
+Available since OpenSSL 1.1.1.
+
+Check openssl doc L<https://docs.openssl.org/master/man3/SSL_CTX_set1_groups/>
+
+=item * get_shared_group
+
+This function returns the NID of the shared group at the specified index.
+It is typically called on the server side after the ClientHello has been
+received.
+
+The index parameter specifies which shared group to retrieve:
+
+=over
+
+=item * C<n = 0> - returns the most preferred shared group (recommended for most applications)
+
+=item * C<n = 1, 2, ...> - returns the second, third, etc. shared group
+
+=item * C<n = -1> - returns the total number of shared groups (may be zero)
+
+=back
+
+Return values:
+
+=over
+
+=item * NID of the shared group for valid indices
+
+=item * 0 if the index n is out of range
+
+=item * If the NID is unknown, returns the bitwise OR of TLSEXT_nid_unknown (0x1000000) and the group id
+
+=back
+
+Examples:
+
+    # Get the most preferred shared group
+    my $group_nid = Net::SSLeay::get_shared_group($ssl, 0);
+
+    # Get total number of shared groups
+    my $count = Net::SSLeay::get_shared_group($ssl, -1);
+
+Available since OpenSSL 1.1.1.
+
+Check openssl doc L<https://docs.openssl.org/master/man3/SSL_get_shared_group/>
+
+=item * get_negotiated_group
+
+This function returns the NID of the group used for the key exchange.
+It should be called after the handshake is complete. Returns NID_undef if
+no group was negotiated or before the handshake.
+
+    my $group_nid = Net::SSLeay::get_negotiated_group($ssl);
+    # returns: NID of the negotiated group or NID_undef
+
+Available since OpenSSL 3.0.0.
+
+Check openssl doc L<https://docs.openssl.org/master/man3/SSL_get_negotiated_group/>
+
+=item * group_to_name
+
+This function converts a group ID (NID) to its name string.
+
+    my $group_name = Net::SSLeay::group_to_name($ssl, $group_id);
+    # returns: group name (e.g., "secp256r1", "secp384r1", "secp521r1") or undef
+
+Available since OpenSSL 3.0.0.
+
+Check openssl doc L<https://docs.openssl.org/master/man3/SSL_group_to_name/>
+
 =back
 
 =head3 Low level API: OSSL_LIB_CTX and OSSL_PROVIDER related functions

--- a/t/local/68_groups.t
+++ b/t/local/68_groups.t
@@ -5,7 +5,7 @@ use Test::Net::SSLeay qw( data_file_path initialise_libssl );
 
 initialise_libssl();
 
-if (!defined &Net::SSLeay::get_negotiated_group) {
+if (!defined &Net::SSLeay::get1_groups) {
     plan skip_all => "no support for group functions";
 } else {
     plan tests => 8;
@@ -14,18 +14,25 @@ if (!defined &Net::SSLeay::get_negotiated_group) {
 # for debugging only
 my $DEBUG = 0;
 
+my $version_num = Net::SSLeay::OPENSSL_VERSION_NUMBER();
+
 my $client = _minSSL->new();
 my $server = _minSSL->new( cert => [
     data_file_path('simple-cert.cert.pem'),
     data_file_path('simple-cert.key.pem'),
 ]);
 
-# Basic handshake with groups and get negotiated group
-ok(_handshake_and_check($client, $server, 'P-521:P-384', 'P-521', 'P-521'), 'handshake with P-521 and check negotiated group');
-ok(_handshake_and_check($client, $server, 'P-521:P-384', 'P-384', 'P-384'), 'handshake with P-384 and check negotiated group');
+SKIP: {
+    skip "No support for get_negotiated_group() and group_to_name() in " . Net::SSLeay::SSLeay_version(), 3
+        if $version_num < 0x30000000;
 
-# Test with single matching group
-ok(_handshake_and_check($client, $server, 'P-256', 'P-256', 'P-256'), 'handshake with single matching group');
+    # Basic handshake with groups and get negotiated group
+    ok(_handshake_and_check($client, $server, 'P-521:P-384', 'P-521', 'P-521'), 'handshake with P-521 and check negotiated group');
+    ok(_handshake_and_check($client, $server, 'P-521:P-384', 'P-384', 'P-384'), 'handshake with P-384 and check negotiated group');
+
+    # Test with single matching group
+    ok(_handshake_and_check($client, $server, 'P-256', 'P-256', 'P-256'), 'handshake with single matching group');
+}
 
 # Test SSL_get_shared_group
 my ($total_count, $shared0, $shared1) = _handshake_and_get_shared($client, $server, 'P-521:P-384', 'P-384:P-521');
@@ -33,10 +40,15 @@ is($total_count, 2, 'get_shared_group(-1) returns count of shared groups');
 ok(defined($shared0) && $shared0 > 0, 'get_shared_group(0) returns valid group');
 ok(defined($shared1) && $shared1 > 0, 'get_shared_group(1) returns valid group');
 
-# Test negotiated group before handshake
-$client->state_connect('P-521');
-my $neg_before = Net::SSLeay::get_negotiated_group($client->_ssl());
-ok($neg_before == 0, 'negotiated group is 0 before handshake');
+SKIP: {
+    skip "No support for get_negotiated_group() in " . Net::SSLeay::SSLeay_version(), 1
+        if $version_num < 0x30000000;
+
+    # Test negotiated group before handshake
+    $client->state_connect('P-521');
+    my $neg_before = Net::SSLeay::get_negotiated_group($client->_ssl());
+    ok($neg_before == 0, 'negotiated group is 0 before handshake');
+}
 
 # Test get1_groups - returns client groups on server side after ClientHello
 $client->state_connect('P-521:P-384');

--- a/t/local/68_groups.t
+++ b/t/local/68_groups.t
@@ -1,0 +1,213 @@
+use lib 'inc';
+
+use Net::SSLeay;
+use Test::Net::SSLeay qw( data_file_path initialise_libssl );
+
+initialise_libssl();
+
+if (!defined &Net::SSLeay::get_negotiated_group) {
+    plan skip_all => "no support for group functions";
+} else {
+    plan tests => 8;
+}
+
+# for debugging only
+my $DEBUG = 0;
+
+my $client = _minSSL->new();
+my $server = _minSSL->new( cert => [
+    data_file_path('simple-cert.cert.pem'),
+    data_file_path('simple-cert.key.pem'),
+]);
+
+# Basic handshake with groups and get negotiated group
+ok(_handshake_and_check($client, $server, 'P-521:P-384', 'P-521', 'P-521'), 'handshake with P-521 and check negotiated group');
+ok(_handshake_and_check($client, $server, 'P-521:P-384', 'P-384', 'P-384'), 'handshake with P-384 and check negotiated group');
+
+# Test with single matching group
+ok(_handshake_and_check($client, $server, 'P-256', 'P-256', 'P-256'), 'handshake with single matching group');
+
+# Test SSL_get_shared_group
+my ($total_count, $shared0, $shared1) = _handshake_and_get_shared($client, $server, 'P-521:P-384', 'P-384:P-521');
+is($total_count, 2, 'get_shared_group(-1) returns count of shared groups');
+ok(defined($shared0) && $shared0 > 0, 'get_shared_group(0) returns valid group');
+ok(defined($shared1) && $shared1 > 0, 'get_shared_group(1) returns valid group');
+
+# Test negotiated group before handshake
+$client->state_connect('P-521');
+my $neg_before = Net::SSLeay::get_negotiated_group($client->_ssl());
+ok($neg_before == 0, 'negotiated group is 0 before handshake');
+
+# Test get1_groups - returns client groups on server side after ClientHello
+$client->state_connect('P-521:P-384');
+$server->state_accept('P-521:P-384');
+_do_handshake($client, $server);
+my $groups = Net::SSLeay::get1_groups($server->_ssl());
+is(@{$groups}, 2, 'get1_groups returns two groups');
+
+sub _handshake_and_get_shared {
+    my ($client, $server, $server_group, $client_group) = @_;
+    $client->state_connect($client_group);
+    $server->state_accept($server_group);
+
+    _do_handshake($client, $server);
+
+    # get_shared_group must be called on server side
+    my $total_count = Net::SSLeay::get_shared_group($server->_ssl(), -1);
+    my $shared0 = Net::SSLeay::get_shared_group($server->_ssl(), 0);
+    my $shared1 = Net::SSLeay::get_shared_group($server->_ssl(), 1);
+
+    return ($total_count, $shared0, $shared1);
+}
+
+sub _handshake_and_check {
+    my ($client, $server, $server_group, $client_group, $expected_group) = @_;
+    $client->state_connect($client_group);
+    $server->state_accept($server_group);
+
+    # Test negotiated group before handshake
+    my $neg_before = Net::SSLeay::get_negotiated_group($client->_ssl());
+    return 0 if $neg_before != 0;
+
+    my $result = _do_handshake($client, $server);
+    return 0 unless $result;
+
+    my $negotiated = Net::SSLeay::get_negotiated_group($client->_ssl());
+    my $negotiated_name = Net::SSLeay::group_to_name($client->_ssl(), $negotiated);
+
+    # Convert expected group name to NID and name for comparison
+    my $exp_nid_and_name = _group_name_to_nid_and_name($expected_group);
+
+    $DEBUG && warn "Expected: $expected_group (NID: $exp_nid_and_name->[0], Name: $exp_nid_and_name->[1]), Got: $negotiated\n";
+
+    return $negotiated == $exp_nid_and_name->[0] && $negotiated_name eq $exp_nid_and_name->[1];
+}
+
+sub _do_handshake {
+    my ($client, $server) = @_;
+
+    my ($client_done, $server_done);
+    for(my $tries = 0; $tries < 10 and !$client_done || !$server_done; $tries++) {
+        $client_done ||= $client->handshake || 0;
+        $server_done ||= $server->handshake || 0;
+
+        my $transfer = 0;
+        if (defined(my $data = $client->bio_read())) {
+            $DEBUG && warn "client -> server: ".length($data)." bytes\n";
+            $server->bio_write($data);
+            $transfer++;
+        }
+        if (defined(my $data = $server->bio_read())) {
+            $DEBUG && warn "server -> client: ".length($data)." bytes\n";
+            $client->bio_write($data);
+            $transfer++;
+        }
+        if (!$transfer) {
+            $client_done = $server_done = 1;
+        }
+    }
+
+    return $client_done && $server_done;
+}
+
+sub _group_name_to_nid_and_name {
+    my $name = shift;
+    # Common group name to NID mappings
+    my %groups = (
+        'P-256' => [415, 'secp256r1'],
+        'P-384' => [715, 'secp384r1'],
+        'P-521' => [716, 'secp521r1'],
+    );
+    return $groups{$name} || 0;
+}
+
+
+{
+    package _minSSL;
+
+    use Test::Net::SSLeay qw(new_ctx);
+
+    sub new {
+        my ($class,%args) = @_;
+        my $ctx = new_ctx();
+        Net::SSLeay::CTX_set_options($ctx,Net::SSLeay::OP_ALL());
+        Net::SSLeay::CTX_set_cipher_list($ctx,'ECDHE');
+        Net::SSLeay::CTX_set_ecdh_auto($ctx,1)
+            if defined &Net::SSLeay::CTX_set_ecdh_auto;
+        my $id = 'client';
+        if ($args{cert}) {
+            my ($cert,$key) = @{ delete $args{cert} };
+            Net::SSLeay::set_cert_and_key($ctx, $cert, $key)
+                || die "failed to use cert file $cert,$key";
+            $id = 'server';
+        }
+
+        my $self = bless { id => $id, ctx => $ctx }, $class;
+        return $self;
+    }
+
+    sub state_accept {
+        my ($self,$group) = @_;
+        _reset($self,$group);
+        Net::SSLeay::set_accept_state($self->{ssl});
+    }
+
+    sub state_connect {
+        my ($self,$group) = @_;
+        _reset($self,$group);
+        Net::SSLeay::set_connect_state($self->{ssl});
+    }
+
+    sub handshake {
+        my $self = shift;
+        my $rv = Net::SSLeay::do_handshake($self->{ssl});
+        $rv = _error($self,$rv);
+        return $rv;
+    }
+
+    sub bio_write {
+        my ($self,$data) = @_;
+        defined $data and $data ne '' or return;
+        Net::SSLeay::BIO_write($self->{rbio},$data);
+    }
+
+    sub bio_read {
+        my ($self) = @_;
+        return Net::SSLeay::BIO_read($self->{wbio});
+    }
+
+    sub _ssl { shift->{ssl} }
+    sub _ctx { shift->{ctx} }
+
+    sub _reset {
+        my ($self,$group) = @_;
+        if ($group) {
+            Net::SSLeay::CTX_set1_groups_list($self->{ctx}, $group);
+        }
+        my $ssl = Net::SSLeay::new($self->{ctx});
+        my @bio = (
+            Net::SSLeay::BIO_new(Net::SSLeay::BIO_s_mem()),
+            Net::SSLeay::BIO_new(Net::SSLeay::BIO_s_mem()),
+        );
+        Net::SSLeay::set_bio($ssl,$bio[0],$bio[1]);
+        $self->{ssl} = $ssl;
+        $self->{rbio} = $bio[0];
+        $self->{wbio} = $bio[1];
+    }
+
+    sub _error {
+        my ($self,$rv) = @_;
+        if ($rv>0) {
+            return $rv;
+        }
+        my $err = Net::SSLeay::get_error($self->{ssl},$rv);
+        if ($err == Net::SSLeay::ERROR_WANT_READ()
+            || $err == Net::SSLeay::ERROR_WANT_WRITE()) {
+            $DEBUG && warn "[$self->{id}] rw:$err\n";
+            return;
+        }
+        $DEBUG && warn "[$self->{id}] ".Net::SSLeay::ERR_error_string($err)."\n";
+        return;
+    }
+
+}


### PR DESCRIPTION
* SSL_get1_groups
* SSL_get_shared_group
* SSL_get_negotiated_group
* SSL_group_to_name

The groups functions are available in OpenSSL 1.1.1 (SSL_get1_groups and SSL_get_shared_group) and OpenSSL 3.0.0 (SSL_get_negotiated_group and SSL_group_to_name) and later.

Add test file for the newly added SSL groups functions.

GH issue: https://github.com/radiator-software/p5-net-ssleay/issues/550