### PR TITLE
Add support for X509_VERIFY_PARAM_get_hostflags

### DIFF
--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -7970,6 +7970,14 @@ X509_VERIFY_PARAM_set_hostflags(param, flags)
     X509_VERIFY_PARAM *param
     unsigned int flags
 
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL && !defined(LIBRESSL_VERSION_NUMBER) /* OpenSSL 1.1.0 */
+
+unsigned int
+X509_VERIFY_PARAM_get_hostflags(param)
+    X509_VERIFY_PARAM *param
+
+#endif
+
 char *
 X509_VERIFY_PARAM_get0_peername(param)
     X509_VERIFY_PARAM *param

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -7970,15 +7970,19 @@ X509_VERIFY_PARAM_set_hostflags(param, flags)
     X509_VERIFY_PARAM *param
     unsigned int flags
 
-unsigned int
-X509_VERIFY_PARAM_get_hostflags(param)
-    X509_VERIFY_PARAM *param
-
 char *
 X509_VERIFY_PARAM_get0_peername(param)
     X509_VERIFY_PARAM *param
 
 #endif /* OpenSSL 1.0.2-beta2, LibreSSL 2.7.0 */
+
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL && !defined(LIBRESSL_VERSION_NUMBER) /* OpenSSL 1.1.0 */
+
+unsigned int
+X509_VERIFY_PARAM_get_hostflags(param)
+    X509_VERIFY_PARAM *param
+
+#endif
 
 #if !defined(LIBRESSL_VERSION_NUMBER) || (LIBRESSL_VERSION_NUMBER < 0x3080000fL) /* LibreSSL < 3.8.0 */
 void

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -7970,6 +7970,8 @@ X509_VERIFY_PARAM_set_hostflags(param, flags)
     X509_VERIFY_PARAM *param
     unsigned int flags
 
+#endif
+
 #if OPENSSL_VERSION_NUMBER >= 0x1010000fL && !defined(LIBRESSL_VERSION_NUMBER) /* OpenSSL 1.1.0 */
 
 unsigned int

--- a/SSLeay.xs
+++ b/SSLeay.xs
@@ -7970,15 +7970,9 @@ X509_VERIFY_PARAM_set_hostflags(param, flags)
     X509_VERIFY_PARAM *param
     unsigned int flags
 
-#endif
-
-#if OPENSSL_VERSION_NUMBER >= 0x1010000fL && !defined(LIBRESSL_VERSION_NUMBER) /* OpenSSL 1.1.0 */
-
 unsigned int
 X509_VERIFY_PARAM_get_hostflags(param)
     X509_VERIFY_PARAM *param
-
-#endif
 
 char *
 X509_VERIFY_PARAM_get0_peername(param)

--- a/lib/Net/SSLeay.pm
+++ b/lib/Net/SSLeay.pm
@@ -892,6 +892,8 @@ my @functions = qw(
     X509_load_cert_crl_file
     X509_load_cert_file
     X509_load_crl_file
+    X509_VERIFY_PARAM_get_flags
+    X509_VERIFY_PARAM_get_hostflags
     accept
     clear
     connect

--- a/lib/Net/SSLeay.pod
+++ b/lib/Net/SSLeay.pod
@@ -8781,6 +8781,21 @@ The flags for controlling wildcard checks and other features are defined in Open
 
 Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/X509_VERIFY_PARAM_set_flags.html>
 
+=item * X509_VERIFY_PARAM_get_hostflags
+
+B<COMPATIBILITY:> requires atleast OpenSSL 1.1.0; not supported by LibreSSL
+
+Returns the current host flags set in $param.
+
+    my $flags = Net::SSLeay::X509_VERIFY_PARAM_get_hostflags($param);
+    # $param - value corresponding to openssl's X509_VERIFY_PARAM structure
+    #
+    # returns: (unsigned int) current host flags (bitmask)
+
+For more details about returned flags bitmask see L</X509_VERIFY_PARAM_set_flags>.
+
+Check openssl doc L<https://www.openssl.org/docs/manmaster/man3/X509_VERIFY_PARAM_set_flags.html>
+
 =item * X509_VERIFY_PARAM_set_purpose
 
 Sets the verification purpose in $param to $purpose. This determines the acceptable purpose

--- a/t/local/68_x509_verify_param_hostflags.t
+++ b/t/local/68_x509_verify_param_hostflags.t
@@ -1,0 +1,49 @@
+# Tests for Net::SSLeay::X509_VERIFY_PARAM_get_hostflags
+
+use lib 'inc';
+
+use Net::SSLeay;
+use Test::Net::SSLeay qw(initialise_libssl);
+
+plan tests => 5;
+
+initialise_libssl();
+
+SKIP: {
+    skip 'X509_VERIFY_PARAM_get_hostflags not available (requires OpenSSL 1.1.0+, not LibreSSL)', 5
+        unless exists &Net::SSLeay::X509_VERIFY_PARAM_get_hostflags;
+
+    my $param = Net::SSLeay::X509_VERIFY_PARAM_new();
+    ok($param, 'X509_VERIFY_PARAM_new');
+
+    is(
+        Net::SSLeay::X509_VERIFY_PARAM_get_hostflags($param),
+        0,
+        'X509_VERIFY_PARAM_get_hostflags returns 0 by default'
+    );
+
+    Net::SSLeay::X509_VERIFY_PARAM_set_hostflags($param, Net::SSLeay::X509_CHECK_FLAG_NO_WILDCARDS());
+    is(
+        Net::SSLeay::X509_VERIFY_PARAM_get_hostflags($param),
+        Net::SSLeay::X509_CHECK_FLAG_NO_WILDCARDS(),
+        'X509_VERIFY_PARAM_get_hostflags returns X509_CHECK_FLAG_NO_WILDCARDS after setting it'
+    );
+
+    Net::SSLeay::X509_VERIFY_PARAM_set_hostflags($param, 0);
+    is(
+        Net::SSLeay::X509_VERIFY_PARAM_get_hostflags($param),
+        0,
+        'X509_VERIFY_PARAM_get_hostflags returns 0 after clearing flags'
+    );
+
+    my $combined = Net::SSLeay::X509_CHECK_FLAG_NO_WILDCARDS()
+                 | Net::SSLeay::X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS();
+    Net::SSLeay::X509_VERIFY_PARAM_set_hostflags($param, $combined);
+    is(
+        Net::SSLeay::X509_VERIFY_PARAM_get_hostflags($param),
+        $combined,
+        'X509_VERIFY_PARAM_get_hostflags returns combined flags'
+    );
+
+    Net::SSLeay::X509_VERIFY_PARAM_free($param);
+}


### PR DESCRIPTION
Tried to add support for X509_VERIFY_PARAM_get_hostflags
  mentioned in (https://github.com/radiator-software/p5-net-ssleay/issues/75)

Reviewed [contribution guidelines]( https://github.com/radiator-software/p5-net-ssleay/blob/147f77a5133770ec53641dd824535502ab2d8db6/CONTRIBUTING.md) link. 

**Testing performed:**
# perl Makefile.PL && make
Do you want to run external tests?
These tests *will* *fail* if you do not have network connectivity. [n] y
...
*** Found OpenSSL-3.0.13 installed in /usr
...
"/usr/bin/perl" -MExtUtils::Command::MM -e 'cp_nonempty' -- SSLeay.bs blib/arch/auto/Net/SSLeay/SSLeay.bs 644
x86_64-linux-gnu-gcc -c  -I"/usr/include" -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv -fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -O2 -g   -DVERSION=\"1.96\" -DXS_VERSION=\"1.96\" -fPIC "-I/usr/lib/x86_64-linux-gnu/perl/5.38/CORE"  -DOPENSSL_API_COMPAT=908 -DNET_SSLEAY_PERL_VERSION=5038002 SSLeay.c
rm -f blib/arch/auto/Net/SSLeay/SSLeay.so
x86_64-linux-gnu-gcc  -shared -L/usr -L/usr/lib64 -L/usr/lib -L/usr/local/lib -fstack-protector-strong  SSLeay.o  -o blib/arch/auto/Net/SSLeay/SSLeay.so  \
   -L/usr -L/usr/lib64 -L/usr/lib -lssl -lcrypto -lz   \
  
chmod 755 blib/arch/auto/Net/SSLeay/SSLeay.so
Manifying 2 pod documents

# make test
"/usr/bin/perl" -MExtUtils::Command::MM -e 'cp_nonempty' -- SSLeay.bs blib/arch/auto/Net/SSLeay/SSLeay.bs 644
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*/*.t t/*/*/*.t
...
# Perl information:
#   Version:         '5.038002'
#   Executable path: '/usr/bin/perl'
...
All tests successful.
Files=52, Tests=2843, 13 wallclock secs ( 0.29 usr  0.05 sys + 11.10 cusr  1.13 csys = 12.57 CPU)
Result: PASS
